### PR TITLE
`phydms_comprehensive` output CSV model comparison

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 ===========
 
+2.3.5
+------
+* `phydms_comprehensive` outputs CSV as well as Markdown model comparison.
+
 2.3.4
 ------
 * Start testing with Python 3.6 and 3.7.

--- a/docs/phydms_comprehensive_prog.rst
+++ b/docs/phydms_comprehensive_prog.rst
@@ -76,6 +76,7 @@ This file is in Markdown format::
     | YNGKP_M5                | 2599.70  | -4683.23      | 12      | alpha_omega=0.30, beta_omega=2.41, kappa=5.84 |
     | YNGKP_M0                | 2679.50  | -4724.13      | 11      | kappa=5.79, omega=0.11                        |
 
+A similar file with the name ``modelcomparison.csv`` will also be created.
 
 ``phydms`` output for each model
 ++++++++++++++++++++++++++++++++++

--- a/phydmslib/_metadata.py
+++ b/phydmslib/_metadata.py
@@ -1,4 +1,4 @@
-__version__ = '2.3.4'
+__version__ = '2.3.5'
 __author__ = 'the Bloom lab (see https://github.com/jbloomlab/phydms/contributors)'
 __url__ = 'http://jbloomlab.github.io/phydms'
 __author_email__ = 'jbloom@fredhutch.org'

--- a/scripts/phydms_comprehensive
+++ b/scripts/phydms_comprehensive
@@ -30,8 +30,9 @@ def RunCmds(cmds):
     except:
         os.kill(pid, signal.SIGTERM)
 
-def createModelComparisonFile(models, outprefix, modelcomparisonfile):
-    """Creates `modelcomparisonfile` in Markdown format.
+def createModelComparisonFile(models, outprefix, modelcomparisonfile,
+                              modelcomparisoncsv):
+    """Creates model comparison files.
 
     `models` is a list of the prefixes used for each run.
 
@@ -44,7 +45,6 @@ def createModelComparisonFile(models, outprefix, modelcomparisonfile):
         optimized parameters.
     """
 
-    # modelcomparison.csv
     columns = ['Model', 'deltaAIC', 'LogLikelihood', 'nParams', 'ParamValues']
     stats = dict([(col, []) for col in columns])
     for modelName in models:
@@ -76,6 +76,10 @@ def createModelComparisonFile(models, outprefix, modelcomparisonfile):
         text.append(formatline.format(*line))
     with open(modelcomparisonfile, 'w') as f:
         f.write('\n'.join(text))
+    (pd.DataFrame(stats)
+     .sort_values('deltaAIC')
+     .to_csv(modelcomparisoncsv, index=False)
+     )
 
 
 def main():
@@ -103,6 +107,7 @@ def main():
         logfile = "{0}.log".format(args['outprefix'])
         args['outprefix'] = '{0}_'.format(args['outprefix'])
     modelcomparisonfile = '{0}modelcomparison.md'.format(args['outprefix'])
+    modelcomparisoncsv = '{0}modelcomparison.csv'.format(args['outprefix'])
     raxmlStandardOutputFile = '{0}raxml_output.txt'.format(args['outprefix'])
 
     #Set up to log everything to logfile.
@@ -295,7 +300,7 @@ def main():
     try:
 
         # remove existing output files
-        outfiles = [modelcomparisonfile]
+        outfiles = [modelcomparisonfile, modelcomparisoncsv]
         removed = []
         for modelname in models.keys():
             for suffix in filesuffixes[modelname]:
@@ -350,7 +355,7 @@ def main():
             time.sleep(1)
 
         createModelComparisonFile(models.keys(), args["outprefix"],
-                modelcomparisonfile)
+                modelcomparisonfile, modelcomparisoncsv)
 
         # make sure all expected output files are there
         for fname in outfiles:

--- a/tests/expected_NP_test_results/modelcomparison.csv
+++ b/tests/expected_NP_test_results/modelcomparison.csv
@@ -1,0 +1,5 @@
+Model,deltaAIC,LogLikelihood,nParams,ParamValues
+ExpCM_NP_prefs_short,0.00,-775.21,6,"beta=3.38, kappa=8.76, omega=0.98"
+averaged_ExpCM_NP_prefs_short,668.90,-1109.66,6,"beta=0.29, kappa=8.96, omega=0.11"
+YNGKP_M5,677.50,-1107.96,12,"alpha_omega=0.30, beta_omega=2.52, kappa=7.08"
+YNGKP_M0,687.76,-1114.09,11,"kappa=7.00, omega=0.12"

--- a/tests/test_phydms_comprehensive.py
+++ b/tests/test_phydms_comprehensive.py
@@ -74,6 +74,11 @@ class test_phydms_comprehensive(unittest.TestCase):
                 sigomegas[name] = omegas[name][omegas[name]['site'].isin(sigsites)]['omega'].values
             self.assertTrue(((sigomegas['actual'] > 1) == (sigomegas['expected'] > 1)).all())
 
+        actualmodelcomp = pandas.read_csv(os.path.join(outprefix,
+                                                       'modelcomparison.csv'))
+        expectmodelcomp = pandas.read_csv(os.path.join(expectedresults,
+                                                       'modelcomparison.csv'))
+        self.assertTrue(actualmodelcomp.equals(expectmodelcomp))
 
 if __name__ == '__main__':
     runner = unittest.TextTestRunner()


### PR DESCRIPTION
Previously `phydms_comprehensive` only created a Markdown
model comparison file, which is not straightforward to parse.
Now it also makes a CSV model comparison file.