### PR TITLE
fix `scipy` 2.0.0 deprecation warnings (ver 2.3.7)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 ===========
 
+2.3.7
+------
+* Fixed ``scipy`` 2.0.0 deprecation warnings by using ``numpy`` functions in many places rather than ``scipy`` functions. See `here <https://docs.scipy.org/doc/scipy/reference/release.1.4.0.html#deprecated-features>`_.
+
 2.3.6
 ------
 * Revert changes in 2.3.5, they led to numerical errors. Users will have to re-scale preferences when optimizations hits upper bound on parameter.

--- a/phydmslib/_metadata.py
+++ b/phydmslib/_metadata.py
@@ -1,4 +1,4 @@
-__version__ = '2.3.6'
+__version__ = '2.3.7'
 __author__ = 'the Bloom lab (see https://github.com/jbloomlab/phydms/contributors)'
 __url__ = 'http://jbloomlab.github.io/phydms'
 __author_email__ = 'jbloom@fredhutch.org'

--- a/phydmslib/constants.py
+++ b/phydmslib/constants.py
@@ -56,6 +56,7 @@ Constants defined:
 
 import re
 import inspect
+import numpy
 import scipy
 import Bio.Seq
 
@@ -73,7 +74,7 @@ assert len(INDEX_TO_AA) == len(AA_TO_INDEX) == N_AA
 
 N_STOP = 0
 STOP_CODON_TO_NT_INDICES = []
-STOP_POSITIONS = scipy.ones((3, N_NT), dtype = 'float')
+STOP_POSITIONS = numpy.ones((3, N_NT), dtype = 'float')
 CODON_TO_INDEX = {}
 INDEX_TO_CODON = {}
 CODON_TO_AA = []
@@ -89,7 +90,7 @@ for nt1 in sorted(NT_TO_INDEX.keys()):
                 CODON_TO_AA.append(AA_TO_INDEX[aa])
                 i += 1
             else:
