### PR TITLE
shortened headers to 253 characters downstream of mafft

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,8 @@
 Changelog
 ===========
+2.3.8
+------
+* Fixed bug in `phydms_prepalignment` due to `mafft` shortening sequence names.
 
 2.3.7
 ------

--- a/phydmslib/_metadata.py
+++ b/phydmslib/_metadata.py
@@ -1,4 +1,4 @@
-__version__ = '2.3.7'
+__version__ = '2.3.8'
 __author__ = 'the Bloom lab (see https://github.com/jbloomlab/phydms/contributors)'
 __url__ = 'http://jbloomlab.github.io/phydms'
 __author_email__ = 'jbloom@fredhutch.org'

--- a/scripts/phydms_prepalignment
+++ b/scripts/phydms_prepalignment
@@ -39,6 +39,11 @@ def MAFFT_CDSandProtAlignments(headseqprots, mafftcmd, tempfileprefix):
     *headseqprots* except coding and protein sequences are aligned.
     The sequence order is preserved in this list.
     """
+    # mafft shortens sequence names to the first 253 characters
+    headseqprots = [(head[:254], seq, prot) for (head, seq, prot) in headseqprots]
+    headseqprotsnames = [head for head, seq, prot in headseqprots]
+    assert len(headseqprotsnames) == len(set(headseqprotsnames)), "The first 253 characters of each sequence name must be unique."
+
     seq_d = dict([(head, seq) for (head, seq, prot) in headseqprots])
     prot_d = dict([(head, prot) for (head, seq, prot) in headseqprots])
 
@@ -55,8 +60,8 @@ def MAFFT_CDSandProtAlignments(headseqprots, mafftcmd, tempfileprefix):
 
     with open(alignedprotsfile,'w') as stdout, open(outputfile, 'w') as stderr:
         subprocess.check_call(
-                [mafftcmd, '--auto', '--thread', '-1', unalignedprotsfile], 
-                stdout=stdout, 
+                [mafftcmd, '--auto', '--thread', '-1', unalignedprotsfile],
+                stdout=stdout,
                 stderr=stderr,
                 )
 
@@ -329,7 +334,7 @@ def main():
     points = []
     labels = []
     for (label, idents, color, marker, alpha) in [
-            ('purged', purged_idents, 'b', 'o', 0.25), 
+            ('purged', purged_idents, 'b', 'o', 0.25),
             ('retained', retained_idents, 'r', 'd', 0.5)
             ]:
         pt = plt.scatter(


### PR DESCRIPTION
This pull request fixes a bug caused by mafft shortening sequence names. In `phydms_prepalignment` function `MAFFT_CDSandProtAlignments` there are two dictionaries keyed by prealignment sequence names. However, `mafft` trims sequence names to 253 characters so there was mismatch of sequence names pre- vs. post-alignment if the original name was greater than 253 characters. The current solution was to create this dictionaries using only the first 253 characters. The script now also checks that trimming to the first 253 characters still results in unique sequence names. 

There is one major downside to this solution. I could not find a reference to the shortening of sequence names in the `mafft` documentation. This means that if `mafft` changes this behavior, which seems unlikely, `phydms_prepalignment` will break again. A more complicated solution would be to check if the post-alignment name is a substring of the pre-alignment name but it is difficult to key a dictionary this way. 

Because a `mafft` behavior change seems unlikely, I went with the simple fix. But I understand if @jbloom  thinks a refactor is worth it for more robust behavior. 

This pull request closes issue #25 