### PR TITLE
Scipy deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ branches:
   only:
     - master
     - model_adequacy
-    - scipy-deprecation-warnings
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ branches:
   only:
     - master
     - model_adequacy
+    - scipy-deprecation-warnings
 
 notifications:
   email:

--- a/phydmslib/constants.py
+++ b/phydmslib/constants.py
@@ -57,7 +57,6 @@ Constants defined:
 import re
 import inspect
 import numpy
-import scipy
 import Bio.Seq
 
 ALMOST_ZERO = 1.0e-6
@@ -90,7 +89,7 @@ for nt1 in sorted(NT_TO_INDEX.keys()):
                 CODON_TO_AA.append(AA_TO_INDEX[aa])
                 i += 1
             else:
-                STOP_CODON_TO_NT_INDICES.append(numpy.zeros((3, N_NT), 
+                STOP_CODON_TO_NT_INDICES.append(numpy.zeros((3, N_NT),
                         dtype='float'))
                 STOP_CODON_TO_NT_INDICES[-1][0][NT_TO_INDEX[nt1]] = 1.0
                 STOP_CODON_TO_NT_INDICES[-1][1][NT_TO_INDEX[nt2]] = 1.0

--- a/phydmslib/numutils.pyx
+++ b/phydmslib/numutils.pyx
@@ -32,7 +32,7 @@ def broadcastMatrixMultiply(numpy.ndarray a, numpy.ndarray b,
     ...   b[i][0][0] = 2
     >>> ab = broadcastMatrixMultiply(a, b)
     >>> expected = scipy.matmul(a, b)
-    >>> scipy.allclose(expected, ab)
+    >>> numpy.allclose(expected, ab)
     True
     """
     assert a.dtype == b.dtype == numpy.double
@@ -48,7 +48,7 @@ def broadcastMatrixMultiply(numpy.ndarray a, numpy.ndarray b,
     cdef int i
     for i in range(r):
         ab[i] = scipy.linalg.blas.dgemm(alpha, a[i], b[i])
-        # the overwrite_c option currently appears to be broken, so we do this 
+        # the overwrite_c option currently appears to be broken, so we do this
     return ab
 
 
@@ -72,7 +72,7 @@ def broadcastMatrixVectorMultiply(numpy.ndarray m, numpy.ndarray v,
 
     >>> m = numpy.array([[[1., 2], [3, 4]], [[5, 6], [7, 8]], [[9, 8], [7, 6]]])
     >>> v = numpy.array([[1., 2], [3, 4], [1, 3]])
-    >>> mv = scipy.ndarray(v.shape, dtype='int')
+    >>> mv = numpy.ndarray(v.shape, dtype='int')
     >>> for r in range(v.shape[0]):
     ...   for x in range(v.shape[1]):
     ...      mvrx = 0
@@ -82,7 +82,7 @@ def broadcastMatrixVectorMultiply(numpy.ndarray m, numpy.ndarray v,
     >>> mv2 = broadcastMatrixVectorMultiply(m, v)
     >>> mv.shape == mv2.shape
     True
-    >>> scipy.allclose(mv, mv2)
+    >>> numpy.allclose(mv, mv2)
     True
     """
     assert v.dtype == m.dtype == numpy.double
@@ -122,9 +122,9 @@ def broadcastGetCols(numpy.ndarray m, numpy.ndarray cols):
     >>> n = 2
     >>> r = 3
     >>> m = numpy.arange(r * n * n).reshape(r, n, n)
-    >>> cols = scipy.random.random_integers(0, n - 1, r)
+    >>> cols = numpy.random.random_integers(0, n - 1, r)
     >>> expected = numpy.array([m[i][:, cols[i]] for i in range(r)])
-    >>> scipy.allclose(expected, broadcastGetCols(m, cols))
+    >>> numpy.allclose(expected, broadcastGetCols(m, cols))
     True
     """
     assert m.ndim == 3

--- a/phydmslib/simulate.py
+++ b/phydmslib/simulate.py
@@ -5,7 +5,6 @@ Written by Jesse Bloom and Sarah Hilton.
 
 import os
 import sys
-import scipy
 import math
 import phydmslib.models
 from phydmslib.constants import *

--- a/phydmslib/treelikelihood.py
+++ b/phydmslib/treelikelihood.py
@@ -12,7 +12,6 @@ import warnings
 warnings.simplefilter('always')
 warnings.simplefilter('ignore', ImportWarning)
 import numpy
-import scipy
 import scipy.optimize
 import Bio.Phylo
 import phydmslib.models
@@ -246,7 +245,7 @@ class TreeLikelihood(object):
                 paramvalue = getattr(self.model, param)
                 if isinstance(paramvalue, float):
                     self._dLshape[param] = self._Lshape
-                elif isinstance(paramvalue, scipy.ndarray) and (paramvalue.ndim
+                elif isinstance(paramvalue, numpy.ndarray) and (paramvalue.ndim
                         == 1):
                     if self._distributionmodel:
                         self._dLshape[param] = (self.model.ncats,
@@ -450,14 +449,14 @@ class TreeLikelihood(object):
                     else:
                         warnings.warn(failmsg + '\n\n' +
                                 "Re-trying with different initial params.")
-                        scipy.random.seed(nparamstry)
+                        numpy.random.seed(nparamstry)
                         # seed at geometric mean of original value, max
                         # bound, min bound, and random number between max and min
                         minarray = numpy.array([self.paramsarraybounds[j][0] for
                                 j in range(len(self.paramsarray))])
                         maxarray = numpy.array([self.paramsarraybounds[j][1] for
                                 j in range(len(self.paramsarray))])
-                        randarray = scipy.random.uniform(minarray, maxarray)
+                        randarray = numpy.random.uniform(minarray, maxarray)
                         newarray = (minarray * maxarray * randarray *
                                 origparamsarray)**(1 / 4.) # geometric mean
                         assert newarray.shape == self.paramsarray.shape
@@ -540,7 +539,7 @@ class TreeLikelihood(object):
         if self._paramsarray is not None:
             return self._paramsarray.copy()
         nparams = len(self._index_to_param)
-        self._paramsarray = scipy.ndarray(shape=(nparams,), dtype='float')
+        self._paramsarray = numpy.ndarray(shape=(nparams,), dtype='float')
         for (i, param) in self._index_to_param.items():
             if isinstance(param, str):
                 self._paramsarray[i] = getattr(self.model, param)
@@ -554,7 +553,7 @@ class TreeLikelihood(object):
     def paramsarray(self, value):
         """Set new `paramsarray` and update via `updateParams`."""
         nparams = len(self._index_to_param)
-        assert (isinstance(value, scipy.ndarray) and value.ndim == 1), (
+        assert (isinstance(value, numpy.ndarray) and value.ndim == 1), (
                 "paramsarray must be 1-dim ndarray")
         assert len(value) == nparams, ("Assigning paramsarray to ndarray "
                 "of the wrong length.")
@@ -620,7 +619,7 @@ class TreeLikelihood(object):
     @t.setter
     def t(self, value):
         """Set new branch lengths, update likelihood and derivatives."""
-        assert (isinstance(value, scipy.ndarray) and (value.dtype ==
+        assert (isinstance(value, numpy.ndarray) and (value.dtype ==
                 'float') and (value.shape == self.t.shape))
         if (self._t != value).any():
             self._t = value.copy()
@@ -643,7 +642,7 @@ class TreeLikelihood(object):
         """Derivative of `loglik` with respect to `paramsarray`."""
         assert self.dparamscurrent, "dloglikarray requires paramscurrent == True"
         nparams = len(self._index_to_param)
-        dloglikarray = scipy.ndarray(shape=(nparams,), dtype='float')
+        dloglikarray = numpy.ndarray(shape=(nparams,), dtype='float')
         for (i, param) in self._index_to_param.items():
             if isinstance(param, str):
                 dloglikarray[i] = self.dloglik[param]
@@ -690,7 +689,7 @@ class TreeLikelihood(object):
         # Underflow by ensuring that none of the site likelihoods is
         # zero.
         undererrstate = 'ignore' if len(catweights) > 1 else 'raise'
-        with scipy.errstate(over='raise', under=undererrstate,
+        with numpy.errstate(over='raise', under=undererrstate,
                 divide='raise', invalid='raise'):
             self.underflowlogscale.fill(0.0)
             self._computePartialLikelihoods()
@@ -803,10 +802,10 @@ class TreeLikelihood(object):
                 istipl = False
             tright = self.t[nright]
             tleft = self.t[nleft]
-            self.L[n] = scipy.ndarray(self._Lshape, dtype='float')
+            self.L[n] = numpy.ndarray(self._Lshape, dtype='float')
             if self.dparamscurrent:
                 for param in self._paramlist_PartialLikelihoods:
-                    self.dL[param][n] = scipy.ndarray(self._dLshape[param],
+                    self.dL[param][n] = numpy.ndarray(self._dLshape[param],
                             dtype='float')
             if self.dtcurrent:
                 for n2 in self.dL_dt.keys():
@@ -887,14 +886,14 @@ class TreeLikelihood(object):
                 assert scale.shape == (self.nsites,)
                 self.underflowlogscale += numpy.log(scale)
                 for k in self._catindices:
-                    self.L[n][k] /= scale[:, scipy.newaxis]
+                    self.L[n][k] /= scale[:, numpy.newaxis]
                     if self.dtcurrent:
                         for n2 in self.dL_dt.keys():
-                            self.dL_dt[n2][n][k] /= scale[:, scipy.newaxis]
+                            self.dL_dt[n2][n][k] /= scale[:, numpy.newaxis]
                     if self.dparamscurrent:
                         for param in self._paramlist_PartialLikelihoods:
                             for j in self._sub_index_param(param):
-                                self.dL[param][n][k][j] /= scale[:, scipy.newaxis]
+                                self.dL[param][n][k][j] /= scale[:, numpy.newaxis]
 
             # free unneeded memory by deleting already used values
             for ntodel in [nright, nleft]:
@@ -920,7 +919,7 @@ class TreeLikelihood(object):
             paramvalue = getattr(self.model, param)
             if isinstance(paramvalue, float):
                 indices = [()]
-            elif (isinstance(paramvalue, scipy.ndarray) and
+            elif (isinstance(paramvalue, numpy.ndarray) and
                     paramvalue.ndim == 1 and paramvalue.shape[0] > 1):
                 indices = [(j,) for j in range(len(paramvalue))]
             else:

--- a/phydmslib/weblogo.py
+++ b/phydmslib/weblogo.py
@@ -20,7 +20,7 @@ import shutil
 import natsort
 import numpy
 import matplotlib
-matplotlib.use('pdf', warn=False)
+matplotlib.use('pdf')
 import pylab
 import PyPDF2
 # the following are part of the weblogo library
@@ -36,8 +36,8 @@ def KyteDoolittleColorMapping(maptype='jet', reverse=True):
 
     Uses the Kyte-Doolittle hydrophobicity scale defined by::
 
-        J. Kyte & R. F. Doolittle: 
-        "A simple method for displaying the hydropathic character of a protein." 
+        J. Kyte & R. F. Doolittle:
+        "A simple method for displaying the hydropathic character of a protein."
         J Mol Biol, 157, 105-132
 
     More positive values indicate higher hydrophobicity, while more negative values
@@ -49,7 +49,7 @@ def KyteDoolittleColorMapping(maptype='jet', reverse=True):
 
         * *mapping_d* is a dictionary keyed by the one-letter amino-acid
           codes. The values are the colors in CSS2 format (e.g. #FF0000
-          for red) for that amino acid. The value for a stop codon 
+          for red) for that amino acid. The value for a stop codon
           (denoted by a ``*`` character) is black (#000000).
 
         * *mapper* is the actual *pylab.cm.ScalarMappable* object.
@@ -84,11 +84,11 @@ def KyteDoolittleColorMapping(maptype='jet', reverse=True):
 def MWColorMapping(maptype='jet', reverse=True):
     """Maps amino-acid molecular weights to colors. Otherwise, this
     function is identical to *KyteDoolittleColorMapping*
-    """ 
+    """
     d = {'A':89,'R':174,'N':132,'D':133,'C':121,'Q':146,'E':147,\
          'G':75,'H':155,'I':131,'L':131,'K':146,'M':149,'F':165,\
          'P':115,'S':105,'T':119,'W':204,'Y':181,'V':117}
-    
+
     aas = sorted(AA_TO_INDEX.keys())
     mws  = [d[aa] for aa in aas]
     if reverse:
@@ -109,7 +109,7 @@ def SingleColorMapping(maptype="#999999"):
     return (None, collections.defaultdict(lambda: maptype), None)
 
 def ChargeColorMapping(maptype='jet', reverse=False):
-    """Maps amino-acid charge at neutral pH to colors. 
+    """Maps amino-acid charge at neutral pH to colors.
     Currently does not use the keyword arguments for *maptype*
     or *reverse* but accepts these arguments to be consistent
     with KyteDoolittleColorMapping and MWColorMapping for now."""
@@ -132,7 +132,7 @@ def FunctionalGroupColorMapping(maptype='jet', reverse=False):
     """Maps amino-acid functional groups to colors.
     Currently does not use the keyword arguments for *maptype*
     or *reverse* but accepts these arguments to be consistent
-    with the other mapping functions, which all get called with 
+    with the other mapping functions, which all get called with
     these arguments."""
 
     small_color = '#f76ab4'
@@ -166,7 +166,7 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
     that site for that amino acid or nucleotide.
 
     Note that stop codons may or may not be included in the logo
-    depending on whether they are present in *pi_d*.  
+    depending on whether they are present in *pi_d*.
 
     CALLING VARIABLES:
 
@@ -177,22 +177,22 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
       listed in *sites*. These should be **strings**, not integers.
 
     * *datatype* should be one of the following strings:
-    
+
         * 'prefs' for preferences
-        
+
         * 'diffprefs' for differential preferences
-        
+
         * 'diffsel' for differential selection
 
     * *data* is a dictionary that has a key for every entry in
       *sites*. For every site *r* in *sites*, *sites[r][x]*
-      is the value for character *x*. 
+      is the value for character *x*.
       Preferences must sum to one; differential preferences to zero.
       All sites must have the same set of characters. The characters
       must be the set of nucleotides or amino acids with or without
       stop codons.
 
-    * *plotfile* is a string giving the name of the created PDF file 
+    * *plotfile* is a string giving the name of the created PDF file
       of the logo plot.
       It must end in the extension ``.pdf``.
 
@@ -201,7 +201,7 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
     * *numberevery* is specifies how frequently we put labels for the sites on
       x-axis.
 
-    * *allowunsorted* : if *True* then we allow the entries in *sites* to 
+    * *allowunsorted* : if *True* then we allow the entries in *sites* to
       **not** be sorted. This means that the logo plot will **not** have
       sites in sorted order.
 
@@ -209,9 +209,9 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
       the maximum that the logo stacks extend in the positive and negative directions.
       Cannot be smaller than the maximum extent of the differential preferences.
 
-    * *ylimits*: is **mandatory** if *datatype* is 'diffsel', and meaningless 
-      otherwise. It is *(ymin, ymax)* where *ymax > 0 > ymin*, and gives extent 
-      of the data in the positive and negative directions. Must encompass the 
+    * *ylimits*: is **mandatory** if *datatype* is 'diffsel', and meaningless
+      otherwise. It is *(ymin, ymax)* where *ymax > 0 > ymin*, and gives extent
+      of the data in the positive and negative directions. Must encompass the
       actual maximum and minimum of the data.
 
     * *overlay* : make overlay bars that indicate other properties for
@@ -236,7 +236,7 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
         - *longname* : longer name for property used on axes label. Can be the
           same as *shortname* if you don't need a different long name.
 
-        - In the special case where both *shortname* and *longname* are 
+        - In the special case where both *shortname* and *longname* are
           the string `wildtype`, then rather than an overlay bar we
           right the one-character wildtype identity in `prop_d` for each
           site.
@@ -253,7 +253,7 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
       stands.
 
     * *overlay_cmap* can be the name of a valid *matplotlib.colors.Colormap*, such as the
-      string *jet* or *bwr*. Otherwise, it can be *None* and a (hopefully) good choice will 
+      string *jet* or *bwr*. Otherwise, it can be *None* and a (hopefully) good choice will
       be made for you.
 
     * *custom_cmap* can be the name of a valid *matplotlib.colors.Colormap* which will be
@@ -266,11 +266,11 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
       for a higher letter stack.
 
     * *map_metric* specifies the amino-acid property metric used to map colors to amino-acid
-      letters. Valid options are 'kd' (Kyte-Doolittle hydrophobicity scale, default), 'mw' 
+      letters. Valid options are 'kd' (Kyte-Doolittle hydrophobicity scale, default), 'mw'
       (molecular weight), 'functionalgroup' (functional groups: small, nucleophilic, hydrophobic,
       aromatic, basic, acidic, and amide), 'charge' (charge at neutral pH), and
       'singlecolor'. If 'charge' is used, then the
-      argument for *custom_cmap* will no longer be meaningful, since 'charge' uses its own 
+      argument for *custom_cmap* will no longer be meaningful, since 'charge' uses its own
       blue/black/red colormapping. Similarly, 'functionalgroup' uses its own colormapping.
 
     * *noseparator* is only meaningful if *datatype* is 'diffsel' or 'diffprefs'.
@@ -334,7 +334,7 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
         ymax = (stackaspectratio * stackwidth + len(overlay) * (barspacing + barheight)) / float(stackaspectratio * stackwidth)
         aspectratio = ymax * stackaspectratio # effective aspect ratio for full range
     else:
-        ymax = 1.0 
+        ymax = 1.0
         aspectratio = stackaspectratio
     rmargin = 11.5 # right margin in points, fixed by weblogo
     stackheightmargin = 16 # margin between stacks in points, fixed by weblogo
@@ -421,7 +421,7 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
         logo_options.stack_width = stackwidth
         logo_options.unit_name = 'probability'
         logo_options.show_yaxis = False
-        logo_options.yaxis_scale = ymax 
+        logo_options.yaxis_scale = ymax
         if alphabet_type == 'aa':
             map_functions = {'kd':KyteDoolittleColorMapping,
                              'mw': MWColorMapping,
@@ -452,7 +452,7 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
         logoformat = weblogolib.LogoFormat(logodata, logo_options)
         # _my_pdf_formatter is modified from weblogo version 3.4 source code
         # to allow custom ordering of the symbols.
-        pdf = _my_pdf_formatter(logodata, logoformat, ordered_alphabets) 
+        pdf = _my_pdf_formatter(logodata, logoformat, ordered_alphabets)
         with open(plotfile, 'wb') as f:
             f.write(pdf)
         assert os.path.isfile(plotfile), "Failed to find expected plotfile %s" % plotfile
@@ -482,9 +482,9 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
             overlaypdf = PyPDF2.PdfFileReader(overlayfile_f).getPage(0)
             xshift = overlaypdf.artBox[2] - plot.artBox[2]
             yshift = (barheight + barspacing) * len(overlay) - 0.5 * barspacing
-            overlaypdf.mergeTranslatedPage(plot, xshift, 
+            overlaypdf.mergeTranslatedPage(plot, xshift,
                     yshift * int(underlay), expand=True)
-            overlaypdf.compressContentStreams() 
+            overlaypdf.compressContentStreams()
             output = PyPDF2.PdfFileWriter()
             output.addPage(overlaypdf)
             output.write(fmerged)
@@ -520,56 +520,56 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
 
 #  Copyright (c) 2003-2004 The Regents of the University of California.
 #  Copyright (c) 2005 Gavin E. Crooks
-#  Copyright (c) 2006-2011, The Regents of the University of California, through 
+#  Copyright (c) 2006-2011, The Regents of the University of California, through
 #  Lawrence Berkeley National Laboratory (subject to receipt of any required
 #  approvals from the U.S. Dept. of Energy).  All rights reserved.
 
 #  This software is distributed under the new BSD Open Source License.
 #  <http://www.opensource.org/licenses/bsd-license.html>
 #
-#  Redistribution and use in source and binary forms, with or without 
-#  modification, are permitted provided that the following conditions are met: 
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
 #
-#  (1) Redistributions of source code must retain the above copyright notice, 
-#  this list of conditions and the following disclaimer. 
+#  (1) Redistributions of source code must retain the above copyright notice,
+#  this list of conditions and the following disclaimer.
 #
-#  (2) Redistributions in binary form must reproduce the above copyright 
-#  notice, this list of conditions and the following disclaimer in the 
-#  documentation and or other materials provided with the distribution. 
+#  (2) Redistributions in binary form must reproduce the above copyright
+#  notice, this list of conditions and the following disclaimer in the
+#  documentation and or other materials provided with the distribution.
 #
-#  (3) Neither the name of the University of California, Lawrence Berkeley 
-#  National Laboratory, U.S. Dept. of Energy nor the names of its contributors 
-#  may be used to endorse or promote products derived from this software 
-#  without specific prior written permission. 
+#  (3) Neither the name of the University of California, Lawrence Berkeley
+#  National Laboratory, U.S. Dept. of Energy nor the names of its contributors
+#  may be used to endorse or promote products derived from this software
+#  without specific prior written permission.
 #
-#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
-#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
-#  POSSIBILITY OF SUCH DAMAGE. 
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
 
 # Replicates README.txt
 
 def _my_pdf_formatter(data, format, ordered_alphabets) :
     """ Generate a logo in PDF format.
-    
+
     Modified from weblogo version 3.4 source code.
     """
     eps = _my_eps_formatter(data, format, ordered_alphabets).decode()
-    gs = weblogolib.GhostscriptAPI()    
+    gs = weblogolib.GhostscriptAPI()
     return gs.convert('pdf', eps, format.logo_width, format.logo_height)
 
 
 def _my_eps_formatter(logodata, format, ordered_alphabets) :
     """ Generate a logo in Encapsulated Postscript (EPS)
-    
-    Modified from weblogo version 3.4 source code. 
+
+    Modified from weblogo version 3.4 source code.
 
     *ordered_alphabets* is a dictionary keyed by zero-indexed
     consecutive sites, with values giving order of characters
@@ -577,12 +577,12 @@ def _my_eps_formatter(logodata, format, ordered_alphabets) :
     """
     substitutions = {}
     from_format =[
-        "creation_date",    "logo_width",           "logo_height",      
+        "creation_date",    "logo_width",           "logo_height",
         "lines_per_logo",   "line_width",           "line_height",
         "line_margin_right","line_margin_left",     "line_margin_bottom",
         "line_margin_top",  "title_height",         "xaxis_label_height",
         "creator_text",     "logo_title",           "logo_margin",
-        "stroke_width",     "tic_length",           
+        "stroke_width",     "tic_length",
         "stacks_per_line",  "stack_margin",
         "yaxis_label",      "yaxis_tic_interval",   "yaxis_minor_tic_interval",
         "xaxis_label",      "xaxis_tic_interval",   "number_interval",
@@ -590,7 +590,7 @@ def _my_eps_formatter(logodata, format, ordered_alphabets) :
         "errorbar_width_fraction",
         "errorbar_gray",    "small_fontsize",       "fontsize",
         "title_fontsize",   "number_fontsize",      "text_font",
-        "logo_font",        "title_font",          
+        "logo_font",        "title_font",
         "logo_label",       "yaxis_scale",          "end_type",
         "debug",            "show_title",           "show_xaxis",
         "show_xaxis_label", "show_yaxis",           "show_yaxis_label",
@@ -598,7 +598,7 @@ def _my_eps_formatter(logodata, format, ordered_alphabets) :
         "rotate_numbers",   "show_ends",            "stack_height",
         "stack_width"
         ]
-   
+
     for s in from_format :
         substitutions[s] = getattr(format,s)
 
@@ -607,12 +607,12 @@ def _my_eps_formatter(logodata, format, ordered_alphabets) :
 
     # --------- COLORS --------------
     def format_color(color):
-        return  " ".join( ("[",str(color.red) , str(color.green), 
-            str(color.blue), "]"))  
+        return  " ".join( ("[",str(color.red) , str(color.green),
+            str(color.blue), "]"))
 
     substitutions["default_color"] = format_color(format.default_color)
 
-    colors = []  
+    colors = []
     if hasattr(format.color_scheme, 'rules'):
         grouplist = format.color_scheme.rules
     else:
@@ -623,13 +623,13 @@ def _my_eps_formatter(logodata, format, ordered_alphabets) :
         for s in group.symbols :
             colors.append( "  ("+s+") " + cf )
     substitutions["color_dict"] = "\n".join(colors)
-        
+
     data = []
-    
+
     # Unit conversion. 'None' for probability units
     conv_factor = None #JDB
     #JDB conv_factor = std_units[format.unit_name]
-    
+
     data.append("StartLine")
 
     seq_from = format.logo_start- format.first_index
@@ -639,18 +639,18 @@ def _my_eps_formatter(logodata, format, ordered_alphabets) :
     # logo_index : User visible coordinate, first_index based
     # stack_index : zero based index of visible stacks
     for seq_index in range(seq_from, seq_to) :
-        logo_index = seq_index + format.first_index 
+        logo_index = seq_index + format.first_index
         stack_index = seq_index - seq_from
-        
+
         if stack_index!=0 and (stack_index % format.stacks_per_line) ==0 :
             data.append("")
             data.append("EndLine")
             data.append("StartLine")
             data.append("")
-        
+
         data.append("(%s) StartStack" % format.annotate[seq_index] )
 
-        if conv_factor: 
+        if conv_factor:
             stack_height = logodata.entropy[seq_index] * std_units[format.unit_name]
         else :
             stack_height = 1.0 # Probability
@@ -676,11 +676,11 @@ def _my_eps_formatter(logodata, format, ordered_alphabets) :
         #s.sort(key= lambda x: x[0])
         #if not format.reverse_stacks: s.reverse()
 
-        C = float(sum(logodata.counts[seq_index])) 
+        C = float(sum(logodata.counts[seq_index]))
         if C > 0.0 :
             fraction_width = 1.0
             if format.scale_width :
-                fraction_width = logodata.weight[seq_index] 
+                fraction_width = logodata.weight[seq_index]
             # print(fraction_width, file=sys.stderr)
             for c in s:
                 data.append(" %f %f (%s) ShowSymbol" % (fraction_width, c[0]*stack_height/C, c[1]) )
@@ -693,17 +693,17 @@ def _my_eps_formatter(logodata, format, ordered_alphabets) :
             low *= conv_factor
             high *= conv_factor
             center *=conv_factor
-            if high> format.yaxis_scale : high = format.yaxis_scale 
+            if high> format.yaxis_scale : high = format.yaxis_scale
 
-            down = (center - low) 
-            up   = (high - center) 
+            down = (center - low)
+            up   = (high - center)
             data.append(" %f %f DrawErrorbar" % (down, up) )
-            
+
         data.append("EndStack")
         data.append("")
-               
+
     data.append("EndLine")
-    substitutions["logo_data"] = "\n".join(data)  
+    substitutions["logo_data"] = "\n".join(data)
 
 
     # Create and output logo
@@ -712,7 +712,7 @@ def _my_eps_formatter(logodata, format, ordered_alphabets) :
 
     return logo.encode()
 #
-# End of code modified from weblogo    
+# End of code modified from weblogo
 #########################################################################
 
 #########################################################################
@@ -725,7 +725,7 @@ def _my_eps_formatter(logodata, format, ordered_alphabets) :
 #  This software is distributed under the MIT Open Source License.
 #  <http://www.opensource.org/licenses/mit-license.html>
 #
-#  Permission is hereby granted, free of charge, to any person obtaining a 
+#  Permission is hereby granted, free of charge, to any person obtaining a
 #  copy of this software and associated documentation files (the "Software"),
 #  to deal in the Software without restriction, including without limitation
 #  the rights to use, copy, modify, merge, publish, distribute, sublicense,
@@ -735,57 +735,57 @@ def _my_eps_formatter(logodata, format, ordered_alphabets) :
 #  The above copyright notice and this permission notice shall be included
 #  in all copies or substantial portions of the Software.
 #
-#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 #  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 #  IN THE SOFTWARE.
 
 
 class _my_Motif(corebio.matrix.AlphabeticArray) :
-    """A two dimensional array where the second dimension is indexed by an 
+    """A two dimensional array where the second dimension is indexed by an
     Alphabet. Used to represent sequence motifs and similar information.
 
-    
+
     Attr:
     - alphabet     -- An Alphabet
     - array        -- A numpy array
     - name         -- The name of this motif (if any) as a string.
     - description  -- The description, if any.
-    
+
     """
-            
+
     def __init__(self, alphabet, array=None, dtype=None, name=None,
             description = None, scale=None) :
         corebio.matrix.AlphabeticArray.__init__(self, (None, alphabet), array, dtype)
         self.name = name
         self.description = description
-        self.scale = scale    
+        self.scale = scale
 
     @property
     def alphabet(self):
         return self.alphabets[1]
-        
+
     def reindex(self, alphabet) :
         return  _my_Motif(alphabet, corebio.matrix.AlphabeticArray.reindex(self, (None, alphabet)))
-  
+
     # These methods alter self, and therefore do not return a value.
     # (Compare to Seq objects, where the data is immutable and therefore methods return a new Seq.)
     # TODO: Should reindex (above) also act on self?
-    
+
     def reverse(self):
         """Reverse sequence data"""
 #        self.array = na.array(self.array[::-1]) # This is a view into the origional numpy array.
         self.array = self.array[::-1] # This is a view into the origional numpy array.
-    
+
     @staticmethod #TODO: should be classmethod?
     def read_transfac( fin, alphabet = None) :
-        """ Parse a sequence matrix from a file. 
+        """ Parse a sequence matrix from a file.
         Returns a tuple of (alphabet, matrix)
         """
-   
+
         items = []
 
         start=True
@@ -816,8 +816,8 @@ class _my_Motif(corebio.matrix.AlphabeticArray) :
         # Vertical or horizontal arrangement?
         if header[0] == 'PO' or header[0] == 'P0': header.pop(0)
 
-        position_header = True    
-        alphabet_header = True    
+        position_header = True
+        alphabet_header = True
         for h in header :
             if not corebio.utils.isint(h) : position_header = False
 #allow non-alphabetic            if not str.isalpha(h) : alphabet_header = False
@@ -832,7 +832,7 @@ class _my_Motif(corebio.matrix.AlphabeticArray) :
         # Check row headers
         if alphabet_header :
             for i,r in enumerate(items) :
-                if not corebio.utils.isint(r[0]) and r[0][0]!='P' : 
+                if not corebio.utils.isint(r[0]) and r[0][0]!='P' :
                     raise ValueError(
                         "Expected position as first item on line %d" % i)
                 r.pop(0)
@@ -840,11 +840,11 @@ class _my_Motif(corebio.matrix.AlphabeticArray) :
         else :
             a = []
             for i,r in enumerate(items) :
-                if not ischar(r[0]) and r[0][0]!='P' : 
+                if not ischar(r[0]) and r[0][0]!='P' :
                     raise ValueError(
                         "Expected position as first item on line %d" % i)
                 a.append(r.pop(0))
-            defacto_alphabet = ''.join(a)                
+            defacto_alphabet = ''.join(a)
 
         # Check defacto_alphabet
         defacto_alphabet = corebio.seq.Alphabet(defacto_alphabet)
@@ -853,9 +853,9 @@ class _my_Motif(corebio.matrix.AlphabeticArray) :
             if not defacto_alphabet.alphabetic(alphabet) :
                 raise ValueError("Incompatible alphabets: %s , %s (defacto)"
                                  % (alphabet, defacto_alphabet))
-        else :            
+        else :
             alphabets = (unambiguous_rna_alphabet,
-                        unambiguous_dna_alphabet,                      
+                        unambiguous_dna_alphabet,
                         unambiguous_protein_alphabet,
                       )
             for a in alphabets :
@@ -864,23 +864,23 @@ class _my_Motif(corebio.matrix.AlphabeticArray) :
                     break
             if not alphabet :
                 alphabet = defacto_alphabet
-   
+
 
         # The last item of each row may be extra cruft. Remove
         if len(items[0]) == len(header) +1 :
             for r in items :
                 r.pop()
 
-        # items should now be a list of lists of numbers (as strings) 
+        # items should now be a list of lists of numbers (as strings)
         rows = len(items)
         cols = len(items[0])
-        matrix = numpy.zeros( (rows,cols) , dtype=numpy.float64) 
+        matrix = numpy.zeros( (rows,cols) , dtype=numpy.float64)
         for r in range( rows) :
             for c in range(cols):
-                matrix[r,c] = float( items[r][c]) 
+                matrix[r,c] = float( items[r][c])
 
         if position_header :
-            matrix.transpose() 
+            matrix.transpose()
 
         return _my_Motif(defacto_alphabet, matrix).reindex(alphabet)
 
@@ -894,7 +894,7 @@ def LogoOverlay(sites, overlayfile, overlay, nperline, sitewidth, rmargin, logoh
     This function creates colored bars overlay bars showing up to two
     properties.
     The trick of this function is to create the bars the right
-    size so they align when they overlay the logo plot. 
+    size so they align when they overlay the logo plot.
 
     CALLING VARIABLES:
 
@@ -960,7 +960,7 @@ def LogoOverlay(sites, overlayfile, overlay, nperline, sitewidth, rmargin, logoh
     prop_types = {}
     for (prop_d, shortname, longname) in overlay:
         if shortname == longname == 'wildtype':
-            assert all([(isinstance(prop, str) and len(prop) == 1) for 
+            assert all([(isinstance(prop, str) and len(prop) == 1) for
                     prop in prop_d.values()]), 'prop_d does not give letters'
             proptype = 'wildtype'
             (vmin, vmax) = (0, 1) # not used, but need to be assigned
@@ -1001,14 +1001,14 @@ def LogoOverlay(sites, overlayfile, overlay, nperline, sitewidth, rmargin, logoh
         for (iprop, (prop_d, shortname, longname)) in enumerate(overlay):
             (proptype, vmin, vmax, propcategories) = prop_types[shortname]
             prop_ax = pylab.axes([
-                    lmargin / figwidth, 
-                    ((nlines - iline - 1) * (logoheight + 
-                        len(overlay) * (barspacing + barheight)) + 
-                        (1 - int(underlay)) * logoheight + int(underlay) * 
-                        barspacing + iprop * (barspacing + barheight)) 
-                        / figheight, 
-                    xlength / figwidth, 
-                    barheight / figheight], 
+                    lmargin / figwidth,
+                    ((nlines - iline - 1) * (logoheight +
+                        len(overlay) * (barspacing + barheight)) +
+                        (1 - int(underlay)) * logoheight + int(underlay) *
+                        barspacing + iprop * (barspacing + barheight))
+                        / figheight,
+                    xlength / figwidth,
+                    barheight / figheight],
                     frameon=(proptype != 'wildtype'))
             prop_ax.xaxis.set_ticks_position('none')
             pylab.xticks([])
@@ -1018,7 +1018,7 @@ def LogoOverlay(sites, overlayfile, overlay, nperline, sitewidth, rmargin, logoh
                 pylab.yticks([])
                 prop_ax.yaxis.set_ticks_position('none')
                 for (isite, site) in enumerate(isites):
-                    pylab.text(isite + 0.5, -0.5, prop_d[site], size=9, 
+                    pylab.text(isite + 0.5, -0.5, prop_d[site], size=9,
                             horizontalalignment='center', family='monospace')
                 continue
             pylab.yticks([0], [shortname], size=8)

--- a/scripts/phydms
+++ b/scripts/phydms
@@ -18,7 +18,6 @@ import warnings
 warnings.simplefilter('always')
 warnings.simplefilter('ignore', ImportWarning)
 import numpy
-import scipy
 import scipy.stats
 import statsmodels.sandbox.stats.multicomp
 import Bio.Phylo
@@ -130,7 +129,7 @@ def fitOmegaBySite(argtup):
     `argtup` is return value of `treeliksForOmegaBySite`.
 
     Returns tuple `(pval, omega, resultstr)` where `pval` is P-value,
-    `omega` is omega, and `resultstr` is tab-separated line with 
+    `omega` is omega, and `resultstr` is tab-separated line with
     site, omega, P, dLnL.
     """
     (site, treeliks, nograd) = argtup
@@ -283,7 +282,7 @@ def main():
                         'be optimized by maximum likelihood.\n')
                 model = phydmslib.models.ExpCM(prefslist, freeparams=freeparams)
             else:
-                g = scipy.ndarray(phydmslib.constants.N_NT, dtype='float')
+                g = numpy.ndarray(phydmslib.constants.N_NT, dtype='float')
                 for (w, nt) in phydmslib.constants.INDEX_TO_NT.items():
                     g[w] = sum([seq.count(nt) for (head, seq) in alignment])
                 assert len(alignment) * len(prefs) * 3 == (g.sum() +
@@ -473,14 +472,14 @@ def main():
             # compute Q-values separately for each sign of omega
             qvalues = numpy.ones(pvalues.shape)
             for op in [operator.ge, operator.le]:
-                pvalues_sign = scipy.where(op(omegas, 1),
+                pvalues_sign = numpy.where(op(omegas, 1),
                         pvalues, 1)
                 qvalues_sign = (statsmodels.sandbox.stats.multicomp
                         .multipletests(pvalues_sign, method='fdr_bh')[1])
-                qvalues = scipy.minimum(qvalues, qvalues_sign)
-            sortindex = scipy.argsort(qvalues)
-            qvalues = scipy.take(qvalues, sortindex)
-            omega_strs = scipy.take(omega_strs, sortindex)
+                qvalues = numpy.minimum(qvalues, qvalues_sign)
+            sortindex = numpy.argsort(qvalues)
+            qvalues = numpy.take(qvalues, sortindex)
+            omega_strs = numpy.take(omega_strs, sortindex)
             omegaresults = ['{0}\t{1:.3g}'.format(omega_str, q) for
                     (omega_str, q) in zip(omega_strs, qvalues)]
             logger.info("Completed fitting the site-specific omega values.")

--- a/tests/test_YNGKPM0.py
+++ b/tests/test_YNGKPM0.py
@@ -10,8 +10,8 @@ are correct for `YNGKP_M0` implemented in `phydmslib.models`."""
 import random
 import unittest
 import numpy
-import scipy
 import scipy.linalg
+import scipy.optimize
 import sympy
 from phydmslib.constants import *
 import phydmslib.models
@@ -25,14 +25,14 @@ class testYNGKP_M0(unittest.TestCase):
         # create alignment
         sequences = [""]
         #self.e_pa = numpy.array([[4.0, 0.0, 0.0, 0.0], [0.0, 1.0, 2.0, 1.0], [0.0, 2.0, 0.0, 2.0]])
-        scipy.random.seed(1)
+        numpy.random.seed(1)
         random.seed(1)
-        self.e_pa = scipy.random.uniform(0.12, 1.0, size = (3, N_NT))
+        self.e_pa = numpy.random.uniform(0.12, 1.0, size = (3, N_NT))
         self.e_pa = self.e_pa/self.e_pa.sum(axis=1, keepdims=True)
         self.nsites = 10
 
         # create initial YNGKP_M0
-        phi = scipy.random.dirichlet([2] * N_NT)
+        phi = numpy.random.dirichlet([2] * N_NT)
         omega = 0.4
         kappa = 2.5
         self.YNGKP_M0 = phydmslib.models.YNGKP_M0(self.e_pa, self.nsites, omega=omega, kappa=kappa)

--- a/tests/test_alignmentSimulation.py
+++ b/tests/test_alignmentSimulation.py
@@ -8,7 +8,6 @@ Written by Sarah Hilton and Jesse Bloom.
 import os
 import sys
 import numpy
-import scipy
 import math
 import unittest
 import random
@@ -34,7 +33,7 @@ class test_simulateAlignment_ExpCM(unittest.TestCase):
     def test_simulateAlignment(self):
         """Simulate evolution, ensure scaled branches match number of subs."""
 
-        scipy.random.seed(1)
+        numpy.random.seed(1)
         random.seed(1)
 
         alignmentPrefix = "test"
@@ -44,7 +43,7 @@ class test_simulateAlignment_ExpCM(unittest.TestCase):
         prefs = []
         minpref = 0.01
         for r in range(nsites):
-            rprefs = scipy.random.dirichlet([1] * N_AA)
+            rprefs = numpy.random.dirichlet([1] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
             prefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))
@@ -53,16 +52,16 @@ class test_simulateAlignment_ExpCM(unittest.TestCase):
         beta = 1.5
         mu = 0.3
         if self.MODEL == phydmslib.models.ExpCM:
-            phi = scipy.random.dirichlet([7] * N_NT)
+            phi = numpy.random.dirichlet([7] * N_NT)
             model = phydmslib.models.ExpCM(prefs, kappa=kappa, omega=omega,
                     beta=beta, mu=mu, phi=phi, freeparams=['mu'])
         elif self.MODEL == phydmslib.models.ExpCM_empirical_phi:
-            g = scipy.random.dirichlet([7] * N_NT)
+            g = numpy.random.dirichlet([7] * N_NT)
             model = phydmslib.models.ExpCM_empirical_phi(prefs, g,
                     kappa=kappa, omega=omega, beta=beta, mu=mu,
                     freeparams=['mu'])
         elif self.MODEL == phydmslib.models.YNGKP_M0:
-            e_pw = numpy.asarray([scipy.random.dirichlet([7] * N_NT) for i
+            e_pw = numpy.asarray([numpy.random.dirichlet([7] * N_NT) for i
                     in range(3)])
             model = phydmslib.models.YNGKP_M0(e_pw, nsites)
         else:

--- a/tests/test_alignmentSimulationRandomSeed.py
+++ b/tests/test_alignmentSimulationRandomSeed.py
@@ -8,7 +8,6 @@ Written by Sarah Hilton and Jesse Bloom.
 import os
 import sys
 import numpy
-import scipy
 import math
 import unittest
 import random
@@ -35,7 +34,7 @@ class test_simulateAlignmentRandomSeed_ExpCM(unittest.TestCase):
     def test_simulateAlignmentRandomSeed(self):
         """Simulate evolution, ensure scaled branches match number of subs."""
 
-        scipy.random.seed(1)
+        numpy.random.seed(1)
         random.seed(1)
 
         # define model
@@ -43,7 +42,7 @@ class test_simulateAlignmentRandomSeed_ExpCM(unittest.TestCase):
         prefs = []
         minpref = 0.01
         for r in range(nsites):
-            rprefs = scipy.random.dirichlet([1] * N_AA)
+            rprefs = numpy.random.dirichlet([1] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
             prefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))
@@ -52,16 +51,16 @@ class test_simulateAlignmentRandomSeed_ExpCM(unittest.TestCase):
         beta = 1.5
         mu = 0.3
         if self.MODEL == phydmslib.models.ExpCM:
-            phi = scipy.random.dirichlet([7] * N_NT)
+            phi = numpy.random.dirichlet([7] * N_NT)
             model = phydmslib.models.ExpCM(prefs, kappa=kappa, omega=omega,
                     beta=beta, mu=mu, phi=phi, freeparams=['mu'])
         elif self.MODEL == phydmslib.models.ExpCM_empirical_phi:
-            g = scipy.random.dirichlet([7] * N_NT)
+            g = numpy.random.dirichlet([7] * N_NT)
             model = phydmslib.models.ExpCM_empirical_phi(prefs, g,
                     kappa=kappa, omega=omega, beta=beta, mu=mu,
                     freeparams=['mu'])
         elif self.MODEL == phydmslib.models.YNGKP_M0:
-            e_pw = numpy.asarray([scipy.random.dirichlet([7] * N_NT) for i
+            e_pw = numpy.asarray([numpy.random.dirichlet([7] * N_NT) for i
                     in range(3)])
             model = phydmslib.models.YNGKP_M0(e_pw, nsites)
         else:

--- a/tests/test_alignmentSimulation_divpressure.py
+++ b/tests/test_alignmentSimulation_divpressure.py
@@ -9,7 +9,6 @@ Written by Sarah Hilton and Jesse Bloom.
 import os
 import sys
 import numpy
-import scipy
 import math
 import unittest
 import random
@@ -35,7 +34,7 @@ class test_simulateAlignment_ExpCM_divselection(unittest.TestCase):
     def test_simulateAlignment(self):
         """Simulate evolution, ensure scaled branches match number of subs."""
 
-        scipy.random.seed(1)
+        numpy.random.seed(1)
         random.seed(1)
 
         alignmentPrefix = "test"
@@ -45,7 +44,7 @@ class test_simulateAlignment_ExpCM_divselection(unittest.TestCase):
         prefs = []
         minpref = 0.01
         for r in range(nsites):
-            rprefs = scipy.random.dirichlet([1] * N_AA)
+            rprefs = numpy.random.dirichlet([1] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
             prefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))
@@ -56,7 +55,7 @@ class test_simulateAlignment_ExpCM_divselection(unittest.TestCase):
         omega2 = 1.2
         deltar = numpy.array([1 if x in random.sample(range(nsites), 20) else 0 for x in range(nsites)])
         if self.MODEL == phydmslib.models.ExpCM_empirical_phi_divpressure:
-            g = scipy.random.dirichlet([7] * N_NT)
+            g = numpy.random.dirichlet([7] * N_NT)
             model = phydmslib.models.ExpCM_empirical_phi_divpressure(prefs, g, deltar,
                     kappa=kappa, omega=omega, beta=beta, mu=mu,
                     freeparams=['mu'], omega2=omega2)

--- a/tests/test_branchScale.py
+++ b/tests/test_branchScale.py
@@ -9,7 +9,6 @@ Written by Jesse Bloom.
 import os
 import sys
 import numpy
-import scipy
 import math
 import unittest
 import random
@@ -35,7 +34,7 @@ class test_branchScale_ExpCM(unittest.TestCase):
     def test_branchScale(self):
         """Simulate evolution, ensure scaled branches match number of subs."""
 
-        scipy.random.seed(1)
+        numpy.random.seed(1)
         random.seed(1)
 
         # define model, only free parameter is mu for testing simulations
@@ -43,7 +42,7 @@ class test_branchScale_ExpCM(unittest.TestCase):
         prefs = []
         minpref = 0.01
         for r in range(nsites):
-            rprefs = scipy.random.dirichlet([1] * N_AA)
+            rprefs = numpy.random.dirichlet([1] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
             prefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))
@@ -52,18 +51,18 @@ class test_branchScale_ExpCM(unittest.TestCase):
         beta = 1.5
         mu = 0.3
         if self.MODEL == phydmslib.models.ExpCM:
-            phi = scipy.random.dirichlet([7] * N_NT)
+            phi = numpy.random.dirichlet([7] * N_NT)
             model = phydmslib.models.ExpCM(prefs, kappa=kappa, omega=omega,
                     beta=beta, mu=mu, phi=phi, freeparams=['mu'])
             partitions = phydmslib.simulate.pyvolvePartitions(model)
         elif self.MODEL == phydmslib.models.ExpCM_empirical_phi:
-            g = scipy.random.dirichlet([7] * N_NT)
+            g = numpy.random.dirichlet([7] * N_NT)
             model = phydmslib.models.ExpCM_empirical_phi(prefs, g,
                     kappa=kappa, omega=omega, beta=beta, mu=mu,
                     freeparams=['mu'])
             partitions = phydmslib.simulate.pyvolvePartitions(model)
         elif self.MODEL == phydmslib.models.YNGKP_M0:
-            e_pw = numpy.asarray([scipy.random.dirichlet([7] * N_NT) for i 
+            e_pw = numpy.asarray([numpy.random.dirichlet([7] * N_NT) for i
                     in range(3)])
             model = phydmslib.models.YNGKP_M0(e_pw, nsites)
             partitions = phydmslib.simulate.pyvolvePartitions(model)
@@ -81,7 +80,7 @@ class test_branchScale_ExpCM(unittest.TestCase):
         os.remove(temptree)
 
         # Simulate evolution of two sequences separated by a long branch.
-        # Then estimate subs per site in a heuristic way that will be 
+        # Then estimate subs per site in a heuristic way that will be
         # roughly correct for short branches. Do this all several times
         # and average results to get better accuracy.
         alignment = '_temp_branchScale_simulatedalignment.fasta'

--- a/tests/test_brlenderivatives.py
+++ b/tests/test_brlenderivatives.py
@@ -11,7 +11,6 @@ import unittest
 import random
 import copy
 import numpy
-import scipy
 import scipy.optimize
 import Bio.Phylo
 import phydmslib.models
@@ -32,11 +31,11 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
     def setUp(self):
         """Set up parameters for test."""
         random.seed(1)
-        scipy.random.seed(1)
+        numpy.random.seed(1)
 
         self.underflowfreq = 1
 
-        # define tree 
+        # define tree
         self.newick = ('((node1:0.2,node2:0.3)node4:0.3,node3:0.5)node5:0.04;')
         tempfile = '_temp.tree'
         with open(tempfile, 'w') as f:
@@ -48,7 +47,7 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
         pyvolvetree = pyvolve.read_tree(tree=self.newick)
         self.nsites = 50
         self.nseqs = self.tree.count_terminals()
-        e_pw = scipy.ndarray((3, N_NT), dtype='float')
+        e_pw = numpy.ndarray((3, N_NT), dtype='float')
         e_pw.fill(0.25)
         yngkp_m0 = phydmslib.models.YNGKP_M0(e_pw, self.nsites)
         partitions = phydmslib.simulate.pyvolvePartitions(yngkp_m0)
@@ -67,9 +66,9 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
         # define model
         prefs = []
         minpref = 0.02
-        g = scipy.random.dirichlet([10] * N_NT)
+        g = numpy.random.dirichlet([10] * N_NT)
         for r in range(self.nsites):
-            rprefs = scipy.random.dirichlet([0.5] * N_AA)
+            rprefs = numpy.random.dirichlet([0.5] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
             prefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))
@@ -78,12 +77,12 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
         elif self.MODEL == phydmslib.models.ExpCM_empirical_phi:
             self.model = phydmslib.models.ExpCM_empirical_phi(prefs, g)
         elif self.MODEL == phydmslib.models.ExpCM_empirical_phi_divpressure:
-            divpressure = scipy.random.uniform(-1, 5, self.nsites)
+            divpressure = numpy.random.uniform(-1, 5, self.nsites)
             divpressure /= max(abs(divpressure))
             self.model = phydmslib.models.ExpCM_empirical_phi_divpressure(
                     prefs, g, divpressure)
         elif self.MODEL == phydmslib.models.YNGKP_M0:
-            e_pw = scipy.random.uniform(0.2, 0.8, size=(3, N_NT))
+            e_pw = numpy.random.uniform(0.2, 0.8, size=(3, N_NT))
             e_pw = e_pw / e_pw.sum(axis=1, keepdims=True)
             self.model = phydmslib.models.YNGKP_M0(e_pw, self.nsites)
         else:
@@ -91,7 +90,7 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
 
         if self.DISTRIBUTIONMODEL is None:
             pass
-        elif (self.DISTRIBUTIONMODEL == 
+        elif (self.DISTRIBUTIONMODEL ==
                 phydmslib.models.GammaDistributedOmegaModel):
             self.model = self.DISTRIBUTIONMODEL(self.model, ncats=4)
         else:
@@ -100,16 +99,16 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
 
     def test_Initialize(self):
         """Test that `TreeLikelihood` initializes properly."""
-        tl = phydmslib.treelikelihood.TreeLikelihood(self.tree, 
+        tl = phydmslib.treelikelihood.TreeLikelihood(self.tree,
                 self.alignment, self.model, underflowfreq=self.underflowfreq,
                 dparamscurrent=False, dtcurrent=True)
         self.assertEqual(tl.dloglik_dt.shape, tl.t.shape)
 
     def test_dM_dt(self):
         """Tests model `dM` with respect to `t`."""
-        scipy.random.seed(1)
+        numpy.random.seed(1)
         random.seed(1)
-        tl = phydmslib.treelikelihood.TreeLikelihood(self.tree, 
+        tl = phydmslib.treelikelihood.TreeLikelihood(self.tree,
                 self.alignment, self.model, underflowfreq=self.underflowfreq,
                 dparamscurrent=False, dtcurrent=True)
 
@@ -129,8 +128,8 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
 
     def test_AdjustBrLen(self):
         """Tests adjusting branch lengths."""
-        scipy.random.seed(1)
-        tl = phydmslib.treelikelihood.TreeLikelihood(self.tree, 
+        numpy.random.seed(1)
+        tl = phydmslib.treelikelihood.TreeLikelihood(self.tree,
                 self.alignment, self.model, underflowfreq=self.underflowfreq,
                 dparamscurrent=False, dtcurrent=True)
         loglik1 = tl.loglik
@@ -138,7 +137,7 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
         self.assertFalse(numpy.allclose(loglik1, tl.loglik))
         tl.t = tl.t / 2
         self.assertTrue(numpy.allclose(loglik1, tl.loglik))
-        tl.t = tl.t * scipy.random.uniform(0.1, 1.5, tl.t.shape)
+        tl.t = tl.t * numpy.random.uniform(0.1, 1.5, tl.t.shape)
         self.assertFalse(numpy.allclose(loglik1, tl.loglik))
         loglik2 = tl.loglik
         t = tl.t
@@ -152,7 +151,7 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
 
     def test_BrLenDerivatives(self):
         """Tests derivatives of branch lengths."""
-        tl = phydmslib.treelikelihood.TreeLikelihood(self.tree, 
+        tl = phydmslib.treelikelihood.TreeLikelihood(self.tree,
                 self.alignment, self.model, underflowfreq=self.underflowfreq,
                 dparamscurrent=False, dtcurrent=True)
 
@@ -169,18 +168,18 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
             return tl.dloglik_dt[n]
 
         for n in range(len(tl.t)):
-            diff = scipy.optimize.check_grad(func, dfunc, 
+            diff = scipy.optimize.check_grad(func, dfunc,
                     numpy.array([tl.t[n]]), n)
             self.assertTrue(diff < 2e-5, diff)
 
 
     def test_dtcurrent(self):
         """Tests use of `dtcurrent` attribute."""
-        tl1 = phydmslib.treelikelihood.TreeLikelihood(self.tree, 
+        tl1 = phydmslib.treelikelihood.TreeLikelihood(self.tree,
                 self.alignment, self.model, underflowfreq=self.underflowfreq,
                 dparamscurrent=False, dtcurrent=True)
 
-        tl2 = phydmslib.treelikelihood.TreeLikelihood(self.tree, 
+        tl2 = phydmslib.treelikelihood.TreeLikelihood(self.tree,
                 self.alignment, self.model, underflowfreq=self.underflowfreq,
                 dparamscurrent=True, dtcurrent=False)
 

--- a/tests/test_brlenoptimize.py
+++ b/tests/test_brlenoptimize.py
@@ -10,8 +10,6 @@ import math
 import unittest
 import random
 import copy
-import scipy
-import scipy.optimize
 import Bio.Phylo
 import phydmslib.models
 import phydmslib.treelikelihood
@@ -31,11 +29,11 @@ class test_BrLenOptimize_ExpCM(unittest.TestCase):
     def setUp(self):
         """Set up parameters for test."""
         random.seed(1)
-        scipy.random.seed(1)
+        numpy.random.seed(1)
 
         self.underflowfreq = 1
 
-        # define tree 
+        # define tree
         self.newick = ('((node1:0.2,node2:0.3)node4:0.3,node3:0.5)node5:0.04;')
         tempfile = '_temp.tree'
         with open(tempfile, 'w') as f:
@@ -47,9 +45,9 @@ class test_BrLenOptimize_ExpCM(unittest.TestCase):
         self.nsites = 50
         prefs = []
         minpref = 0.02
-        g = scipy.random.dirichlet([5] * N_NT)
+        g = numpy.random.dirichlet([5] * N_NT)
         for r in range(self.nsites):
-            rprefs = scipy.random.dirichlet([0.5] * N_AA)
+            rprefs = numpy.random.dirichlet([0.5] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
             prefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))
@@ -78,7 +76,7 @@ class test_BrLenOptimize_ExpCM(unittest.TestCase):
             raise ValueError("Invalid MODEL: {0}".format(self.MODEL))
         if self.DISTRIBUTIONMODEL is None:
             pass
-        elif (self.DISTRIBUTIONMODEL == 
+        elif (self.DISTRIBUTIONMODEL ==
                 phydmslib.models.GammaDistributedOmegaModel):
             self.model = self.DISTRIBUTIONMODEL(self.model, ncats=4)
         else:
@@ -87,11 +85,11 @@ class test_BrLenOptimize_ExpCM(unittest.TestCase):
 
     def test_Optimize(self):
         """Tests optimization of branch lengths."""
-        tl = phydmslib.treelikelihood.TreeLikelihood(self.tree, 
+        tl = phydmslib.treelikelihood.TreeLikelihood(self.tree,
                 self.alignment, self.model, underflowfreq=self.underflowfreq)
         maxresult = tl.maximizeLikelihood(optimize_brlen=True)
 
-        tl2 = phydmslib.treelikelihood.TreeLikelihood(self.tree, 
+        tl2 = phydmslib.treelikelihood.TreeLikelihood(self.tree,
                 self.alignment, self.model, underflowfreq=self.underflowfreq)
         maxresult = tl.maximizeLikelihood(optimize_brlen=False)
 

--- a/tests/test_diffprefsbysite.py
+++ b/tests/test_diffprefsbysite.py
@@ -9,7 +9,6 @@ import unittest
 import subprocess
 import random
 import pandas
-import scipy
 import scipy.stats
 import phydmslib.file_io
 import phydmslib.models
@@ -27,7 +26,7 @@ class test_DiffPrefsBySiteExpCM(unittest.TestCase):
 
     def setUp(self):
         random.seed(1)
-        scipy.random.seed(1)
+        numpy.random.seed(1)
         self.tree = os.path.abspath(os.path.join(os.path.dirname(__file__),
                 './NP_data/NP_tree.newick'))
         self.alignment = os.path.abspath(os.path.join(os.path.dirname(__file__),
@@ -62,7 +61,7 @@ class test_DiffPrefsBySiteExpCM(unittest.TestCase):
     def test_OnSimulatedData(self):
         """Run ``phydms`` on the simulated data."""
         random.seed(1)
-        scipy.random.seed(1)
+        numpy.random.seed(1)
         partitions = phydmslib.simulate.pyvolvePartitions(self.model)
         evolver = pyvolve.Evolver(partitions=partitions,
                 tree=pyvolve.read_tree(file=self.tree))

--- a/tests/test_expcm.py
+++ b/tests/test_expcm.py
@@ -9,8 +9,8 @@ are correct for `ExpCM` implemented in `phydmslib.models`."""
 import random
 import unittest
 import numpy
-import scipy
 import scipy.linalg
+import scipy.optimize
 import sympy
 from phydmslib.constants import *
 import phydmslib.models
@@ -23,18 +23,18 @@ class testExpCM(unittest.TestCase):
 
         # create preferences
         random.seed(1)
-        scipy.random.seed(1)
+        numpy.random.seed(1)
         self.nsites = 2
         self.prefs = []
         minpref = 0.01
         for r in range(self.nsites):
-            rprefs = scipy.random.dirichlet([0.5] * N_AA)
+            rprefs = numpy.random.dirichlet([0.5] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
             self.prefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))
 
         # create initial ExpCM
-        phi = scipy.random.dirichlet([2] * N_NT)
+        phi = numpy.random.dirichlet([2] * N_NT)
         omega = 0.7
         kappa = 2.5
         beta = 1.9

--- a/tests/test_expcm_divpressure.py
+++ b/tests/test_expcm_divpressure.py
@@ -7,8 +7,8 @@ Edited by Sarah Hilton
 
 import random
 import unittest
-import scipy
 import scipy.linalg
+import scipy.optimize
 import sympy
 import numpy
 from phydmslib.constants import *
@@ -21,17 +21,17 @@ class test_compare_ExpCM_empirical_phi_with_and_without_divpressure(unittest.Tes
         """Make sure all attributes are the same when `divpressure` is 0."""
 
         random.seed(1)
-        scipy.random.seed(1)
+        numpy.random.seed(1)
 
         nsites = 6
         prefs = []
         minpref = 0.01
         for r in range(nsites):
-            rprefs = scipy.random.dirichlet([0.5] * N_AA)
+            rprefs = numpy.random.dirichlet([0.5] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
             prefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))
-        g = scipy.random.dirichlet([3] * N_NT)
+        g = numpy.random.dirichlet([3] * N_NT)
         omega = 0.7
         omega2 = 0.2
         kappa = 2.5
@@ -80,19 +80,19 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
 
         # create preferences
         random.seed(1)
-        scipy.random.seed(1)
+        numpy.random.seed(1)
         self.nsites = 6
         self.prefs = []
         minpref = 0.01
         for r in range(self.nsites):
-            rprefs = scipy.random.dirichlet([0.5] * N_AA)
+            rprefs = numpy.random.dirichlet([0.5] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
             self.prefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))
         self.divpressure = numpy.random.randint(2, size=self.nsites)
 
         # create initial ExpCM
-        g = scipy.random.dirichlet([3] * N_NT)
+        g = numpy.random.dirichlet([3] * N_NT)
         omega = 0.7
         omega2 = 0.2
         kappa = 2.5

--- a/tests/test_expcm_empirical_phi.py
+++ b/tests/test_expcm_empirical_phi.py
@@ -7,8 +7,8 @@ Written by Jesse Bloom.
 import random
 import unittest
 import numpy
-import scipy
 import scipy.linalg
+import scipy.optimize
 import sympy
 from phydmslib.constants import *
 import phydmslib.models
@@ -21,18 +21,18 @@ class testExpCM_empirical_phi(unittest.TestCase):
 
         # create preferences
         random.seed(1)
-        scipy.random.seed(1)
+        numpy.random.seed(1)
         self.nsites = 7
         self.prefs = []
         minpref = 0.01
         for r in range(self.nsites):
-            rprefs = scipy.random.dirichlet([0.5] * N_AA)
+            rprefs = numpy.random.dirichlet([0.5] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
             self.prefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))
 
         # create initial ExpCM
-        g = scipy.random.dirichlet([3] * N_NT)
+        g = numpy.random.dirichlet([3] * N_NT)
         omega = 0.7
         kappa = 2.5
         beta = 1.2

--- a/tests/test_expcm_fitprefs_invquadraticprior.py
+++ b/tests/test_expcm_fitprefs_invquadraticprior.py
@@ -7,8 +7,7 @@ import random
 import unittest
 import copy
 import numpy
-import scipy
-import scipy.linalg
+import scipy.optimize
 import sympy
 from phydmslib.constants import *
 import phydmslib.models
@@ -21,20 +20,20 @@ class test_ExpCM_fitprefs_invquadraticprior(unittest.TestCase):
 
     def setUp(self):
         """Set up for tests."""
-        scipy.random.seed(1)
+        numpy.random.seed(1)
         random.seed(1)
         nsites = 1
         minpref = 0.001
         self.prefs = []
         for r in range(nsites):
-            rprefs = scipy.random.dirichlet([0.7] * N_AA)
+            rprefs = numpy.random.dirichlet([0.7] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs[0] = rprefs[1] + 1.0e-8 # ensure near equal prefs handled OK
             rprefs /= rprefs.sum()
             self.prefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))