-                STOP_CODON_TO_NT_INDICES.append(scipy.zeros((3, N_NT), 
+                STOP_CODON_TO_NT_INDICES.append(numpy.zeros((3, N_NT), 
                         dtype='float'))
                 STOP_CODON_TO_NT_INDICES[-1][0][NT_TO_INDEX[nt1]] = 1.0
                 STOP_CODON_TO_NT_INDICES[-1][1][NT_TO_INDEX[nt2]] = 1.0
@@ -99,23 +100,23 @@ for nt1 in sorted(NT_TO_INDEX.keys()):
                 STOP_POSITIONS[2][NT_TO_INDEX[nt3]] = -1.0
                 N_STOP += 1
 
-STOP_CODON_TO_NT_INDICES = scipy.asarray(STOP_CODON_TO_NT_INDICES)
+STOP_CODON_TO_NT_INDICES = numpy.asarray(STOP_CODON_TO_NT_INDICES)
 
 N_CODON = len(CODON_TO_INDEX)
-CODON_TO_AA = scipy.array(CODON_TO_AA, dtype='int')
+CODON_TO_AA = numpy.array(CODON_TO_AA, dtype='int')
 assert len(CODON_TO_INDEX) == len(INDEX_TO_CODON) == len(CODON_TO_AA) == N_CODON
 
 PURINES = frozenset(['A', 'G'])
 PYRIMIDINES = frozenset(['C', 'T'])
 assert PURINES.union(PYRIMIDINES) == frozenset(NT_TO_INDEX.keys())
 
-CODON_TRANSITION = scipy.full((N_CODON, N_CODON), False, dtype='bool')
-CODON_SINGLEMUT = scipy.full((N_CODON, N_CODON), False, dtype='bool')
-CODON_NT_MUT = scipy.full((N_NT, N_CODON, N_CODON), False, dtype='bool')
-CODON_NT = scipy.full((3, N_NT, N_CODON), False, dtype='bool')
-CODON_NT_INDEX = scipy.full((3, N_CODON), -1, dtype='int')
-CODON_NONSYN = scipy.full((N_CODON, N_CODON), False, dtype='bool')
-CODON_NT_COUNT = scipy.zeros((N_NT, N_CODON), dtype='int')
+CODON_TRANSITION = numpy.full((N_CODON, N_CODON), False, dtype='bool')
+CODON_SINGLEMUT = numpy.full((N_CODON, N_CODON), False, dtype='bool')
+CODON_NT_MUT = numpy.full((N_NT, N_CODON, N_CODON), False, dtype='bool')
+CODON_NT = numpy.full((3, N_NT, N_CODON), False, dtype='bool')
+CODON_NT_INDEX = numpy.full((3, N_CODON), -1, dtype='int')
+CODON_NONSYN = numpy.full((N_CODON, N_CODON), False, dtype='bool')
+CODON_NT_COUNT = numpy.zeros((N_NT, N_CODON), dtype='int')
 for (x, codonx) in INDEX_TO_CODON.items():
     for (i, ntx) in enumerate(codonx):
         for w in range(N_NT):

--- a/phydmslib/numutils.pyx
+++ b/phydmslib/numutils.pyx
@@ -42,7 +42,7 @@ def broadcastMatrixMultiply(numpy.ndarray a, numpy.ndarray b,
     cdef int n = a.shape[1]
     assert n == a.shape[2] == b.shape[2] == b.shape[1]
     if not a.flags['C']:
-        a = scipy.ascontiguousarray(a)
+        a = numpy.ascontiguousarray(a)
     assert b.flags['C'], "b not C contiguous"
     cdef numpy.ndarray ab = numpy.ndarray((r, n, n), dtype=numpy.double)
     cdef int i
@@ -70,8 +70,8 @@ def broadcastMatrixVectorMultiply(numpy.ndarray m, numpy.ndarray v,
             `mv[r]` is the matrix-vector product of `m[r]` with
             `v[r]` for 0 <= `r` <= `d1`.
 
-    >>> m = scipy.array([[[1., 2], [3, 4]], [[5, 6], [7, 8]], [[9, 8], [7, 6]]])
-    >>> v = scipy.array([[1., 2], [3, 4], [1, 3]])
+    >>> m = numpy.array([[[1., 2], [3, 4]], [[5, 6], [7, 8]], [[9, 8], [7, 6]]])
+    >>> v = numpy.array([[1., 2], [3, 4], [1, 3]])
     >>> mv = scipy.ndarray(v.shape, dtype='int')
     >>> for r in range(v.shape[0]):
     ...   for x in range(v.shape[1]):
@@ -93,14 +93,14 @@ def broadcastMatrixVectorMultiply(numpy.ndarray m, numpy.ndarray v,
     cdef int n = v.shape[1]
     assert n == m.shape[1] == m.shape[2]
     if not m.flags['C']:
-        m = scipy.ascontiguousarray(m)
+        m = numpy.ascontiguousarray(m)
     assert v.flags['C']
     cdef numpy.ndarray mv = numpy.ndarray((r, n), dtype=numpy.double)
     cdef int i
     for i in range(r):
         mv[i] = scipy.linalg.blas.dgemv(alpha, m[i], v[i])
     return mv
-    #return scipy.sum(m * v[:, None, :], axis=2)
+    #return numpy.sum(m * v[:, None, :], axis=2)
 
 
 def broadcastGetCols(numpy.ndarray m, numpy.ndarray cols):
@@ -121,16 +121,16 @@ def broadcastGetCols(numpy.ndarray m, numpy.ndarray cols):
 
     >>> n = 2
     >>> r = 3
-    >>> m = scipy.arange(r * n * n).reshape(r, n, n)
+    >>> m = numpy.arange(r * n * n).reshape(r, n, n)
     >>> cols = scipy.random.random_integers(0, n - 1, r)
-    >>> expected = scipy.array([m[i][:, cols[i]] for i in range(r)])
+    >>> expected = numpy.array([m[i][:, cols[i]] for i in range(r)])
     >>> scipy.allclose(expected, broadcastGetCols(m, cols))
     True
     """
     assert m.ndim == 3
     assert cols.ndim == 1
     assert cols.shape[0] == m.shape[0]
-    return m[scipy.arange(m.shape[0]), :, cols]
+    return m[numpy.arange(m.shape[0]), :, cols]
 
 
 if __name__ == '__main__':

--- a/phydmslib/simulate.py
+++ b/phydmslib/simulate.py
@@ -48,7 +48,7 @@ def pyvolvePartitions(model, divselection=None):
 
     partitions = []
     for r in range(model.nsites):
-        matrix = scipy.zeros((len(codons), len(codons)), dtype='float')
+        matrix = numpy.zeros((len(codons), len(codons)), dtype='float')
         for (xi, x) in enumerate(codons):
             for (yi, y) in enumerate(codons):
                 ntdiffs = [(x[j], y[j]) for j in range(3) if x[j] != y[j]]

--- a/scripts/phydms
+++ b/scripts/phydms
@@ -17,6 +17,7 @@ import multiprocessing
 import warnings
 warnings.simplefilter('always')
 warnings.simplefilter('ignore', ImportWarning)
+import numpy
 import scipy
 import scipy.stats
 import statsmodels.sandbox.stats.multicomp
@@ -85,7 +86,7 @@ def fitDiffPrefsBySite(argtup):
     diffprefs = treelik.model.pi[0] - treelik.model.origpi[0]
     resultstr = [str(site)] + ['{0:.4f}'.format(diffprefs[a])
             for a in range(N_AA)]
-    halfabssum = 0.5 * scipy.absolute(diffprefs).sum()
+    halfabssum = 0.5 * numpy.absolute(diffprefs).sum()
     resultstr.append('{0:.4f}'.format(halfabssum))
     return (halfabssum, '\t'.join(resultstr))
 
@@ -233,7 +234,7 @@ def main():
             logger.info(('Codon substitution model with be {0} version '
                     'of YNGKP (Yang, Nielsen, Goldman, & Pederson. Genetics. '
                     '155:431-449).').format(modelvariant))
-            e_pw = scipy.ones((3,phydmslib.constants.N_NT), dtype='float')
+            e_pw = numpy.ones((3,phydmslib.constants.N_NT), dtype='float')
             for p in range(3):
                 for (w, nt) in phydmslib.constants.INDEX_TO_NT.items():
                     e_pw[p][w] = sum([list(seq)[p::3].count(nt) for (head, seq)
@@ -312,7 +313,7 @@ def main():
                     logger.info(('Read diversifying pressure from {0} '
                             'for all sites.').format(args['divpressure']))
                     divPressureSites = list(divpressure.keys())
-                    divpressure = scipy.array([divpressure[x] for x in
+                    divpressure = numpy.array([divpressure[x] for x in
                             sorted(divPressureSites)])
                     model = phydmslib.models.ExpCM_empirical_phi_divpressure(
                             prefslist, g, divpressure, freeparams=freeparams)
@@ -466,11 +467,11 @@ def main():
                 if ncpus > 1:
                     pool.close()
                     pool.join()
-            pvalues = scipy.array([tup[0] for tup in omegaresults])
-            omegas = scipy.array([tup[1] for tup in omegaresults])
+            pvalues = numpy.array([tup[0] for tup in omegaresults])
+            omegas = numpy.array([tup[1] for tup in omegaresults])
             omega_strs = [tup[2] for tup in omegaresults]
             # compute Q-values separately for each sign of omega
-            qvalues = scipy.ones(pvalues.shape)
+            qvalues = numpy.ones(pvalues.shape)
             for op in [operator.ge, operator.le]:
                 pvalues_sign = scipy.where(op(omegas, 1),
                         pvalues, 1)

--- a/scripts/phydms_divpressure
+++ b/scripts/phydms_divpressure
@@ -91,7 +91,7 @@ def createModelComparisonFile(models, outprefix):
         df["DiversifyingPressureType"] = [modelID[2] for x in range(len(df))]
         df["DiversifyingPressureID"] = [modelID[1] + "_" + str(modelID[3]) \
                 for x in range(len(df))]
-        final = pd.concat([final,df])
+        final = pd.concat([final, df], sort=True)
         with open(outprefix + outFilePrefix + "_loglikelihood.txt") as f:
             temp = {"Preferences":[],"DiversifyingPressureSet":[],
                     "DiversifyingPressureType":[],"DiversifyingPressureID":[],

--- a/tests/test_YNGKPM0.py
+++ b/tests/test_YNGKPM0.py
@@ -9,6 +9,7 @@ are correct for `YNGKP_M0` implemented in `phydmslib.models`."""
 
 import random
 import unittest
+import numpy
 import scipy
 import scipy.linalg
 import sympy
@@ -23,7 +24,7 @@ class testYNGKP_M0(unittest.TestCase):
 
         # create alignment
         sequences = [""]
-        #self.e_pa = scipy.array([[4.0, 0.0, 0.0, 0.0], [0.0, 1.0, 2.0, 1.0], [0.0, 2.0, 0.0, 2.0]])
+        #self.e_pa = numpy.array([[4.0, 0.0, 0.0, 0.0], [0.0, 1.0, 2.0, 1.0], [0.0, 2.0, 0.0, 2.0]])
         scipy.random.seed(1)
         random.seed(1)
         self.e_pa = scipy.random.uniform(0.12, 1.0, size = (3, N_NT))
@@ -35,10 +36,10 @@ class testYNGKP_M0(unittest.TestCase):
         omega = 0.4
         kappa = 2.5
         self.YNGKP_M0 = phydmslib.models.YNGKP_M0(self.e_pa, self.nsites, omega=omega, kappa=kappa)
-        self.assertTrue(scipy.allclose(omega, self.YNGKP_M0.omega))
-        self.assertTrue(scipy.allclose(kappa, self.YNGKP_M0.kappa))
+        self.assertTrue(numpy.allclose(omega, self.YNGKP_M0.omega))
+        self.assertTrue(numpy.allclose(kappa, self.YNGKP_M0.kappa))
 
-        self.assertTrue(scipy.allclose(scipy.repeat(1.0, self.nsites), self.YNGKP_M0.stationarystate.sum(axis=1)))
+        self.assertTrue(numpy.allclose(numpy.repeat(1.0, self.nsites), self.YNGKP_M0.stationarystate.sum(axis=1)))
 
         # now check YNGKP_M0 attributes / derivates, updating several times
         for update in range(2):
@@ -56,12 +57,12 @@ class testYNGKP_M0(unittest.TestCase):
         self.assertEqual(self.nsites, self.YNGKP_M0.nsites)
 
         # make sure Prxy has rows summing to zero
-        self.assertFalse(scipy.isnan(self.YNGKP_M0.Pxy).any())
-        self.assertFalse(scipy.isinf(self.YNGKP_M0.Pxy).any())
-        diag = scipy.eye(N_CODON, dtype='bool')
-        self.assertTrue(scipy.allclose(0, scipy.sum(self.YNGKP_M0.Pxy[0],
+        self.assertFalse(numpy.isnan(self.YNGKP_M0.Pxy).any())
+        self.assertFalse(numpy.isinf(self.YNGKP_M0.Pxy).any())
+        diag = numpy.eye(N_CODON, dtype='bool')
+        self.assertTrue(numpy.allclose(0, numpy.sum(self.YNGKP_M0.Pxy[0],
                 axis=1)))
-        self.assertTrue(scipy.allclose(0, self.YNGKP_M0.Pxy[0].sum()))
+        self.assertTrue(numpy.allclose(0, self.YNGKP_M0.Pxy[0].sum()))
         self.assertTrue((self.YNGKP_M0.Pxy[0][diag] <= 0).all())
         self.assertTrue((self.YNGKP_M0.Pxy[0][~diag] >= 0).all())
         assert self.YNGKP_M0.Pxy.shape == (1, N_CODON, N_CODON)
@@ -120,14 +121,14 @@ class testYNGKP_M0(unittest.TestCase):
         """Makes sure matrix exponentials of YNGKP_M0 are as expected."""
         for r in range(1):
             # fromdiag is recomputed Prxy after diagonalization
-            fromdiag = scipy.dot(self.YNGKP_M0.A[0], scipy.dot(scipy.diag(
+            fromdiag = numpy.dot(self.YNGKP_M0.A[0], numpy.dot(numpy.diag(
                     self.YNGKP_M0.D[r]), self.YNGKP_M0.Ainv[r]))
-            self.assertTrue(scipy.allclose(self.YNGKP_M0.Pxy[r], fromdiag,
+            self.assertTrue(numpy.allclose(self.YNGKP_M0.Pxy[r], fromdiag,
                     atol=1e-5), "Max diff {0}".format((self.YNGKP_M0.Pxy[r] - fromdiag).max()))
 
             for t in [0.02, 0.2, 0.5]:
                 direct = scipy.linalg.expm(self.YNGKP_M0.Pxy[r] * self.YNGKP_M0.mu * t)
-                self.assertTrue(scipy.allclose(self.YNGKP_M0.M(t)[r], direct, atol=1e-6),
+                self.assertTrue(numpy.allclose(self.YNGKP_M0.M(t)[r], direct, atol=1e-6),
                         "Max diff {0}".format((self.YNGKP_M0.M(t)[r] - direct).max()))
         # check derivatives of M calculated by dM
         # implementation looks a bit complex because `check_grad` function

--- a/tests/test_alignmentSimulation.py
+++ b/tests/test_alignmentSimulation.py
@@ -7,6 +7,7 @@ Written by Sarah Hilton and Jesse Bloom.
 
 import os
 import sys
+import numpy
 import scipy
 import math
 import unittest
@@ -61,7 +62,7 @@ class test_simulateAlignment_ExpCM(unittest.TestCase):
                     kappa=kappa, omega=omega, beta=beta, mu=mu,
                     freeparams=['mu'])
         elif self.MODEL == phydmslib.models.YNGKP_M0:
-            e_pw = scipy.asarray([scipy.random.dirichlet([7] * N_NT) for i
+            e_pw = numpy.asarray([scipy.random.dirichlet([7] * N_NT) for i
                     in range(3)])
             model = phydmslib.models.YNGKP_M0(e_pw, nsites)
         else:
@@ -108,11 +109,11 @@ class test_simulateAlignment_ExpCM(unittest.TestCase):
 
         # We expect nsubs = t, but build in some tolerance
         # with rtol since we simulated finite number of sites.
-        self.assertTrue(scipy.allclose(nsubs, t, rtol=0.2),
+        self.assertTrue(numpy.allclose(nsubs, t, rtol=0.2),
                 ("Simulated subs per site of {0} is not close "
                 "to expected value of {1} (branchScale = {2}, t = {3})").format(
                 nsubs, t, model.branchScale, t))
-        self.assertTrue(scipy.allclose(treedist, nsubs, rtol=0.2), (
+        self.assertTrue(numpy.allclose(treedist, nsubs, rtol=0.2), (
                 "Simulated subs per site of {0} is not close to inferred "
                 "branch length of {1}").format(nsubs, treedist))
 

--- a/tests/test_alignmentSimulationRandomSeed.py
+++ b/tests/test_alignmentSimulationRandomSeed.py
@@ -7,6 +7,7 @@ Written by Sarah Hilton and Jesse Bloom.
 
 import os
 import sys
+import numpy
 import scipy
 import math
 import unittest
@@ -60,7 +61,7 @@ class test_simulateAlignmentRandomSeed_ExpCM(unittest.TestCase):
                     kappa=kappa, omega=omega, beta=beta, mu=mu,
                     freeparams=['mu'])
         elif self.MODEL == phydmslib.models.YNGKP_M0:
-            e_pw = scipy.asarray([scipy.random.dirichlet([7] * N_NT) for i
+            e_pw = numpy.asarray([scipy.random.dirichlet([7] * N_NT) for i
                     in range(3)])
             model = phydmslib.models.YNGKP_M0(e_pw, nsites)
         else:

--- a/tests/test_alignmentSimulation_divpressure.py
+++ b/tests/test_alignmentSimulation_divpressure.py
@@ -8,6 +8,7 @@ Written by Sarah Hilton and Jesse Bloom.
 
 import os
 import sys
+import numpy
 import scipy
 import math
 import unittest
@@ -53,7 +54,7 @@ class test_simulateAlignment_ExpCM_divselection(unittest.TestCase):
         beta = 1.5
         mu = 0.3
         omega2 = 1.2
-        deltar = scipy.array([1 if x in random.sample(range(nsites), 20) else 0 for x in range(nsites)])
+        deltar = numpy.array([1 if x in random.sample(range(nsites), 20) else 0 for x in range(nsites)])
         if self.MODEL == phydmslib.models.ExpCM_empirical_phi_divpressure:
             g = scipy.random.dirichlet([7] * N_NT)
             model = phydmslib.models.ExpCM_empirical_phi_divpressure(prefs, g, deltar,
@@ -103,11 +104,11 @@ class test_simulateAlignment_ExpCM_divselection(unittest.TestCase):
 
         # We expect nsubs = t, but build in some tolerance
         # with rtol since we simulated finite number of sites.
-        self.assertTrue(scipy.allclose(nsubs, t, rtol=0.2),
+        self.assertTrue(numpy.allclose(nsubs, t, rtol=0.2),
                 ("Simulated subs per site of {0} is not close "
                 "to expected value of {1} (branchScale = {2}, t = {3})").format(
                 nsubs, t, model.branchScale, t))
-        self.assertTrue(scipy.allclose(treedist, nsubs, rtol=0.2), (
+        self.assertTrue(numpy.allclose(treedist, nsubs, rtol=0.2), (
                 "Simulated subs per site of {0} is not close to inferred "
                 "branch length of {1}").format(nsubs, treedist))
 

--- a/tests/test_branchScale.py
+++ b/tests/test_branchScale.py
@@ -8,6 +8,7 @@ Written by Jesse Bloom.
 
 import os
 import sys
+import numpy
 import scipy
 import math
 import unittest
@@ -62,7 +63,7 @@ class test_branchScale_ExpCM(unittest.TestCase):
                     freeparams=['mu'])
             partitions = phydmslib.simulate.pyvolvePartitions(model)
         elif self.MODEL == phydmslib.models.YNGKP_M0:
-            e_pw = scipy.asarray([scipy.random.dirichlet([7] * N_NT) for i 
+            e_pw = numpy.asarray([scipy.random.dirichlet([7] * N_NT) for i 
                     in range(3)])
             model = phydmslib.models.YNGKP_M0(e_pw, nsites)
             partitions = phydmslib.simulate.pyvolvePartitions(model)
@@ -110,11 +111,11 @@ class test_branchScale_ExpCM(unittest.TestCase):
 
         # We expect nsubs = branchScale * t, but build in some tolerance
         # with rtol since we simulated finite number of sites.
-        self.assertTrue(scipy.allclose(nsubs, model.branchScale * t, rtol=0.2),
+        self.assertTrue(numpy.allclose(nsubs, model.branchScale * t, rtol=0.2),
                 ("Simulated subs per site of {0} is not close "
                 "to expected value of {1} (branchScale = {2}, t = {3})").format(
                 nsubs, t * model.branchScale, model.branchScale, t))
-        self.assertTrue(scipy.allclose(treedist, nsubs, rtol=0.2), (
+        self.assertTrue(numpy.allclose(treedist, nsubs, rtol=0.2), (
                 "Simulated subs per site of {0} is not close to inferred "
                 "branch length of {1}").format(nsubs, treedist))
 

--- a/tests/test_brlenderivatives.py
+++ b/tests/test_brlenderivatives.py
@@ -10,6 +10,7 @@ import math
 import unittest
 import random
 import copy
+import numpy
 import scipy
 import scipy.optimize
 import Bio.Phylo
@@ -122,7 +123,7 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
             k = random.choice(tl._catindices)
             x = random.randint(0, N_CODON - 1)
             y = random.randint(0, N_CODON - 1)
-            t = scipy.array([random.uniform(0.05, 0.5)])
+            t = numpy.array([random.uniform(0.05, 0.5)])
             diff = scipy.optimize.check_grad(func, dfunc, t, k, r, x, y)
             self.assertTrue(abs(diff) < 1e-4, "diff = {0}".format(diff))
 
@@ -134,20 +135,20 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
                 dparamscurrent=False, dtcurrent=True)
         loglik1 = tl.loglik
         tl.t = 2 * tl.t
-        self.assertFalse(scipy.allclose(loglik1, tl.loglik))
+        self.assertFalse(numpy.allclose(loglik1, tl.loglik))
         tl.t = tl.t / 2
-        self.assertTrue(scipy.allclose(loglik1, tl.loglik))
+        self.assertTrue(numpy.allclose(loglik1, tl.loglik))
         tl.t = tl.t * scipy.random.uniform(0.1, 1.5, tl.t.shape)
-        self.assertFalse(scipy.allclose(loglik1, tl.loglik))
+        self.assertFalse(numpy.allclose(loglik1, tl.loglik))
         loglik2 = tl.loglik
         t = tl.t
         t[1] *= 3
         tl.t = t
-        self.assertFalse(scipy.allclose(loglik2, tl.loglik))
+        self.assertFalse(numpy.allclose(loglik2, tl.loglik))
         t = tl.t
         t[1] /= 3
         tl.t = t
-        self.assertTrue(scipy.allclose(loglik2, tl.loglik))
+        self.assertTrue(numpy.allclose(loglik2, tl.loglik))
 
     def test_BrLenDerivatives(self):
         """Tests derivatives of branch lengths."""
@@ -169,7 +170,7 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
 
         for n in range(len(tl.t)):
             diff = scipy.optimize.check_grad(func, dfunc, 
-                    scipy.array([tl.t[n]]), n)
+                    numpy.array([tl.t[n]]), n)
             self.assertTrue(diff < 2e-5, diff)
 
 
@@ -183,7 +184,7 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
                 self.alignment, self.model, underflowfreq=self.underflowfreq,
                 dparamscurrent=True, dtcurrent=False)
 
-        self.assertTrue(scipy.allclose(tl1.loglik, tl2.loglik))
+        self.assertTrue(numpy.allclose(tl1.loglik, tl2.loglik))
 
         with self.assertRaises(Exception) as context:
             tl2.dtcurrent = True
@@ -201,8 +202,8 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
         tl2.t = 1.1 * tl2.t
         tl2.dparamscurrent = False
         tl2.dtcurrent = True
-        self.assertTrue(scipy.allclose(tl1.dloglik_dt, tl2.dloglik_dt))
-        self.assertTrue(scipy.allclose(tl1.loglik, tl2.loglik))
+        self.assertTrue(numpy.allclose(tl1.dloglik_dt, tl2.dloglik_dt))
+        self.assertTrue(numpy.allclose(tl1.loglik, tl2.loglik))
 
         tl1.updateParams({'kappa':3.15})
         tl2.updateParams({'kappa':3.15})
@@ -211,8 +212,8 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
         tl1.dtcurrent = False
         tl1.dparamscurrent = True
         for (param, deriv) in tl1.dloglik.items():
-            self.assertTrue(scipy.allclose(deriv, tl2.dloglik[param]))
-        self.assertTrue(scipy.allclose(tl1.loglik, tl2.loglik))
+            self.assertTrue(numpy.allclose(deriv, tl2.dloglik[param]))
+        self.assertTrue(numpy.allclose(tl1.loglik, tl2.loglik))
 
 
 class test_BrLenDerivatives_ExpCM_empirical_phi(test_BrLenDerivatives_ExpCM):

--- a/tests/test_expcm.py
+++ b/tests/test_expcm.py
@@ -8,6 +8,7 @@ are correct for `ExpCM` implemented in `phydmslib.models`."""
 
 import random
 import unittest
+import numpy
 import scipy
 import scipy.linalg
 import sympy
@@ -39,19 +40,19 @@ class testExpCM(unittest.TestCase):
         beta = 1.9
         self.expcm = phydmslib.models.ExpCM(self.prefs, phi=phi, omega=omega,
                 kappa=kappa, beta=beta)
-        self.assertTrue(scipy.allclose(phi, self.expcm.phi))
-        self.assertTrue(scipy.allclose(omega, self.expcm.omega))
-        self.assertTrue(scipy.allclose(kappa, self.expcm.kappa))
-        self.assertTrue(scipy.allclose(beta, self.expcm.beta))
+        self.assertTrue(numpy.allclose(phi, self.expcm.phi))
+        self.assertTrue(numpy.allclose(omega, self.expcm.omega))
+        self.assertTrue(numpy.allclose(kappa, self.expcm.kappa))
+        self.assertTrue(numpy.allclose(beta, self.expcm.beta))
 
-        self.assertTrue(scipy.allclose(scipy.repeat(1.0, self.nsites), self.expcm.stationarystate.sum(axis=1)))
+        self.assertTrue(numpy.allclose(numpy.repeat(1.0, self.nsites), self.expcm.stationarystate.sum(axis=1)))
 
         # now check ExpCM attributes / derivates, updating several times
         for update in range(2):
             self.params = {'omega':random.uniform(*self.expcm.PARAMLIMITS['omega']),
                       'kappa':random.uniform(*self.expcm.PARAMLIMITS['kappa']),
                       'beta':random.uniform(0.5, 2.5),
-                      'eta':scipy.array([random.uniform(*self.expcm.PARAMLIMITS['eta']) for i in range(N_NT - 1)]),
+                      'eta':numpy.array([random.uniform(*self.expcm.PARAMLIMITS['eta']) for i in range(N_NT - 1)]),
                       'mu':random.uniform(0.05, 3.0),
                      }
             self.expcm.updateParams(self.params)
@@ -64,27 +65,27 @@ class testExpCM(unittest.TestCase):
         self.assertEqual(self.nsites, self.expcm.nsites)
 
         # make sure Prxy has rows summing to zero
-        self.assertFalse(scipy.isnan(self.expcm.Prxy).any())
-        self.assertFalse(scipy.isinf(self.expcm.Prxy).any())
-        diag = scipy.eye(N_CODON, dtype='bool')
+        self.assertFalse(numpy.isnan(self.expcm.Prxy).any())
+        self.assertFalse(numpy.isinf(self.expcm.Prxy).any())
+        diag = numpy.eye(N_CODON, dtype='bool')
         for r in range(self.nsites):
-            self.assertTrue(scipy.allclose(0, scipy.sum(self.expcm.Prxy[r],
+            self.assertTrue(numpy.allclose(0, numpy.sum(self.expcm.Prxy[r],
                     axis=1)))
-            self.assertTrue(scipy.allclose(0, self.expcm.Prxy[r].sum()))
+            self.assertTrue(numpy.allclose(0, self.expcm.Prxy[r].sum()))
             self.assertTrue((self.expcm.Prxy[r][diag] <= 0).all())
             self.assertTrue((self.expcm.Prxy[r][~diag] >= 0).all())
 
         # make sure prx sums to 1 for each r
         self.assertTrue((self.expcm.prx >= 0).all())
         for r in range(self.nsites):
-            self.assertTrue(scipy.allclose(1, self.expcm.prx[r].sum()))
+            self.assertTrue(numpy.allclose(1, self.expcm.prx[r].sum()))
 
         # prx is eigenvector or Prxy for the same r, but not different r
         for r in range(self.nsites):
-            self.assertTrue(scipy.allclose(0, scipy.dot(self.expcm.prx[r],
+            self.assertTrue(numpy.allclose(0, numpy.dot(self.expcm.prx[r],
                     self.expcm.Prxy[r])))
             if r > 0:
-                self.assertFalse(scipy.allclose(0, scipy.dot(self.expcm.prx[r],
+                self.assertFalse(numpy.allclose(0, numpy.dot(self.expcm.prx[r],
                         self.expcm.Prxy[r - 1])))
 
     def check_ExpCM_derivatives(self):
@@ -121,19 +122,19 @@ class testExpCM(unittest.TestCase):
                             phiw = eta0 * eta1 * eta2
                         else:
                             raise ValueError("Invalid w")
-                        self.assertTrue(scipy.allclose(float(phiw.subs(values)),
+                        self.assertTrue(numpy.allclose(float(phiw.subs(values)),
                                 self.expcm.phi[w]))
                         if CODON_TRANSITION[x][y]:
                             Qxy = kappa * phiw
                         else:
                             Qxy = phiw
-                        self.assertTrue(scipy.allclose(float(Qxy.subs(values)),
+                        self.assertTrue(numpy.allclose(float(Qxy.subs(values)),
                                 self.expcm.Qxy[x][y]))
                         if CODON_NONSYN[x][y]:
                             if pirAx == pirAy:
                                 Prxy = Qxy * omega
                             else:
-                                Prxy = Qxy * omega * (-beta * scipy.log(pirAx / pirAy) / (1 - (pirAx / pirAy)**beta))
+                                Prxy = Qxy * omega * (-beta * numpy.log(pirAx / pirAy) / (1 - (pirAx / pirAy)**beta))
                         else:
                             Prxy = Qxy
                     for (name, actual, expect) in [
@@ -149,7 +150,7 @@ class testExpCM(unittest.TestCase):
                             expectval = 0
                         else:
                             expectval = float(expect.subs(values))
-                        self.assertTrue(scipy.allclose(actual, expectval, atol=1e-4),
+                        self.assertTrue(numpy.allclose(actual, expectval, atol=1e-4),
                                 "{0}: {1} vs {2}".format(name, actual, expectval))
 
         # check prx
@@ -186,21 +187,21 @@ class testExpCM(unittest.TestCase):
                         ('dprx_deta2', self.expcm.dprx['eta'][2][r][x], sympy.diff(prx, eta2)),
                         ]:
                     expectval = float(expect.subs(values))
-                    self.assertTrue(scipy.allclose(actual, expectval, atol=1e-5),
+                    self.assertTrue(numpy.allclose(actual, expectval, atol=1e-5),
                             "{0}: {1} vs {2}".format(name, actual, expectval))
 
     def check_ExpCM_matrix_exponentials(self):
         """Makes sure matrix exponentials of ExpCM are as expected."""
         for r in range(self.nsites):
             # fromdiag is recomputed Prxy after diagonalization
-            fromdiag = scipy.dot(self.expcm.A[r], scipy.dot(scipy.diag(
+            fromdiag = numpy.dot(self.expcm.A[r], numpy.dot(numpy.diag(
                     self.expcm.D[r]), self.expcm.Ainv[r]))
-            self.assertTrue(scipy.allclose(self.expcm.Prxy[r], fromdiag,
+            self.assertTrue(numpy.allclose(self.expcm.Prxy[r], fromdiag,
                     atol=1e-5), "Max diff {0}".format((self.expcm.Prxy[r] - fromdiag).max()))
 
             for t in [0.02, 0.2, 0.5]:
                 direct = scipy.linalg.expm(self.expcm.Prxy[r] * self.expcm.mu * t)
-                self.assertTrue(scipy.allclose(self.expcm.M(t)[r], direct, atol=1e-6),
+                self.assertTrue(numpy.allclose(self.expcm.M(t)[r], direct, atol=1e-6),
                         "Max diff {0}".format((self.expcm.M(t)[r] - direct).max()))
         # check derivatives of M calculated by dM
         # implementation looks a bit complex because `check_grad` function

--- a/tests/test_expcm_divpressure.py
+++ b/tests/test_expcm_divpressure.py
@@ -10,7 +10,7 @@ import unittest
 import scipy
 import scipy.linalg
 import sympy
-import numpy as np
+import numpy
 from phydmslib.constants import *
 import phydmslib.models
 
@@ -36,7 +36,7 @@ class test_compare_ExpCM_empirical_phi_with_and_without_divpressure(unittest.Tes
         omega2 = 0.2
         kappa = 2.5
         beta = 1.2
-        divpressure = scipy.zeros(nsites)
+        divpressure = numpy.zeros(nsites)
 
         expcm = phydmslib.models.ExpCM_empirical_phi(
                 prefs, g, omega=omega, kappa=kappa, beta=beta)
@@ -45,30 +45,30 @@ class test_compare_ExpCM_empirical_phi_with_and_without_divpressure(unittest.Tes
                 prefs, g, divPressureValues=divpressure, omega=omega,
                 kappa=kappa, beta=beta, omega2=omega2)
 
-        self.assertTrue(scipy.allclose(expcm.stationarystate,
+        self.assertTrue(numpy.allclose(expcm.stationarystate,
                 expcm_divpressure.stationarystate),
                 "stationarystate differs.")
-        self.assertTrue(scipy.allclose(expcm.Qxy,
+        self.assertTrue(numpy.allclose(expcm.Qxy,
                 expcm_divpressure.Qxy),
                 "Qxy differs")
-        self.assertTrue(scipy.allclose(expcm.Frxy,
+        self.assertTrue(numpy.allclose(expcm.Frxy,
                 expcm_divpressure.Frxy),
                 "Frxy differs")
-        self.assertTrue(scipy.allclose(expcm.Prxy,
+        self.assertTrue(numpy.allclose(expcm.Prxy,
                 expcm_divpressure.Prxy),
                 "Prxy differs")
         t = 0.02
-        self.assertTrue(scipy.allclose(expcm.M(t),
+        self.assertTrue(numpy.allclose(expcm.M(t),
                 expcm_divpressure.M(t)),
                 "M({0}) differs".format(t))
         for param in ['kappa', 'omega', 'beta']:
-            self.assertTrue(scipy.allclose(getattr(expcm, param),
+            self.assertTrue(numpy.allclose(getattr(expcm, param),
                     getattr(expcm_divpressure, param)),
                     "param values differ for {0}".format(param))
-            self.assertTrue(scipy.allclose(expcm.dstationarystate(param),
+            self.assertTrue(numpy.allclose(expcm.dstationarystate(param),
                     expcm_divpressure.dstationarystate(param)),
                     "dstationarystate differs for {0}".format(param))
-            self.assertTrue(scipy.allclose(expcm.dM(t, param, expcm.M(t)),
+            self.assertTrue(numpy.allclose(expcm.dM(t, param, expcm.M(t)),
                     expcm_divpressure.dM(t, param, expcm_divpressure.M(t))),
                     "dM({0}) differs for {1}".format(t, param))
 
@@ -89,7 +89,7 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
             self.prefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))
-        self.divpressure = np.random.randint(2, size=self.nsites)
+        self.divpressure = numpy.random.randint(2, size=self.nsites)
 
         # create initial ExpCM
         g = scipy.random.dirichlet([3] * N_NT)
@@ -109,7 +109,7 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
                       'omega2': random.uniform(0.1,0.3)
                      }
             self.expcm_divpressure.updateParams(self.params)
-            self.assertTrue(scipy.allclose(g, self.expcm_divpressure.g))
+            self.assertTrue(numpy.allclose(g, self.expcm_divpressure.g))
 
             self.check_empirical_phi()
 
@@ -130,10 +130,10 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
             for x in range(N_CODON):
                 for w in range(N_NT):
                     nt_freqs[w] += self.expcm_divpressure.prx[r][x] * CODON_NT_COUNT[w][x]
-        self.assertTrue(scipy.allclose(sum(nt_freqs), 3 * self.nsites))
-        nt_freqs = scipy.array(nt_freqs)
+        self.assertTrue(numpy.allclose(sum(nt_freqs), 3 * self.nsites))
+        nt_freqs = numpy.array(nt_freqs)
         nt_freqs /= nt_freqs.sum()
-        self.assertTrue(scipy.allclose(nt_freqs, self.expcm_divpressure.g, atol=1e-5),
+        self.assertTrue(numpy.allclose(nt_freqs, self.expcm_divpressure.g, atol=1e-5),
                 "Actual nt_freqs: {0}\nExpected (g): {1}".format(
                 nt_freqs, self.expcm_divpressure.g))
 
@@ -198,31 +198,31 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
         self.assertEqual(self.nsites, self.expcm_divpressure.nsites)
 
         # make sure Prxy has rows summing to zero
-        self.assertFalse(scipy.isnan(self.expcm_divpressure.Prxy).any())
-        self.assertFalse(scipy.isinf(self.expcm_divpressure.Prxy).any())
-        diag = scipy.eye(N_CODON, dtype='bool')
+        self.assertFalse(numpy.isnan(self.expcm_divpressure.Prxy).any())
+        self.assertFalse(numpy.isinf(self.expcm_divpressure.Prxy).any())
+        diag = numpy.eye(N_CODON, dtype='bool')
         for r in range(self.nsites):
-            self.assertTrue(scipy.allclose(0, scipy.sum(self.expcm_divpressure.Prxy[r],
+            self.assertTrue(numpy.allclose(0, numpy.sum(self.expcm_divpressure.Prxy[r],
                     axis=1)))
-            self.assertTrue(scipy.allclose(0, self.expcm_divpressure.Prxy[r].sum()))
+            self.assertTrue(numpy.allclose(0, self.expcm_divpressure.Prxy[r].sum()))
             self.assertTrue((self.expcm_divpressure.Prxy[r][diag] <= 0).all())
             self.assertTrue((self.expcm_divpressure.Prxy[r][~diag] >= 0).all())
 
         # make sure prx sums to 1 for each r
         self.assertTrue((self.expcm_divpressure.prx >= 0).all())
         for r in range(self.nsites):
-            self.assertTrue(scipy.allclose(1, self.expcm_divpressure.prx[r].sum()))
+            self.assertTrue(numpy.allclose(1, self.expcm_divpressure.prx[r].sum()))
 
         # prx is eigenvector or Prxy for the same r, but not different r
         for r in range(self.nsites):
-            self.assertTrue(scipy.allclose(0, scipy.dot(self.expcm_divpressure.prx[r],
+            self.assertTrue(numpy.allclose(0, numpy.dot(self.expcm_divpressure.prx[r],
                     self.expcm_divpressure.Prxy[r])))
             if r > 0:
-                self.assertFalse(scipy.allclose(0, scipy.dot(self.expcm_divpressure.prx[r],
+                self.assertFalse(numpy.allclose(0, numpy.dot(self.expcm_divpressure.prx[r],
                         self.expcm_divpressure.Prxy[r - 1])))
 
         # phi sums to one
-        self.assertTrue(scipy.allclose(1, self.expcm_divpressure.phi.sum()))
+        self.assertTrue(numpy.allclose(1, self.expcm_divpressure.phi.sum()))
 
     def check_ExpCM_derivatives(self):
         """Makes sure derivatives are as expected."""
@@ -276,15 +276,15 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
         """Makes sure matrix exponentials are as expected."""
         for r in range(self.nsites):
             # fromdiag is recomputed Prxy after diagonalization
-            fromdiag = scipy.dot(self.expcm_divpressure.A[r], scipy.dot(scipy.diag(
+            fromdiag = numpy.dot(self.expcm_divpressure.A[r], numpy.dot(numpy.diag(
                     self.expcm_divpressure.D[r]), self.expcm_divpressure.Ainv[r]))
-            self.assertTrue(scipy.allclose(self.expcm_divpressure.Prxy[r], fromdiag,
+            self.assertTrue(numpy.allclose(self.expcm_divpressure.Prxy[r], fromdiag,
                     atol=1e-5), "Max diff {0}".format(
                     (self.expcm_divpressure.Prxy[r] - fromdiag).max()))
 
             for t in [0.02, 0.2, 0.5]:
                 direct = scipy.linalg.expm(self.expcm_divpressure.Prxy[r] * self.expcm_divpressure.mu * t)
-                self.assertTrue(scipy.allclose(self.expcm_divpressure.M(t)[r], direct, atol=1e-6),
+                self.assertTrue(numpy.allclose(self.expcm_divpressure.M(t)[r], direct, atol=1e-6),
                         "Max diff {0}".format((self.expcm_divpressure.M(t)[r] - direct).max()))
         # check derivatives of M calculated by dM
         # implementation looks a bit complex because `check_grad` function

--- a/tests/test_expcm_empirical_phi.py
+++ b/tests/test_expcm_empirical_phi.py
@@ -6,6 +6,7 @@ Written by Jesse Bloom.
 
 import random
 import unittest
+import numpy
 import scipy
 import scipy.linalg
 import sympy
@@ -37,7 +38,7 @@ class testExpCM_empirical_phi(unittest.TestCase):
         beta = 1.2
         self.expcm = phydmslib.models.ExpCM_empirical_phi(self.prefs,
                 g=g, omega=omega, kappa=kappa, beta=beta)
-        self.assertTrue(scipy.allclose(g, self.expcm.g))
+        self.assertTrue(numpy.allclose(g, self.expcm.g))
 
         # now check ExpCM attributes / derivates, updating several times
         for update in range(2):
@@ -47,7 +48,7 @@ class testExpCM_empirical_phi(unittest.TestCase):
                       'mu':random.uniform(0.05, 5.0),
                      }
             self.expcm.updateParams(self.params)
-            self.assertTrue(scipy.allclose(g, self.expcm.g))
+            self.assertTrue(numpy.allclose(g, self.expcm.g))
             self.check_empirical_phi()
             self.check_dQxy_dbeta()
             self.check_dprx_dbeta()
@@ -62,10 +63,10 @@ class testExpCM_empirical_phi(unittest.TestCase):
             for x in range(N_CODON):
                 for w in range(N_NT):
                     nt_freqs[w] += self.expcm.prx[r][x] * CODON_NT_COUNT[w][x]
-        self.assertTrue(scipy.allclose(sum(nt_freqs), 3 * self.nsites))
-        nt_freqs = scipy.array(nt_freqs)
+        self.assertTrue(numpy.allclose(sum(nt_freqs), 3 * self.nsites))
+        nt_freqs = numpy.array(nt_freqs)
         nt_freqs /= nt_freqs.sum()
-        self.assertTrue(scipy.allclose(nt_freqs, self.expcm.g, atol=1e-5),
+        self.assertTrue(numpy.allclose(nt_freqs, self.expcm.g, atol=1e-5),
                 "Actual nt_freqs: {0}\nExpected (g): {1}".format(
                 nt_freqs, self.expcm.g))
 
@@ -129,31 +130,31 @@ class testExpCM_empirical_phi(unittest.TestCase):
         self.assertEqual(self.nsites, self.expcm.nsites)
 
         # make sure Prxy has rows summing to zero
-        self.assertFalse(scipy.isnan(self.expcm.Prxy).any())
-        self.assertFalse(scipy.isinf(self.expcm.Prxy).any())
-        diag = scipy.eye(N_CODON, dtype='bool')
+        self.assertFalse(numpy.isnan(self.expcm.Prxy).any())
+        self.assertFalse(numpy.isinf(self.expcm.Prxy).any())
+        diag = numpy.eye(N_CODON, dtype='bool')
         for r in range(self.nsites):
-            self.assertTrue(scipy.allclose(0, scipy.sum(self.expcm.Prxy[r],
+            self.assertTrue(numpy.allclose(0, numpy.sum(self.expcm.Prxy[r],
                     axis=1)))
-            self.assertTrue(scipy.allclose(0, self.expcm.Prxy[r].sum()))
+            self.assertTrue(numpy.allclose(0, self.expcm.Prxy[r].sum()))
             self.assertTrue((self.expcm.Prxy[r][diag] <= 0).all())
             self.assertTrue((self.expcm.Prxy[r][~diag] >= 0).all())
 
         # make sure prx sums to 1 for each r
         self.assertTrue((self.expcm.prx >= 0).all())
         for r in range(self.nsites):
-            self.assertTrue(scipy.allclose(1, self.expcm.prx[r].sum()))
+            self.assertTrue(numpy.allclose(1, self.expcm.prx[r].sum()))
 
         # prx is eigenvector or Prxy for the same r, but not different r
         for r in range(self.nsites):
-            self.assertTrue(scipy.allclose(0, scipy.dot(self.expcm.prx[r],
+            self.assertTrue(numpy.allclose(0, numpy.dot(self.expcm.prx[r],
                     self.expcm.Prxy[r])))
             if r > 0:
-                self.assertFalse(scipy.allclose(0, scipy.dot(self.expcm.prx[r],
+                self.assertFalse(numpy.allclose(0, numpy.dot(self.expcm.prx[r],
                         self.expcm.Prxy[r - 1])))
 
         # phi sums to one
-        self.assertTrue(scipy.allclose(1, self.expcm.phi.sum()))
+        self.assertTrue(numpy.allclose(1, self.expcm.phi.sum()))
 
     def check_ExpCM_derivatives(self):
         """Makes sure derivatives are as expected."""
@@ -206,15 +207,15 @@ class testExpCM_empirical_phi(unittest.TestCase):
         """Makes sure matrix exponentials are as expected."""
         for r in range(self.nsites):
             # fromdiag is recomputed Prxy after diagonalization
-            fromdiag = scipy.dot(self.expcm.A[r], scipy.dot(scipy.diag(
+            fromdiag = numpy.dot(self.expcm.A[r], numpy.dot(numpy.diag(
                     self.expcm.D[r]), self.expcm.Ainv[r]))
-            self.assertTrue(scipy.allclose(self.expcm.Prxy[r], fromdiag,
+            self.assertTrue(numpy.allclose(self.expcm.Prxy[r], fromdiag,
                     atol=1e-5), "Max diff {0}".format(
                     (self.expcm.Prxy[r] - fromdiag).max()))
 
             for t in [0.02, 0.2, 0.5]:
                 direct = scipy.linalg.expm(self.expcm.Prxy[r] * self.expcm.mu * t)
-                self.assertTrue(scipy.allclose(self.expcm.M(t)[r], direct, atol=1e-6),
+                self.assertTrue(numpy.allclose(self.expcm.M(t)[r], direct, atol=1e-6),
                         "Max diff {0}".format((self.expcm.M(t)[r] - direct).max()))
         # check derivatives of M calculated by dM
         # implementation looks a bit complex because `check_grad` function

--- a/tests/test_expcm_fitprefs.py
+++ b/tests/test_expcm_fitprefs.py
@@ -6,6 +6,7 @@ Written by Jesse Bloom."""
 import random
 import unittest
 import copy
+import numpy
 import scipy
 import scipy.linalg
 import sympy
@@ -42,14 +43,14 @@ class test_ExpCM_fitprefs(unittest.TestCase):
             self.assertTrue(abs(values[1][1] - values[2][1]) > diffpref, 
                     "choose another random number seed as pirAx and pirAy "
                     "are too close.")
-            self.assertTrue(scipy.allclose(float(dFrxy_dpirAx.subs(values)),
+            self.assertTrue(numpy.allclose(float(dFrxy_dpirAx.subs(values)),
                     float(sympy.diff(Frxy, pirAx).subs(values))))
-            self.assertTrue(scipy.allclose(float(dFrxy_dpirAy.subs(values)),
+            self.assertTrue(numpy.allclose(float(dFrxy_dpirAy.subs(values)),
                     float(sympy.diff(Frxy, pirAy).subs(values))))
             values[2][1] = values[1][1] * (1 + diffpref)
-            self.assertTrue(scipy.allclose(float(dFrxy_dpirAx_prefsequal.subs(
+            self.assertTrue(numpy.allclose(float(dFrxy_dpirAx_prefsequal.subs(
                     values)), float(sympy.diff(Frxy, pirAx).subs(values))))
-            self.assertTrue(scipy.allclose(float(dFrxy_dpirAy_prefsequal.subs(
+            self.assertTrue(numpy.allclose(float(dFrxy_dpirAy_prefsequal.subs(
                     values)), float(sympy.diff(Frxy, pirAy).subs(values))))
 
         expcm_fitprefs = copy.deepcopy(self.expcm_fitprefs)
@@ -68,41 +69,41 @@ class test_ExpCM_fitprefs(unittest.TestCase):
                     # check Prxy values
                     if values[pirAx] == values[pirAy]:
                         if CODON_TO_AA[x] == CODON_TO_AA[y]:
-                            self.assertTrue(scipy.allclose(Qxy,
+                            self.assertTrue(numpy.allclose(Qxy,
                                     expcm_fitprefs.Prxy[r][x][y]))
                         else:
-                            self.assertTrue(scipy.allclose(Qxy * values[omega],
+                            self.assertTrue(numpy.allclose(Qxy * values[omega],
                                     expcm_fitprefs.Prxy[r][x][y]))
                     else:
-                        self.assertTrue(scipy.allclose(Qxy * float(Frxy.subs(
+                        self.assertTrue(numpy.allclose(Qxy * float(Frxy.subs(
                             values.items())), expcm_fitprefs.Prxy[r][x][y]))
 
                     # check dFrxy_dpi
                     if values[pirAx] == values[pirAy]:
                         if CODON_TO_AA[x] == CODON_TO_AA[y]:
-                            self.assertTrue(scipy.allclose(0,
+                            self.assertTrue(numpy.allclose(0,
                                     -expcm_fitprefs.tildeFrxy[r][x][y] / 
                                     values[pirAx]))
-                            self.assertTrue(scipy.allclose(0,
+                            self.assertTrue(numpy.allclose(0,
                                     -expcm_fitprefs.tildeFrxy[r][x][y] / 
                                     values[pirAy]))
                         else:
-                            self.assertTrue(scipy.allclose(
+                            self.assertTrue(numpy.allclose(
                                     float(dFrxy_dpirAx_prefsequal.subs(
                                     values.items())),
                                     -expcm_fitprefs.tildeFrxy[r][x][y] / 
                                     values[pirAx]))
-                            self.assertTrue(scipy.allclose(
+                            self.assertTrue(numpy.allclose(
                                     float(dFrxy_dpirAy_prefsequal.subs(
                                     values.items())),
                                     expcm_fitprefs.tildeFrxy[r][x][y] / 
                                     values[pirAy]))
                     else:
-                        self.assertTrue(scipy.allclose(
+                        self.assertTrue(numpy.allclose(
                                 float(dFrxy_dpirAx.subs(values.items())),
                                 -expcm_fitprefs.tildeFrxy[r][x][y] / 
                                 values[pirAx]))
-                        self.assertTrue(scipy.allclose(
+                        self.assertTrue(numpy.allclose(
                                 float(dFrxy_dpirAy.subs(values.items())),
                                 expcm_fitprefs.tildeFrxy[r][x][y] / 
                                 values[pirAy]))
@@ -141,8 +142,8 @@ class test_ExpCM_fitprefs(unittest.TestCase):
             zeta2 = expcm_fitprefs2.zeta
             pi = self.expcm_fitprefs.zeta
             pi2 = expcm_fitprefs2.zeta
-            self.assertTrue(scipy.allclose(zeta, zeta2) == (origbeta == 1))
-            self.assertTrue(scipy.allclose(pi, pi2) == (origbeta == 1))
+            self.assertTrue(numpy.allclose(zeta, zeta2) == (origbeta == 1))
+            self.assertTrue(numpy.allclose(pi, pi2) == (origbeta == 1))
             for r in range(expcm_fitprefs2.nsites):
                 for x in range(N_CODON):
                     pix = self.expcm_fitprefs.pi_codon[r][x]
@@ -169,7 +170,7 @@ class test_ExpCM_fitprefs(unittest.TestCase):
 
         expcm_fitprefs = copy.deepcopy(self.expcm_fitprefs)
 
-        self.assertTrue(scipy.allclose(expcm_fitprefs.pi, expcm_fitprefs.origpi))
+        self.assertTrue(numpy.allclose(expcm_fitprefs.pi, expcm_fitprefs.origpi))
         k = 0
         for r in range(expcm_fitprefs.nsites):
             for i in range(N_AA - 1):
@@ -178,10 +179,10 @@ class test_ExpCM_fitprefs(unittest.TestCase):
                 zeta = oldzeta.copy()
                 zeta[k] *= 0.9
                 expcm_fitprefs.updateParams({'zeta':zeta})
-                self.assertFalse(scipy.allclose(oldzeta, expcm_fitprefs.zeta))
-                self.assertFalse(scipy.allclose(oldpi[r], 
+                self.assertFalse(numpy.allclose(oldzeta, expcm_fitprefs.zeta))
+                self.assertFalse(numpy.allclose(oldpi[r], 
                         expcm_fitprefs.pi[r]))
-                self.assertFalse(scipy.allclose(expcm_fitprefs.pi,
+                self.assertFalse(numpy.allclose(expcm_fitprefs.pi,
                         expcm_fitprefs.origpi))
                 if self.MODEL == phydmslib.models.ExpCM_fitprefs:
                     self.assertTrue(expcm_fitprefs.pi[r][i] > oldpi[r][i])
@@ -216,7 +217,7 @@ class test_ExpCM_fitprefs(unittest.TestCase):
         j = 0
         for r in range(nsites):
             for i in range(N_AA - 1):
-                zetari = scipy.array([expcm_fitprefs.zeta.reshape(
+                zetari = numpy.array([expcm_fitprefs.zeta.reshape(
                         nsites, N_AA - 1)[r][i]])
                 for x in range(N_CODON):
                     diff = scipy.optimize.check_grad(func, dfunc,
@@ -250,7 +251,7 @@ class test_ExpCM_fitprefs(unittest.TestCase):
         j = 0
         for r in range(nsites):
             for i in range(N_AA - 1):
-                zetari = scipy.array([expcm_fitprefs.zeta.reshape(
+                zetari = numpy.array([expcm_fitprefs.zeta.reshape(
                         nsites, N_AA - 1)[r][i]])
                 for x in random.sample(range(N_CODON), 10):
                     for y in random.sample(range(N_CODON), 10):
@@ -287,7 +288,7 @@ class test_ExpCM_fitprefs(unittest.TestCase):
 
         for r in range(nsites):
             for i in range(N_AA - 1):
-                zetari = scipy.array([expcm_fitprefs.zeta.reshape(
+                zetari = numpy.array([expcm_fitprefs.zeta.reshape(
                         nsites, N_AA - 1)[r][i]])
                 for x in random.sample(range(N_CODON), 10):
                     for y in random.sample(range(N_CODON), 10):

--- a/tests/test_expcm_fitprefs_invquadraticprior.py
+++ b/tests/test_expcm_fitprefs_invquadraticprior.py
@@ -6,6 +6,7 @@ Written by Jesse Bloom."""
 import random
 import unittest
 import copy
+import numpy
 import scipy
 import scipy.linalg
 import sympy
@@ -44,7 +45,7 @@ class test_ExpCM_fitprefs_invquadraticprior(unittest.TestCase):
         lnpr = sympy.ln((1 / (1 + c1 * (pi - theta)**2))**c2)
         deriv = -2 * c1 * c2 * (pi - theta) / (1 + c1 * (pi - theta)**2)
         values = [(c1, 150), (c2, 0.5), (pi, 0.3), (theta, 0.421)]
-        self.assertTrue(scipy.allclose(
+        self.assertTrue(numpy.allclose(
                 float(deriv.subs(values)), float(sympy.diff(lnpr, pi).subs(values))))
 
 
@@ -53,7 +54,7 @@ class test_ExpCM_fitprefs_invquadraticprior(unittest.TestCase):
         scipy.random.seed(1)
 
         expcm_fitprefs = copy.deepcopy(self.expcm_fitprefs)
-        self.assertTrue(scipy.allclose(expcm_fitprefs.pi, expcm_fitprefs.origpi))
+        self.assertTrue(numpy.allclose(expcm_fitprefs.pi, expcm_fitprefs.origpi))
         if self.MODEL == phydmslib.models.ExpCM_fitprefs:
             newzeta = expcm_fitprefs.zeta.copy() * scipy.random.uniform(0.9, 1.0, 
                     expcm_fitprefs.zeta.shape)
@@ -63,7 +64,7 @@ class test_ExpCM_fitprefs_invquadraticprior(unittest.TestCase):
         else:
             raise RuntimeError("invalid MODEL: {0}".format(self.MODEL))
         expcm_fitprefs.updateParams({'zeta':newzeta})
-        self.assertFalse(scipy.allclose(expcm_fitprefs.pi, expcm_fitprefs.origpi))
+        self.assertFalse(numpy.allclose(expcm_fitprefs.pi, expcm_fitprefs.origpi))
         nsites = expcm_fitprefs.nsites
 
         def func(zetari, i, r):
@@ -81,7 +82,7 @@ class test_ExpCM_fitprefs_invquadraticprior(unittest.TestCase):
         j = 0
         for r in range(nsites):
             for i in range(N_AA - 1):
-                zetari = scipy.array([expcm_fitprefs.zeta.reshape(
+                zetari = numpy.array([expcm_fitprefs.zeta.reshape(
                         nsites, N_AA - 1)[r][i]])
                 diff = scipy.optimize.check_grad(func, dfunc, zetari, i, r)
                 deriv = dfunc(zetari, i, r)

--- a/tests/test_gammadistributedbeta_model.py
+++ b/tests/test_gammadistributedbeta_model.py
@@ -6,6 +6,7 @@ Written by Jesse Bloom and Sarah Hilton.
 
 import random
 import unittest
+import numpy
 import scipy
 import scipy.linalg
 import scipy.optimize
@@ -70,13 +71,13 @@ class test_GammaDistributedBeta_ExpCM(unittest.TestCase):
         ncats = 4
         gammamodel = phydmslib.models.GammaDistributedBetaModel(basemodel,
                 ncats)
-        self.assertTrue(scipy.allclose(scipy.array([m.beta for m in
+        self.assertTrue(numpy.allclose(numpy.array([m.beta for m in
                 gammamodel._models]), phydmslib.models.DiscreteGamma(
                 gammamodel.alpha_lambda, gammamodel.beta_lambda,
                 gammamodel.ncats)))
         for (param, pvalue) in paramvalues.items():
             if param != gammamodel.distributedparam:
-                self.assertTrue(scipy.allclose(getattr(gammamodel, param),
+                self.assertTrue(numpy.allclose(getattr(gammamodel, param),
                         pvalue))
 
         # try some updates and make sure everything remains OK
@@ -91,16 +92,16 @@ class test_GammaDistributedBeta_ExpCM(unittest.TestCase):
                     newvalues[param] = scipy.random.uniform(
                             low, high, paramlength)
             gammamodel.updateParams(newvalues)
-            self.assertTrue(scipy.allclose(scipy.array([m.beta for m in
+            self.assertTrue(numpy.allclose(numpy.array([m.beta for m in
                     gammamodel._models]), phydmslib.models.DiscreteGamma(
                     gammamodel.alpha_lambda, gammamodel.beta_lambda,
                     gammamodel.ncats)))
             for (param, pvalue) in newvalues.items():
                 if param != gammamodel.distributedparam:
-                    self.assertTrue(scipy.allclose(pvalue,
+                    self.assertTrue(numpy.allclose(pvalue,
                             getattr(gammamodel, param)))
                     if param not in gammamodel.distributionparams:
-                        self.assertTrue(all([scipy.allclose(pvalue,
+                        self.assertTrue(all([numpy.allclose(pvalue,
                                 getattr(m, param)) for m in
                                 gammamodel._models]))
 
@@ -112,11 +113,11 @@ class test_GammaDistributedBeta_ExpCM(unittest.TestCase):
             t = 0.15
             for k in range(gammamodel.ncats):
                 M = gammamodel.M(k, t)
-                self.assertTrue(scipy.allclose(gammamodel._models[k].M(t), M))
+                self.assertTrue(numpy.allclose(gammamodel._models[k].M(t), M))
                 for param in gammamodel.freeparams:
                     if param not in gammamodel.distributionparams:
                         dM = gammamodel.dM(k, t, param, M)
-                        self.assertTrue(scipy.allclose(dM,
+                        self.assertTrue(numpy.allclose(dM,
                                 gammamodel._models[k].dM(t, param, Mt=None)))
 
             # Check derivatives with respect to distribution params
@@ -135,10 +136,10 @@ class test_GammaDistributedBeta_ExpCM(unittest.TestCase):
                         gammamodel.updateParams({param:x[0]})
                         return gammamodel.d_distributionparams[param][k]
                     diff = scipy.optimize.check_grad(func, dfunc,
-                            scipy.array([pvalue]))
+                            numpy.array([pvalue]))
                     gammamodel.updateParams({param:pvalue})
                     diffs.append(diff)
-                diffs = scipy.array(diffs)
+                diffs = numpy.array(diffs)
                 self.assertTrue((diffs < 1e-5).all(), ("Excessive diff "
                         "for d_distributionparams[{0}] when "
                         "distributionparams = {1}:\n{2}".format(
@@ -146,12 +147,12 @@ class test_GammaDistributedBeta_ExpCM(unittest.TestCase):
 
             # Check the stationary state and deriviative of the stationary state
             # Stationary states should be different for each `k`
-            self.assertFalse(all([scipy.allclose(gammamodel.stationarystate(i),
+            self.assertFalse(all([numpy.allclose(gammamodel.stationarystate(i),
                     gammamodel.stationarystate(j)) for i in
                     range(gammamodel.ncats) for j in range(i+1, gammamodel.ncats)]))
             # The derviative of the stationary states should be different with
             # respect to beta for each `k`
-            self.assertFalse(all([scipy.allclose(gammamodel.dstationarystate(i, "beta"),
+            self.assertFalse(all([numpy.allclose(gammamodel.dstationarystate(i, "beta"),
                     gammamodel.dstationarystate(j, "beta")) for i in
                     range(gammamodel.ncats) for j in range(i+1, gammamodel.ncats)]))
 

--- a/tests/test_gammadistributedomega_model.py
+++ b/tests/test_gammadistributedomega_model.py
@@ -6,6 +6,7 @@ Written by Jesse Bloom.
 
 import random
 import unittest
+import numpy
 import scipy
 import scipy.linalg
 import scipy.optimize
@@ -66,13 +67,13 @@ class test_GammaDistributedOmega_ExpCM(unittest.TestCase):
         ncats = 4
         gammamodel = phydmslib.models.GammaDistributedOmegaModel(basemodel,
                 ncats)
-        self.assertTrue(scipy.allclose(scipy.array([m.omega for m in
+        self.assertTrue(numpy.allclose(numpy.array([m.omega for m in
                 gammamodel._models]), phydmslib.models.DiscreteGamma(
                 gammamodel.alpha_lambda, gammamodel.beta_lambda,
                 gammamodel.ncats)))
         for (param, pvalue) in paramvalues.items():
             if param != gammamodel.distributedparam:
-                self.assertTrue(scipy.allclose(getattr(gammamodel, param),
+                self.assertTrue(numpy.allclose(getattr(gammamodel, param),
                         pvalue))
 
         # try some updates and make sure everything remains OK
@@ -87,16 +88,16 @@ class test_GammaDistributedOmega_ExpCM(unittest.TestCase):
                     newvalues[param] = scipy.random.uniform(
                             low, high, paramlength)
             gammamodel.updateParams(newvalues)
-            self.assertTrue(scipy.allclose(scipy.array([m.omega for m in
+            self.assertTrue(numpy.allclose(numpy.array([m.omega for m in
                     gammamodel._models]), phydmslib.models.DiscreteGamma(
                     gammamodel.alpha_lambda, gammamodel.beta_lambda,
                     gammamodel.ncats)))
             for (param, pvalue) in newvalues.items():
                 if param != gammamodel.distributedparam:
-                    self.assertTrue(scipy.allclose(pvalue,
+                    self.assertTrue(numpy.allclose(pvalue,
                             getattr(gammamodel, param)))
                     if param not in gammamodel.distributionparams:
-                        self.assertTrue(all([scipy.allclose(pvalue,
+                        self.assertTrue(all([numpy.allclose(pvalue,
                                 getattr(m, param)) for m in
                                 gammamodel._models]))
 
@@ -107,11 +108,11 @@ class test_GammaDistributedOmega_ExpCM(unittest.TestCase):
             t = 0.15
             for k in range(gammamodel.ncats):
                 M = gammamodel.M(k, t)
-                self.assertTrue(scipy.allclose(gammamodel._models[k].M(t), M))
+                self.assertTrue(numpy.allclose(gammamodel._models[k].M(t), M))
                 for param in gammamodel.freeparams:
                     if param not in gammamodel.distributionparams:
                         dM = gammamodel.dM(k, t, param, M)
-                        self.assertTrue(scipy.allclose(dM,
+                        self.assertTrue(numpy.allclose(dM,
                                 gammamodel._models[k].dM(t, param, Mt=None)))
 
             # Check derivatives with respect to distribution params
@@ -130,10 +131,10 @@ class test_GammaDistributedOmega_ExpCM(unittest.TestCase):
                         gammamodel.updateParams({param:x[0]})
                         return gammamodel.d_distributionparams[param][k]
                     diff = scipy.optimize.check_grad(func, dfunc,
-                            scipy.array([pvalue]))
+                            numpy.array([pvalue]))
                     gammamodel.updateParams({param:pvalue})
                     diffs.append(diff)
-                diffs = scipy.array(diffs)
+                diffs = numpy.array(diffs)
                 self.assertTrue((diffs < 1e-5).all(), ("Excessive diff "
                         "for d_distributionparams[{0}] when "
                         "distributionparams = {1}:\n{2}".format(

--- a/tests/test_omegabysite.py
+++ b/tests/test_omegabysite.py
@@ -81,7 +81,7 @@ class test_OmegaBySiteYNGKP(test_OmegaBySiteExpCM):
     """Tests ``--omegabysite`` to ``phydms`` for `YNGKP_M0`."""
 
     def initializeModel(self):
-        e_pw = scipy.full((3, N_NT), 1.0 / N_NT, dtype='float')
+        e_pw = numpy.full((3, N_NT), 1.0 / N_NT, dtype='float')
         # mu > 1 leads to longer branches in simulation
         self.model = phydmslib.models.YNGKP_M0(e_pw, self.nsites, mu=4.0)
         self.modelname = 'YNGKP'

--- a/tests/test_phydms_comprehensive.py
+++ b/tests/test_phydms_comprehensive.py
@@ -10,6 +10,7 @@ import os
 import unittest
 import multiprocessing
 import subprocess
+import numpy
 import scipy
 import pandas
 
@@ -56,7 +57,7 @@ class test_phydms_comprehensive(unittest.TestCase):
                             (x, y) = line.split('=')
                             values[name][x.strip()] = float(y)
             for param in values['actual'].keys():
-                self.assertTrue(scipy.allclose(values['actual'][param],
+                self.assertTrue(numpy.allclose(values['actual'][param],
                         values['expected'][param], atol=1e-2, rtol=1e-5))
 
             omegas = {}
@@ -66,7 +67,7 @@ class test_phydms_comprehensive(unittest.TestCase):
                 omegas[name] = pandas.read_csv(fname,
                         comment='#', sep='\t')
                 omegas[name] = omegas[name].sort_values(by='site', axis=0)
-            self.assertTrue(scipy.allclose(omegas['actual']['P'].values,
+            self.assertTrue(numpy.allclose(omegas['actual']['P'].values,
                     omegas['expected']['P'].values, atol=0.01, rtol=0.03))
             sigsites = omegas['expected'][omegas['expected']['P'] < 0.05]['site'].values
             sigomegas = {}

--- a/tests/test_phydms_divpressure.py
+++ b/tests/test_phydms_divpressure.py
@@ -11,6 +11,7 @@ import shutil
 import unittest
 import subprocess
 import pandas as pd
+import numpy
 import scipy
 
 
@@ -51,7 +52,7 @@ class test_phydms_testdivpressure(unittest.TestCase):
         columns = [x for x in actual.columns.values if x != "value"]
         actual.sort_values(by=columns, inplace=True)
         expected.sort_values(by=columns, inplace=True)
-        self.assertTrue(scipy.allclose(actual["value"],
+        self.assertTrue(numpy.allclose(actual["value"],
                 expected["value"], atol=5e-2, rtol=1e-5),
                 f"{actual.to_csv(index=False)}\n{expected.to_csv(index=False)}")
 

--- a/tests/test_spielmanwr.py
+++ b/tests/test_spielmanwr.py
@@ -5,6 +5,7 @@ Written by Jesse Bloom and Sarah Hilton."""
 
 import random
 import unittest
+import numpy
 import scipy
 from phydmslib.constants import *
 import phydmslib.models
@@ -53,9 +54,9 @@ class testExpCM_spielmanwr(unittest.TestCase):
                         numerator += prx * Prxy
                         denominator += prx * Qxy
             wr.append(numerator/denominator)
-        wr = scipy.array(wr)
-        self.assertTrue(scipy.allclose(wr, scipy.array(self.model.spielman_wr(norm=False)), rtol=0.01))
-        self.assertTrue(scipy.allclose(wr/self.model.omega, scipy.array(self.model.spielman_wr()), rtol=0.01))
+        wr = numpy.array(wr)
+        self.assertTrue(numpy.allclose(wr, numpy.array(self.model.spielman_wr(norm=False)), rtol=0.01))
+        self.assertTrue(numpy.allclose(wr/self.model.omega, numpy.array(self.model.spielman_wr()), rtol=0.01))
 
 
 class test_empirical_phi_spielmanwr(testExpCM_spielmanwr):

--- a/tests/test_treelikelihood.py
+++ b/tests/test_treelikelihood.py
@@ -10,6 +10,7 @@ import math
 import unittest
 import random
 import copy
+import numpy
 import scipy
 import scipy.optimize
 import Bio.Phylo
@@ -150,16 +151,16 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
         self.assertTrue(nparams == sum(map(lambda x: (1 if isinstance(x, float)
                 else len(x)), modelparams.values())))
         # set to new value, make sure have changed
-        tl.paramsarray = scipy.array([random.uniform(0.7, 0.8) for i in
+        tl.paramsarray = numpy.array([random.uniform(0.7, 0.8) for i in
                 range(nparams)])
         for (param, value) in modelparams.items():
-            self.assertFalse(scipy.allclose(value, getattr(tl.model, param)))
-        self.assertFalse(scipy.allclose(logl, tl.loglik))
+            self.assertFalse(numpy.allclose(value, getattr(tl.model, param)))
+        self.assertFalse(numpy.allclose(logl, tl.loglik))
         # re-set to old value, make sure return to original values
         tl.paramsarray = copy.deepcopy(paramsarray)
-        self.assertTrue(scipy.allclose(logl, tl.loglik))
+        self.assertTrue(numpy.allclose(logl, tl.loglik))
         for (param, value) in modelparams.items():
-            self.assertTrue(scipy.allclose(value, getattr(tl.model, param)))
+            self.assertTrue(numpy.allclose(value, getattr(tl.model, param)))
 
     def test_Likelihood(self):
         """Tests likelihood."""
@@ -184,8 +185,8 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
             for (node, t) in self.brlen.items():
                 M[node] = model.M(t / model.branchScale)
             # compute partials at root node
-            partials = scipy.zeros(shape=(self.nsites, N_CODON))
-            siteloglik = scipy.zeros(shape=(self.nsites,))
+            partials = numpy.zeros(shape=(self.nsites, N_CODON))
+            siteloglik = numpy.zeros(shape=(self.nsites,))
             loglik = 0.0
             for r in range(self.nsites):
                 for y in range(N_CODON):
@@ -205,7 +206,7 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
             for (name, d) in [('partials', partials_by_mu),
                                       ('siteloglik', siteloglik_by_mu),
                                       ('loglik', loglik_by_mu)]:
-                self.assertTrue(scipy.allclose(d[mu1]['actual'],
+                self.assertTrue(numpy.allclose(d[mu1]['actual'],
                         d[mu1]['expected']), "Mismatch: {0}".format(name))
 
     def test_LikelihoodDerivativesModelParams(self):
@@ -232,7 +233,7 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
                 return tl.dloglikarray[i]
             for iparam in range(len(tl.paramsarray)):
                 diff = scipy.optimize.check_grad(func, dfunc,
-                        scipy.array([tl.paramsarray[iparam]]), iparam)
+                        numpy.array([tl.paramsarray[iparam]]), iparam)
                 self.assertTrue(diff < 1e-1, ("{0}: diff {1}, value "
                         "{2}, deriv {3}").format(tl._index_to_param[iparam],
                         diff, tl.paramsarray[iparam],
@@ -258,11 +259,11 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
             self.assertTrue(tl.loglik > startloglik, "no loglik increase: "
                     "start = {0}, end = {1}".format(startloglik, tl.loglik))
             for (otherloglik, otherparams) in zip(logliks, paramsarrays):
-                self.assertTrue(scipy.allclose(tl.loglik, otherloglik,
+                self.assertTrue(numpy.allclose(tl.loglik, otherloglik,
                         atol=1e-3, rtol=1e-3),
                         "Large difference in loglik: {0} vs {1}".format(
                         otherloglik, tl.loglik))
-                self.assertTrue(scipy.allclose(tl.paramsarray, otherparams,
+                self.assertTrue(numpy.allclose(tl.paramsarray, otherparams,
                         atol=1e-2, rtol=1e-1),
                         "Large difference in paramsarray: {0} vs {1}, {2}".format(
                         otherparams, tl.paramsarray, self.model))

--- a/tests/test_treelikelihood_fitprefs.py
+++ b/tests/test_treelikelihood_fitprefs.py
@@ -88,7 +88,7 @@ class test_TreeLikelihood_ExpCM_fitprefs(unittest.TestCase):
                     self.alignment, model)
 
         logliks = [tl.loglik for tl in tls.values()]
-        self.assertTrue(all([scipy.allclose(logliks[0], logliki)
+        self.assertTrue(all([numpy.allclose(logliks[0], logliki)
                 for logliki in logliks]),
                 "All loglik should be equal prior to optimization as pi "
                 "starts at initial origpi values.")
@@ -127,16 +127,16 @@ class test_TreeLikelihood_ExpCM_fitprefs(unittest.TestCase):
             else:
                 raise ValueError("Unrecognized MODEL: {0}".format(self.MODEL))
             if firstloglik:
-                self.assertFalse(scipy.allclose(firstloglik, tl.loglik,
+                self.assertFalse(numpy.allclose(firstloglik, tl.loglik,
                         atol=0.02), "loglik matches even with random pi")
             maxresult = tl.maximizeLikelihood()
             if firstloglik:
-                self.assertTrue(scipy.allclose(firstloglik, tl.loglik,
+                self.assertTrue(numpy.allclose(firstloglik, tl.loglik,
                         atol=0.4), "loglik not the same for different starts:"
                         " {0} versus {1}".format(firstloglik, tl.loglik))
             else:
                 firstloglik = tl.loglik
-            self.assertTrue(scipy.allclose(tl.model.origpi, self.model.pi))
+            self.assertTrue(numpy.allclose(tl.model.origpi, self.model.pi))
             # ensure highest prefs are for amino acids with nonzero counts
             for r in range(tl.nsites):
                 for (c, nc) in self.codoncounts[r].items():

--- a/tests/test_underflow.py
+++ b/tests/test_underflow.py
@@ -50,12 +50,12 @@ class test_underflow(unittest.TestCase):
             tl_nocorrection = phydmslib.treelikelihood.TreeLikelihood(
                     tree, alignment, m, underflowfreq=100000)
 
-            self.assertTrue(scipy.allclose(tl.loglik, tl_nocorrection.loglik),
+            self.assertTrue(numpy.allclose(tl.loglik, tl_nocorrection.loglik),
                     ("Log likelihoods differ with and without correction "
                     "for {0}: {1} versus {2}".format(desc, tl.loglik,
                     tl_nocorrection.loglik)))
             for (param, dl) in tl_nocorrection.dloglik.items():
-                self.assertTrue(scipy.allclose(dl, tl.dloglik[param]),
+                self.assertTrue(numpy.allclose(dl, tl.dloglik[param]),
                         ('dloglik differs with and without correction for {0}: '
                         '{1}, {2} versus {3}'.format(param, desc,
                         tl.dloglik[param], dl)))
@@ -65,12 +65,12 @@ class test_underflow(unittest.TestCase):
             tl_nocorrection.dparamscurrent = False
             tl.dtcurrent = True
             tl_nocorrection.dtcurrent = True
-            self.assertTrue(scipy.allclose(tl.loglik, tl_nocorrection.loglik),
+            self.assertTrue(numpy.allclose(tl.loglik, tl_nocorrection.loglik),
                     ("Log likelihoods differ with and without correction "
                     "for {0}: {1} versus {2}".format(desc, tl.loglik,
                     tl_nocorrection.loglik)))
-            self.assertTrue(scipy.allclose(tl.loglik, oldloglik))
-            self.assertTrue(scipy.allclose(tl.dloglik_dt,
+            self.assertTrue(numpy.allclose(tl.loglik, oldloglik))
+            self.assertTrue(numpy.allclose(tl.dloglik_dt,
                     tl_nocorrection.dloglik_dt))
 
 


### PR DESCRIPTION
As described [here](https://docs.scipy.org/doc/scipy/reference/release.1.4.0.html#deprecated-features), in `scipy` 2.0.0 not all parts of `numpy` interface will be maintained. This is currently causing a lot deprecation warnings. Fixed by changing `scipy` calls to `numpy` calls for relevant functions.

Also incremented to version 2.3.7.