### PR TITLE
replace bound on max stringency

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 ===========
 
+2.3.6
+------
+* Revert changes in 2.3.5, they led to numerical errors. Users will have to re-scale preferences when optimizations hits upper bound on parameter.
+
 2.3.5
 ------
 * Increased maximum bound for stringency parameter as the max bound was too low and being hit during optimization in some cases.

--- a/docs/phydmslib.rst
+++ b/docs/phydmslib.rst
@@ -8,79 +8,79 @@ phydmslib.constants module
 --------------------------
 
 .. automodule:: phydmslib.constants
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 phydmslib.file\_io module
 -------------------------
 
 .. automodule:: phydmslib.file_io
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 phydmslib.models module
 -----------------------
 
 .. automodule:: phydmslib.models
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 phydmslib.numutils module
 -------------------------
 
 .. automodule:: phydmslib.numutils
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 phydmslib.parsearguments module
 -------------------------------
 
 .. automodule:: phydmslib.parsearguments
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 phydmslib.simulate module
 -------------------------
 
 .. automodule:: phydmslib.simulate
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 phydmslib.treelikelihood module
 -------------------------------
 
 .. automodule:: phydmslib.treelikelihood
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 phydmslib.utils module
 ----------------------
 
 .. automodule:: phydmslib.utils
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 phydmslib.weblogo module
 ------------------------
 
 .. automodule:: phydmslib.weblogo
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: phydmslib
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/phydmslib/_metadata.py
+++ b/phydmslib/_metadata.py
@@ -1,4 +1,4 @@
-__version__ = '2.3.5'
+__version__ = '2.3.6'
 __author__ = 'the Bloom lab (see https://github.com/jbloomlab/phydms/contributors)'
 __url__ = 'http://jbloomlab.github.io/phydms'
 __author_email__ = 'jbloom@fredhutch.org'

--- a/phydmslib/models.py
+++ b/phydmslib/models.py
@@ -295,7 +295,7 @@ class ExpCM(Model):
     _REPORTPARAMS = ['kappa', 'omega', 'beta', 'phi']
     _PARAMLIMITS = {'kappa':(0.01, 100.0),
                    'omega':(1.0e-5, 100.0),
-                   'beta':(1.0e-5, 20),
+                   'beta':(1.0e-5, 10),
                    'eta':(0.01, 0.99),
                    'phi':(0.001, 0.999),
                    'pi':(ALMOST_ZERO, 1),

--- a/tests/test_brlenderivatives.py
+++ b/tests/test_brlenderivatives.py
@@ -66,7 +66,7 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
         # define model
         prefs = []
         minpref = 0.02
-        g = scipy.random.dirichlet([5] * N_NT)
+        g = scipy.random.dirichlet([10] * N_NT)
         for r in range(self.nsites):
             rprefs = scipy.random.dirichlet([0.5] * N_AA)
             rprefs[rprefs < minpref] = minpref


### PR DESCRIPTION
In version 2.3.5, we let the max stringency parameter
go to values greater than 10. But this leads to
numerical optimization issues / overflow on real
data. So put the bound back at 10; users will
have to pre-scale very flat prefs.