-        self.expcm_fitprefs = self.MODEL(self.prefs, 
+        self.expcm_fitprefs = self.MODEL(self.prefs,
                 prior=('invquadratic', 150.0, 0.5), kappa=3.0, omega=0.3,
-                phi=scipy.random.dirichlet([5] * N_NT))
+                phi=numpy.random.dirichlet([5] * N_NT))
         assert len(self.expcm_fitprefs.zeta.flatten()) == nsites * (N_AA - 1)
         assert self.expcm_fitprefs.nsites == nsites
 
@@ -51,15 +50,15 @@ class test_ExpCM_fitprefs_invquadraticprior(unittest.TestCase):
 
     def test_dlogprior(self):
         """Test `dlogprior`."""
-        scipy.random.seed(1)
+        numpy.random.seed(1)
 
         expcm_fitprefs = copy.deepcopy(self.expcm_fitprefs)
         self.assertTrue(numpy.allclose(expcm_fitprefs.pi, expcm_fitprefs.origpi))
         if self.MODEL == phydmslib.models.ExpCM_fitprefs:
-            newzeta = expcm_fitprefs.zeta.copy() * scipy.random.uniform(0.9, 1.0, 
+            newzeta = expcm_fitprefs.zeta.copy() * numpy.random.uniform(0.9, 1.0,
                     expcm_fitprefs.zeta.shape)
         elif self.MODEL == phydmslib.models.ExpCM_fitprefs2:
-            newzeta = expcm_fitprefs.zeta.copy() * scipy.random.uniform(0.01, 10.0, 
+            newzeta = expcm_fitprefs.zeta.copy() * numpy.random.uniform(0.01, 10.0,
                     expcm_fitprefs.zeta.shape)
         else:
             raise RuntimeError("invalid MODEL: {0}".format(self.MODEL))

--- a/tests/test_gammadistributedbeta_model.py
+++ b/tests/test_gammadistributedbeta_model.py
@@ -7,8 +7,6 @@ Written by Jesse Bloom and Sarah Hilton.
 import random
 import unittest
 import numpy
-import scipy
-import scipy.linalg
 import scipy.optimize
 from phydmslib.constants import *
 import phydmslib.models
@@ -25,21 +23,21 @@ class test_GammaDistributedBeta_ExpCM(unittest.TestCase):
         """Initialize, test values, update, test again."""
 
         random.seed(1)
-        scipy.random.seed(1)
+        numpy.random.seed(1)
         nsites = 10
 
         # create preference set
         prefs = []
         minpref = 0.01
         for r in range(nsites):
-            rprefs = scipy.random.dirichlet([0.5] * N_AA)
+            rprefs = numpy.random.dirichlet([0.5] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
             prefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))
 
         if self.BASEMODEL == phydmslib.models.ExpCM:
             paramvalues = {
-                    'eta':scipy.random.dirichlet([5] * (N_NT - 1)),
+                    'eta':numpy.random.dirichlet([5] * (N_NT - 1)),
                     'omega':0.7,
                     'kappa':2.5,
                     'beta':1.2,
@@ -51,7 +49,7 @@ class test_GammaDistributedBeta_ExpCM(unittest.TestCase):
                     set(basemodel.freeparams)))
             basemodel.updateParams(paramvalues)
         elif self.BASEMODEL == phydmslib.models.ExpCM_empirical_phi:
-            g = scipy.random.dirichlet([3] * N_NT)
+            g = numpy.random.dirichlet([3] * N_NT)
             paramvalues = {
                     'omega':0.7,
                     'kappa':2.5,
@@ -89,7 +87,7 @@ class test_GammaDistributedBeta_ExpCM(unittest.TestCase):
                     newvalues[param] = random.uniform(low, high)
                 else:
                     paramlength = gammamodel.PARAMTYPES[param][1]
-                    newvalues[param] = scipy.random.uniform(
+                    newvalues[param] = numpy.random.uniform(
                             low, high, paramlength)
             gammamodel.updateParams(newvalues)
             self.assertTrue(numpy.allclose(numpy.array([m.beta for m in

--- a/tests/test_gammadistributedomega_model.py
+++ b/tests/test_gammadistributedomega_model.py
@@ -7,8 +7,6 @@ Written by Jesse Bloom.
 import random
 import unittest
 import numpy
-import scipy
-import scipy.linalg
 import scipy.optimize
 from phydmslib.constants import *
 import phydmslib.models
@@ -25,19 +23,19 @@ class test_GammaDistributedOmega_ExpCM(unittest.TestCase):
         """Initialize, test values, update, test again."""
 
         random.seed(1)
-        scipy.random.seed(1)
+        numpy.random.seed(1)
         nsites = 10
 
         if self.BASEMODEL == phydmslib.models.ExpCM:
             prefs = []
             minpref = 0.01
             for r in range(nsites):
-                rprefs = scipy.random.dirichlet([0.5] * N_AA)
+                rprefs = numpy.random.dirichlet([0.5] * N_AA)
                 rprefs[rprefs < minpref] = minpref
                 rprefs /= rprefs.sum()
                 prefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))
             paramvalues = {
-                    'eta':scipy.random.dirichlet([5] * (N_NT - 1)),
+                    'eta':numpy.random.dirichlet([5] * (N_NT - 1)),
                     'omega':0.7,
                     'kappa':2.5,
                     'beta':1.2,
@@ -49,7 +47,7 @@ class test_GammaDistributedOmega_ExpCM(unittest.TestCase):
                     set(basemodel.freeparams)))
             basemodel.updateParams(paramvalues)
         elif self.BASEMODEL == phydmslib.models.YNGKP_M0:
-            e_pw = scipy.random.uniform(0.4, 0.6, size=(3, N_NT))
+            e_pw = numpy.random.uniform(0.4, 0.6, size=(3, N_NT))
             e_pw = e_pw / e_pw.sum(axis=1, keepdims=True)
             basemodel = self.BASEMODEL(e_pw, nsites)
             paramvalues = {
@@ -85,7 +83,7 @@ class test_GammaDistributedOmega_ExpCM(unittest.TestCase):
                     newvalues[param] = random.uniform(low, high)
                 else:
                     paramlength = gammamodel.PARAMTYPES[param][1]
-                    newvalues[param] = scipy.random.uniform(
+                    newvalues[param] = numpy.random.uniform(
                             low, high, paramlength)
             gammamodel.updateParams(newvalues)
             self.assertTrue(numpy.allclose(numpy.array([m.omega for m in

--- a/tests/test_phydms_comprehensive.py
+++ b/tests/test_phydms_comprehensive.py
@@ -11,7 +11,6 @@ import unittest
 import multiprocessing
 import subprocess
 import numpy
-import scipy
 import pandas
 
 

--- a/tests/test_phydms_divpressure.py
+++ b/tests/test_phydms_divpressure.py
@@ -12,7 +12,6 @@ import unittest
 import subprocess
 import pandas as pd
 import numpy
-import scipy
 
 
 class test_phydms_testdivpressure(unittest.TestCase):
@@ -39,7 +38,7 @@ class test_phydms_testdivpressure(unittest.TestCase):
         if os.path.isdir(outprefix):
             shutil.rmtree(outprefix)
 
-        
+
         subprocess.check_call(['phydms_divpressure', outprefix, alignment,
                 prefs, "--tree", tree, divpressure, divpressure2])
         actual = os.path.abspath(os.path.join(outprefix,

--- a/tests/test_spielmanwr.py
+++ b/tests/test_spielmanwr.py
@@ -6,7 +6,6 @@ Written by Jesse Bloom and Sarah Hilton."""
 import random
 import unittest
 import numpy
-import scipy
 from phydmslib.constants import *
 import phydmslib.models
 
@@ -22,13 +21,13 @@ class testExpCM_spielmanwr(unittest.TestCase):
 
         # create models
         random.seed(1)
-        scipy.random.seed(1)
+        numpy.random.seed(1)
         nsites = 10
-        g = scipy.random.dirichlet([5] * N_NT)
+        g = numpy.random.dirichlet([5] * N_NT)
         prefs = []
         minpref = 0.01
         for r in range(nsites):
-            rprefs = scipy.random.dirichlet([0.5] * N_AA)
+            rprefs = numpy.random.dirichlet([0.5] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
             prefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))

--- a/tests/test_treelikelihood.py
+++ b/tests/test_treelikelihood.py
@@ -11,7 +11,6 @@ import unittest
 import random
 import copy
 import numpy
-import scipy
 import scipy.optimize
 import Bio.Phylo
 import phydmslib.models
@@ -32,7 +31,7 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
     def setUp(self):
         """Set up parameters for test."""
         random.seed(1)
-        scipy.random.seed(1)
+        numpy.random.seed(1)
 
         # define tree
         self.newick = ('((node1:0.2,node2:0.3)node4:0.3,node3:0.5)node5:0.04;')
@@ -52,7 +51,7 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
         pyvolvetree = pyvolve.read_tree(tree=self.newick)
         self.nsites = 60
         self.nseqs = self.tree.count_terminals()
-        e_pw = scipy.ndarray((3, N_NT), dtype='float')
+        e_pw = numpy.ndarray((3, N_NT), dtype='float')
         e_pw.fill(0.25)
         yngkp_m0 = phydmslib.models.YNGKP_M0(e_pw, self.nsites)
         partitions = phydmslib.simulate.pyvolvePartitions(yngkp_m0)
@@ -80,11 +79,11 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
         # define model
         prefs = []
         minpref = 0.02
-        g = scipy.random.dirichlet([5] * N_NT)
+        g = numpy.random.dirichlet([5] * N_NT)
         g[g < 0.1] = 0.1
         g /= g.sum()
         for r in range(self.nsites):
-            rprefs = scipy.random.dirichlet([0.5] * N_AA)
+            rprefs = numpy.random.dirichlet([0.5] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
             prefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))
@@ -93,12 +92,12 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
         elif self.MODEL == phydmslib.models.ExpCM_empirical_phi:
             self.model = phydmslib.models.ExpCM_empirical_phi(prefs, g)
         elif self.MODEL == phydmslib.models.ExpCM_empirical_phi_divpressure:
-            divpressure = scipy.random.uniform(-1, 5, self.nsites)
+            divpressure = numpy.random.uniform(-1, 5, self.nsites)
             divpressure /= max(abs(divpressure))
             self.model = phydmslib.models.ExpCM_empirical_phi_divpressure(
                     prefs, g, divpressure)
         elif self.MODEL == phydmslib.models.YNGKP_M0:
-            e_pw = scipy.random.uniform(0.2, 0.8, size=(3, N_NT))
+            e_pw = numpy.random.uniform(0.2, 0.8, size=(3, N_NT))
             e_pw = e_pw / e_pw.sum(axis=1, keepdims=True)
             self.model = phydmslib.models.YNGKP_M0(e_pw, self.nsites)
         else:
@@ -119,7 +118,7 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
     def test_Initialize(self):
         """Test that initializes properly."""
         random.seed(1)
-        scipy.random.seed(1)
+        numpy.random.seed(1)
 
         tl = phydmslib.treelikelihood.TreeLikelihood(self.tree,
                 self.alignment, self.model)
@@ -138,7 +137,7 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
     def test_paramsarray(self):
         """Tests params array setting and getting."""
         random.seed(1)
-        scipy.random.seed(1)
+        numpy.random.seed(1)
 
         modelparams = self.getModelParams(seed=1)
         model = copy.deepcopy(self.model)
@@ -165,8 +164,8 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
     def test_Likelihood(self):
         """Tests likelihood."""
         random.seed(1)
-        scipy.random.seed(1)
-        
+        numpy.random.seed(1)
+
         if self.DISTRIBUTIONMODEL:
             return # test doesn't work for DistributionModel
         mus = [0.5, 1.5]
@@ -212,8 +211,8 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
     def test_LikelihoodDerivativesModelParams(self):
         """Test derivatives of with respect to model params."""
         random.seed(1)
-        scipy.random.seed(1)
-        
+        numpy.random.seed(1)
+
         tl = phydmslib.treelikelihood.TreeLikelihood(self.tree,
                 self.alignment, self.model)
 
@@ -244,8 +243,8 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
 
         Make sure it gives the same value for several starting points."""
         random.seed(1)
-        scipy.random.seed(1)
-        
+        numpy.random.seed(1)
+
         tl = phydmslib.treelikelihood.TreeLikelihood(self.tree,
                 self.alignment, self.model)
 
@@ -273,15 +272,15 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
     def getModelParams(self, seed):
         """Dict of random model params for random number seed `seed`."""
         random.seed(seed)
-        scipy.random.seed(seed)
+        numpy.random.seed(seed)
 
         modelparams = {}
         for param in self.model.freeparams:
             pvalue = getattr(self.model, param)
             if isinstance(pvalue, float):
                 modelparams[param] = random.uniform(0.5, 1.5)
-            elif isinstance(pvalue, scipy.ndarray) and pvalue.ndim == 1:
-                modelparams[param] = scipy.random.dirichlet([6] * len(pvalue))
+            elif isinstance(pvalue, numpy.ndarray) and pvalue.ndim == 1:
+                modelparams[param] = numpy.random.dirichlet([6] * len(pvalue))
             else:
                 raise ValueError("Can't handle {0}".format(param))
         return modelparams

--- a/tests/test_treelikelihood_fitprefs.py
+++ b/tests/test_treelikelihood_fitprefs.py
@@ -7,9 +7,6 @@ import random
 import unittest
 import copy
 import os
-import scipy
-import scipy.linalg
-import sympy
 from phydmslib.constants import *
 import phydmslib.models
 import phydmslib.file_io
@@ -25,7 +22,7 @@ class test_TreeLikelihood_ExpCM_fitprefs(unittest.TestCase):
 
     def setUp(self):
         """Set up for tests."""
-        scipy.random.seed(1)
+        numpy.random.seed(1)
         random.seed(1)
 
         nsites = 1
@@ -33,15 +30,15 @@ class test_TreeLikelihood_ExpCM_fitprefs(unittest.TestCase):
         self.prefs = []
         self.realprefs = []
         for r in range(nsites):
-            rprefs = scipy.random.dirichlet([0.5] * N_AA)
+            rprefs = numpy.random.dirichlet([0.5] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
             self.prefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))
-            scipy.random.shuffle(rprefs)
+            numpy.random.shuffle(rprefs)
             self.realprefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))
         self.kappa = 3.0
         self.omega = 3.0
-        self.phi = scipy.random.dirichlet([5] * N_NT)
+        self.phi = numpy.random.dirichlet([5] * N_NT)
         self.model = self.MODEL(self.prefs,
                 prior=None, kappa=self.kappa, omega=self.omega, phi=self.phi)
         self.realmodel = phydmslib.models.ExpCM(self.realprefs,
@@ -117,12 +114,12 @@ class test_TreeLikelihood_ExpCM_fitprefs(unittest.TestCase):
         tl = copy.deepcopy(self.tl)
         firstloglik = None
         for seed in range(3):
-            scipy.random.seed(seed)
+            numpy.random.seed(seed)
             if self.MODEL == phydmslib.models.ExpCM_fitprefs:
-                tl.paramsarray = scipy.random.uniform(0.1, 0.99,
+                tl.paramsarray = numpy.random.uniform(0.1, 0.99,
                         len(tl.paramsarray))
             elif self.MODEL == phydmslib.models.ExpCM_fitprefs2:
-                tl.paramsarray = scipy.random.uniform(0.5, 5.0,
+                tl.paramsarray = numpy.random.uniform(0.5, 5.0,
                         len(tl.paramsarray))
             else:
                 raise ValueError("Unrecognized MODEL: {0}".format(self.MODEL))

--- a/tests/test_underflow.py
+++ b/tests/test_underflow.py
@@ -5,7 +5,6 @@ Written by Jesse Bloom.
 
 import os
 import sys
-import scipy
 import math
 import unittest
 import random
@@ -22,7 +21,7 @@ class test_underflow(unittest.TestCase):
     def test_underflow(self):
         """Tests correction for numerical underflow."""
 
-        scipy.random.seed(1)
+        numpy.random.seed(1)
         random.seed(1)
 
         treefile = os.path.abspath(os.path.join(os.path.dirname(__file__),


### PR DESCRIPTION
This PR changes many of the `scipy` calls to `numpy` calls. This is because in the future users will not be able to access `numpy` functions (such as `ndarray`) through the `scipy` api. Right now, the code throws a lot of deprecation warnings. 

`scipy` is still a dependency because we do use `scipy`-specific functions. 

Resolves #29 