### PR TITLE
Lint the code

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,13 +2,3 @@
 exclude = docs,.eggs,setup.py,phydmslib/_metadata.py,phydmslib/__init__.py
 application-import-names = phydmslib
 ignore = E121,E123,E126,E226,E24,E704,W503,W504,W506,D205,D400,D401,RST303,RST304,I100,I101,I201,D301,D402,T001
-per-file-ignores =
-              phydmslib/utils.py:F401,
-              phydmslib/utils.py:B30,
-              phydmslib/weblogo.py:E241,
-              phydmslib/weblogo.py:B006,
-              phydmslib/weblogo.py:A002,
-              phydmslib/file_io.py:F401,
-              phydmslib/models.py:RST301,
-              phydmslib/models.py:RST201,
-              tests/profile_phydms.py:T001

--- a/.flake8
+++ b/.flake8
@@ -2,4 +2,4 @@
 exclude = docs,.eggs,setup.py,phydmslib/_metadata.py,phydmslib/__init__.py
 application-import-names = phydmslib
 ignore = E121,E123,E126,E226,E24,E704,W503,W504,W506,D205,D400,D401,RST303,RST304,I100,I101,I201,D301,D402,T001
-per-file-ignores = tests/run_phydms.py:E501
+per-file-ignores = tests/run_phydms.py:E501,phydmslib/weblogo.py:A002

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
 exclude = docs,.eggs,setup.py,phydmslib/_metadata.py
 application-import-names = phydmslib
-ignore = E121,E123,E126,E226,E24,E704,W503,W504,W506,D205,D400,D401,RST303,RST304,I100
+ignore = E121,E123,E126,E226,E24,E704,W503,W504,W506,D205,D400,D401,RST303,RST304,I100,I201,D301,D402
 per-file-ignores = phydmslib/utils.py:F401,phydmslib/weblogo.py:E241,phydmslib/file_io.py:F401

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-exclude = docs
+exclude = docs,.eggs,setup.py,phydmslib/_metadata.py
 application-import-names = phydmslib
-ignore = E121,E123,E126,E226,E24,E704,W503,W504,W506,D205,D400,D401,RST303,RST304
+ignore = E121,E123,E126,E226,E24,E704,W503,W504,W506,D205,D400,D401,RST303,RST304,I100
 per-file-ignores = phydmslib/utils.py:F401,phydmslib/weblogo.py:E241,phydmslib/file_io.py:F401

--- a/.flake8
+++ b/.flake8
@@ -2,4 +2,13 @@
 exclude = docs,.eggs,setup.py,phydmslib/_metadata.py,phydmslib/__init__.py
 application-import-names = phydmslib
 ignore = E121,E123,E126,E226,E24,E704,W503,W504,W506,D205,D400,D401,RST303,RST304,I100,I101,I201,D301,D402,T001
-per-file-ignores = phydmslib/utils.py:F401,phydmslib/weblogo.py:E241,phydmslib/file_io.py:F401,phydmslib/models.py:RST301,phydmslib/models.py:RST201,phydmslib/models.py:RST301,tests/profile_phydms.py:T001,phydmslib/weblogo.py:B006,phydmslib/weblogo.py:A002,phydmslib/utils.py:B301
+per-file-ignores =
+              phydmslib/utils.py:F401,
+              phydmslib/utils.py:B30,
+              phydmslib/weblogo.py:E241,
+              phydmslib/weblogo.py:B006,
+              phydmslib/weblogo.py:A002,
+              phydmslib/file_io.py:F401,
+              phydmslib/models.py:RST301,
+              phydmslib/models.py:RST201,
+              tests/profile_phydms.py:T001

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
 exclude = docs,.eggs,setup.py,phydmslib/_metadata.py,phydmslib/__init__.py
 application-import-names = phydmslib
-ignore = E121,E123,E126,E226,E24,E704,W503,W504,W506,D205,D400,D401,RST303,RST304,I100,I201,D301,D402
+ignore = E121,E123,E126,E226,E24,E704,W503,W504,W506,D205,D400,D401,RST303,RST304,I100,I101,I201,D301,D402
 per-file-ignores = phydmslib/utils.py:F401,phydmslib/weblogo.py:E241,phydmslib/file_io.py:F401

--- a/.flake8
+++ b/.flake8
@@ -2,3 +2,4 @@
 exclude = docs,.eggs,setup.py,phydmslib/_metadata.py,phydmslib/__init__.py
 application-import-names = phydmslib
 ignore = E121,E123,E126,E226,E24,E704,W503,W504,W506,D205,D400,D401,RST303,RST304,I100,I101,I201,D301,D402,T001
+per-file-ignores = tests/run_phydms.py:E501

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+exclude = docs
+application-import-names = phydmslib
+ignore = E121,E123,E126,E226,E24,E704,W503,W504,W506,D205,D400,D401,RST303,RST304
+per-file-ignores = phydmslib/utils.py:F401,phydmslib/weblogo.py:E241,phydmslib/file_io.py:F401

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-exclude = docs,.eggs,setup.py,phydmslib/_metadata.py
+exclude = docs,.eggs,setup.py,phydmslib/_metadata.py,phydmslib/__init__.py
 application-import-names = phydmslib
 ignore = E121,E123,E126,E226,E24,E704,W503,W504,W506,D205,D400,D401,RST303,RST304,I100,I201,D301,D402
 per-file-ignores = phydmslib/utils.py:F401,phydmslib/weblogo.py:E241,phydmslib/file_io.py:F401

--- a/.flake8
+++ b/.flake8
@@ -2,4 +2,4 @@
 exclude = docs,.eggs,setup.py,phydmslib/_metadata.py,phydmslib/__init__.py
 application-import-names = phydmslib
 ignore = E121,E123,E126,E226,E24,E704,W503,W504,W506,D205,D400,D401,RST303,RST304,I100,I101,I201,D301,D402,T001
-per-file-ignores = phydmslib/utils.py:F401,phydmslib/weblogo.py:E241,phydmslib/file_io.py:F401,phydmslib/models.py:RST301,phydmslib/models.py:RST201,tests/profile_phydms.py:T001
+per-file-ignores = phydmslib/utils.py:F401,phydmslib/weblogo.py:E241,phydmslib/file_io.py:F401,phydmslib/models.py:RST301,phydmslib/models.py:RST201,tests/profile_phydms.py:T001,phydmslib/weblogo.py:B006,phydmslib/weblogo.py:A002

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
 exclude = docs,.eggs,setup.py,phydmslib/_metadata.py,phydmslib/__init__.py
 application-import-names = phydmslib
-ignore = E121,E123,E126,E226,E24,E704,W503,W504,W506,D205,D400,D401,RST303,RST304,I100,I101,I201,D301,D402
-per-file-ignores = phydmslib/utils.py:F401,phydmslib/weblogo.py:E241,phydmslib/file_io.py:F401
+ignore = E121,E123,E126,E226,E24,E704,W503,W504,W506,D205,D400,D401,RST303,RST304,I100,I101,I201,D301,D402,T001
+per-file-ignores = phydmslib/utils.py:F401,phydmslib/weblogo.py:E241,phydmslib/file_io.py:F401,phydmslib/models.py:RST301,phydmslib/models.py:RST201,tests/profile_phydms.py:T001

--- a/.flake8
+++ b/.flake8
@@ -2,4 +2,4 @@
 exclude = docs,.eggs,setup.py,phydmslib/_metadata.py,phydmslib/__init__.py
 application-import-names = phydmslib
 ignore = E121,E123,E126,E226,E24,E704,W503,W504,W506,D205,D400,D401,RST303,RST304,I100,I101,I201,D301,D402,T001
-per-file-ignores = phydmslib/utils.py:F401,phydmslib/weblogo.py:E241,phydmslib/file_io.py:F401,phydmslib/models.py:RST301,phydmslib/models.py:RST201,tests/profile_phydms.py:T001,phydmslib/weblogo.py:B006,phydmslib/weblogo.py:A002
+per-file-ignores = phydmslib/utils.py:F401,phydmslib/weblogo.py:E241,phydmslib/file_io.py:F401,phydmslib/models.py:RST301,phydmslib/models.py:RST201,phydmslib/models.py:RST301,tests/profile_phydms.py:T001,phydmslib/weblogo.py:B006,phydmslib/weblogo.py:A002,phydmslib/utils.py:B301

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .*
 !.gitignore
 !.travis.yml
+!.flake8
 /*.png
 custom_matrix_frequencies.txt
 *.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
   - sudo apt-get install raxml
 
 install:
+  - pip install -r test_requirements.txt
   - pip install -e .
 
 # following here: https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ services:
   - xvfb
 
 script:
+  - flake8
   - pytest
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ branches:
   only:
     - master
     - model_adequacy
-    - linter
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ branches:
   only:
     - master
     - model_adequacy
+    - linter
 
 notifications:
   email:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,11 @@
 Changelog
 ===========
+2.3.9
+------
+* Started testing Pep8 compliance with `flake8`
+
+* Removed deprecated `scipy` functions
+
 2.3.8
 ------
 * Fixed bug in `phydms_prepalignment` due to `mafft` shortening sequence names.

--- a/phydmslib/_metadata.py
+++ b/phydmslib/_metadata.py
@@ -1,4 +1,4 @@
-__version__ = '2.3.8'
+__version__ = '2.3.9'
 __author__ = 'the Bloom lab (see https://github.com/jbloomlab/phydms/contributors)'
 __url__ = 'http://jbloomlab.github.io/phydms'
 __author_email__ = 'jbloom@fredhutch.org'

--- a/phydmslib/constants.py
+++ b/phydmslib/constants.py
@@ -63,12 +63,12 @@ import Bio.Seq
 ALMOST_ZERO = 1.0e-6
 
 INDEX_TO_NT = dict(enumerate('ACGT'))
-NT_TO_INDEX = dict([(nt, i) for (i, nt) in INDEX_TO_NT.items()])
+NT_TO_INDEX = {nt: i for (i, nt) in INDEX_TO_NT.items()}
 N_NT = len(INDEX_TO_NT)
 assert len(INDEX_TO_NT) == len(NT_TO_INDEX) == N_NT
 
 INDEX_TO_AA = dict(enumerate('ACDEFGHIKLMNPQRSTVWY'))
-AA_TO_INDEX = dict([(aa, i) for (i, aa) in INDEX_TO_AA.items()])
+AA_TO_INDEX = {aa: i for (i, aa) in INDEX_TO_AA.items()}
 N_AA = len(INDEX_TO_AA)
 assert len(INDEX_TO_AA) == len(AA_TO_INDEX) == N_AA
 

--- a/phydmslib/file_io.py
+++ b/phydmslib/file_io.py
@@ -1,6 +1,4 @@
-"""
-Module for input / output from files.
-"""
+"""Module for input / output from files."""
 
 
 import sys
@@ -119,7 +117,7 @@ def ReadCodonAlignment(fastafile, checknewickvalid):
                          .format(fastafile, seqlen))
 
     terminalcodon = []
-    codons_by_position = dict([(icodon, []) for icodon in range(seqlen // 3)])
+    codons_by_position = {icodon: [] for icodon in range(seqlen // 3)}
     for (head, seq) in seqs:
         assert len(seq) % 3 == 0
         for icodon in range(seqlen // 3):
@@ -239,7 +237,7 @@ def readPrefs(prefsfile, minpref=0, avgprefs=False, randprefs=False,
         prefs = dict([(int(r), rprefs) for (r, rprefs) in prefs.items()])
     else:
         sites = [str(r) for r in sites]
-        prefs = dict([(str(r), rprefs) for (r, rprefs) in prefs.items()])
+        prefs = {str(r): rprefs for (r, rprefs) in prefs.items()}
 
     assert len(set(sites)) == len(sites), "Non-unique sites in prefsfiles"
     assert (all([all([pi >= 0 for pi in rprefs.values()]) for rprefs in
@@ -255,7 +253,7 @@ def readPrefs(prefsfile, minpref=0, avgprefs=False, randprefs=False,
                                            "all amino acids at site {1}"
                                            .format(prefsfile, r))
         rsum = float(sum(rprefs.values()))
-        prefs[r] = dict([(aa, pi / rsum) for (aa, pi) in rprefs.items()])
+        prefs[r] = {aa: pi / rsum for (aa, pi) in rprefs.items()}
     assert set(sites) == set(prefs.keys())
 
     # Iteratively adjust until all prefs exceed minpref after re-scaling.
@@ -292,7 +290,7 @@ def readPrefs(prefsfile, minpref=0, avgprefs=False, randprefs=False,
 
 
 def readPrefs_dms_tools_format(f):
-    """Reads the amino-acid preferences written by `dms_tools v1.
+    """Reads the amino-acid preferences written by `dms_tools v1`.
 
     This is an exact copy of the same code from
     `dms_tools.file_io.ReadPreferences`. It is copied because

--- a/phydmslib/file_io.py
+++ b/phydmslib/file_io.py
@@ -106,7 +106,7 @@ def ReadCodonAlignment(fastafile, checknewickvalid):
     assert seqs, "{0} failed to specify any sequences".format(fastafile)
 
     seqlen = len(seqs[0][1])
-    if not all([len(seq) == seqlen for (head, seq) in seqs]):
+    if not all((len(seq) == seqlen for (head, seq) in seqs)):
         raise ValueError(("All sequences in {0} are not of the same length; "
                           "they must not be properly aligned")
                          .format(fastafile))
@@ -140,29 +140,29 @@ def ReadCodonAlignment(fastafile, checknewickvalid):
         terminalcodon.append(aa)
 
     for (icodon, codonlist) in codons_by_position.items():
-        if all([codon == '---' for codon in codonlist]):
+        if all((codon == '---' for codon in codonlist)):
             raise ValueError(("In {0}, all codons are gaps at position {1}")
                              .format(fastafile, icodon + 1))
 
-    if all([aa in ['*', '-'] for aa in terminalcodon]):
+    if all((aa in ['*', '-'] for aa in terminalcodon)):
         if len(seq) == 3:
             raise ValueError(("The only codon is a terminal stop codon for "
                               "the sequences in {0}").format(fastafile))
         seqs = [(head, seq[: -3]) for (head, seq) in seqs]
-    elif any([aa == '*' for aa in terminalcodon]):
+    elif any((aa == '*' for aa in terminalcodon)):
         raise ValueError(("Only some sequences in {0} have a terminal stop "
                           "codon. All or none must have terminal stop.")
                          .format(fastafile))
 
-    if any([gapmatch.search(seq) for (head, seq) in seqs]):
+    if any((gapmatch.search(seq) for (head, seq) in seqs)):
         raise ValueError(("In {0}, at least one sequence is entirely composed "
                           "of gaps.").format(fastafile))
 
     if checknewickvalid:
-        if len(set([head for (head, seq) in seqs])) != len(seqs):
+        if len(set((head for (head, seq) in seqs))) != len(seqs):
             raise ValueError("Headers in {0} not all unique".format(fastafile))
         disallowedheader = re.compile(r'[\s\:\;\(\)\[\]\,\'\"]')
-        for (head, seq) in seqs:
+        for (head, _seq) in seqs:
             if disallowedheader.search(head):
                 raise ValueError(("Invalid character in header in {0}:"
                                   "\n{1}").format(fastafile, head))
@@ -209,8 +209,8 @@ def readPrefs(prefsfile, minpref=0, avgprefs=False, randprefs=False,
         pandasformat = True
     except ValueError:
         pandasformat = False
-    if pandasformat and (set(df.columns) == aas.union(set(['site'])) or
-                         set(df.columns) == aas.union(set(['site', '*']))):
+    if pandasformat and (set(df.columns) == aas.union({'site'}) or
+                         set(df.columns) == aas.union({'site', '*'})):
         # read valid preferences as data frame
         sites = df['site'].tolist()
         prefs = {}
@@ -234,14 +234,14 @@ def readPrefs(prefsfile, minpref=0, avgprefs=False, randprefs=False,
                              .format(prefsfile))
         assert (min(sites) == 1 and max(sites) - min(sites)
                 == len(sites) - 1), "Sites not consecutive starting at 1"
-        prefs = dict([(int(r), rprefs) for (r, rprefs) in prefs.items()])
+        prefs = {int(r): rprefs for (r, rprefs) in prefs.items()}
     else:
         sites = [str(r) for r in sites]
         prefs = {str(r): rprefs for (r, rprefs) in prefs.items()}
 
     assert len(set(sites)) == len(sites), "Non-unique sites in prefsfiles"
-    assert (all([all([pi >= 0 for pi in rprefs.values()]) for rprefs in
-                prefs.values()])), ("prefs < 0 in prefsfile {0}"
+    assert (all((all((pi >= 0 for pi in rprefs.values())) for rprefs in
+                prefs.values()))), ("prefs < 0 in prefsfile {0}"
                                     .format(prefsfile))
     for r in list(prefs.keys()):
         rprefs = prefs[r]
@@ -260,11 +260,11 @@ def readPrefs(prefsfile, minpref=0, avgprefs=False, randprefs=False,
     for r in list(prefs.keys()):
         rprefs = prefs[r]
         iterations = 0
-        while any([pi < minpref for pi in rprefs.values()]):
-            rprefs = dict([(aa, max(1.1 * minpref, pi)) for (aa, pi)
-                           in rprefs.items()])
+        while any((pi < minpref for pi in rprefs.values())):
+            rprefs = {aa: max(1.1 * minpref, pi) for (aa, pi)
+                      in rprefs.items()}
             newsum = float(sum(rprefs.values()))
-            rprefs = dict([(aa, pi / newsum) for (aa, pi) in rprefs.items()])
+            rprefs = {aa: (pi / newsum) for (aa, pi) in rprefs.items()}
             iterations += 1
             assert iterations <= 3, "minpref adjustment not converging."
         prefs[r] = rprefs
@@ -272,12 +272,12 @@ def readPrefs(prefsfile, minpref=0, avgprefs=False, randprefs=False,
     if randprefs:
         assert not avgprefs, "randprefs and avgprefs are incompatible"
         random.seed(seed)
-        sites = sorted([r for r in prefs.keys()])
+        sites = sorted(list(prefs.keys()))
         prefs = [prefs[r] for r in sites]
         random.shuffle(sites)
         prefs = dict(zip(sites, prefs))
     elif avgprefs:
-        avg_prefs = dict([(aa, 0.0) for aa in aas])
+        avg_prefs = {aa: 0.0 for aa in aas}
         for rprefs in prefs.values():
             for aa in aas:
                 avg_prefs[aa] += rprefs[aa]
@@ -343,8 +343,8 @@ def readPrefs_dms_tools_format(f):
                 if not len(entries) - i == len(characters):
                     raise ValueError("Header line does not have valid "
                                      "credible interval format:\n%s" % line)
-                if not all([entries[i + j] == 'PI_%s_95' % characters[j]
-                            for j in range(len(characters))]):
+                if not all((entries[i + j] == 'PI_%s_95' % characters[j]
+                            for j in range(len(characters)))):
                     raise ValueError("mean and credible interval character "
                                      "mismatch in header:\n%s" % line)
                 linelength = 2 * len(characters) + 3
@@ -367,15 +367,14 @@ def readPrefs_dms_tools_format(f):
                     "Valid possibilities: %s" % (entries[1], ', '
                                                  .join(characters)))
             h[r] = float(entries[2])
-            pi_means[r] = dict([(x, float(entries[3 + i])) for (i, x)
-                                in enumerate(characters)])
+            pi_means[r] = {x: float(entries[3 + i]) for (i, x)
+                           in enumerate(characters)}
             if pi_95credint is not None:
-                pi_95credint[r] = dict([(x,
-                                        (float(entries[3 + len(characters) + i]
-                                               .split(',')[0]),
-                                         float(entries[3 + len(characters) + i]
-                                               .split(',')[1])))
-                                        for (i, x) in enumerate(characters)])
+                pi_95credint[r] = {x: (float(entries[3 + len(characters)
+                                                     + i].split(',')[0]),
+                                       float(entries[3 + len(characters)
+                                                     + i].split(',')[1]))
+                                   for (i, x) in enumerate(characters)}
     return (sites, wts, pi_means, pi_95credint, h)
 
 

--- a/phydmslib/file_io.py
+++ b/phydmslib/file_io.py
@@ -2,7 +2,7 @@
 
 
 import sys
-import io
+import io  # noqa: F401
 import re
 import time
 import platform

--- a/phydmslib/file_io.py
+++ b/phydmslib/file_io.py
@@ -159,7 +159,7 @@ def ReadCodonAlignment(fastafile, checknewickvalid):
                           "of gaps.").format(fastafile))
 
     if checknewickvalid:
-        if len(set((head for (head, seq) in seqs))) != len(seqs):
+        if len({head for (head, seq) in seqs}) != len(seqs):
             raise ValueError("Headers in {0} not all unique".format(fastafile))
         disallowedheader = re.compile(r'[\s\:\;\(\)\[\]\,\'\"]')
         for (head, _seq) in seqs:
@@ -272,7 +272,7 @@ def readPrefs(prefsfile, minpref=0, avgprefs=False, randprefs=False,
     if randprefs:
         assert not avgprefs, "randprefs and avgprefs are incompatible"
         random.seed(seed)
-        sites = sorted(list(prefs.keys()))
+        sites = sorted(prefs.keys())
         prefs = [prefs[r] for r in sites]
         random.shuffle(sites)
         prefs = dict(zip(sites, prefs))

--- a/phydmslib/file_io.py
+++ b/phydmslib/file_io.py
@@ -4,7 +4,6 @@ Module for input / output from files.
 
 
 import sys
-import io
 import re
 import time
 import platform
@@ -403,21 +402,25 @@ def readDivPressure(fileName):
         pandasformat = True
     except ValueError:
         pandasformat = False
-    df.columns = ['site', 'divPressureValue']
-    scaleFactor = max(df["divPressureValue"].abs())
-    if scaleFactor > 0:
-        df["divPressureValue"] = [x / scaleFactor for x
-                                  in df["divPressureValue"]]
-    assert len(df['site'].tolist()) == len(set(df['site'].tolist())),\
-           ("There is at least one non-unique site in {0}".format(fileName))
-    assert max(df["divPressureValue"].abs()) <= 1,\
-           ("The scaling produced a diversifying pressure value with an "
-            "absolute value greater than one.")
-    sites = df['site'].tolist()
-    divPressure = {}
-    for r in sites:
-        divPressure[r] = df[df['site'] == r]["divPressureValue"].tolist()[0]
-    return divPressure
+    if pandasformat:
+        df.columns = ['site', 'divPressureValue']
+        scaleFactor = max(df["divPressureValue"].abs())
+        if scaleFactor > 0:
+            df["divPressureValue"] = [x / scaleFactor for x
+                                      in df["divPressureValue"]]
+        assert len(df['site'].tolist()) == len(set(df['site'].tolist())),\
+               ("There is at >= non-unique site in {0}".format(fileName))
+        assert max(df["divPressureValue"].abs()) <= 1,\
+               ("The scaling produced a diversifying pressure value with an "
+                "absolute value greater than one.")
+        sites = df['site'].tolist()
+        divPressure = {}
+        for r in sites:
+            divPressure[r] = (df[df['site'] == r]["divPressureValue"]
+                              .tolist()[0])
+        return divPressure
+    else:
+        raise ValueError('Could not file {0}'.format(fileName))
 
 
 if __name__ == '__main__':

--- a/phydmslib/file_io.py
+++ b/phydmslib/file_io.py
@@ -363,9 +363,9 @@ def readPrefs_dms_tools_format(f):
             sites.append(r)
             wts[r] = entries[1]
             assert entries[1] in characters or entries[1] == '?',\
-                   ("Character %s is not one of the valid ones in header. "
-                    "Valid possibilities: %s" % (entries[1], ', '
-                                                 .join(characters)))
+                ("Character %s is not one of the valid ones in header. "
+                 "Valid possibilities: %s" % (entries[1], ', '.join(characters)
+                                              ))
             h[r] = float(entries[2])
             pi_means[r] = {x: float(entries[3 + i]) for (i, x)
                            in enumerate(characters)}
@@ -407,10 +407,10 @@ def readDivPressure(fileName):
             df["divPressureValue"] = [x / scaleFactor for x
                                       in df["divPressureValue"]]
         assert len(df['site'].tolist()) == len(set(df['site'].tolist())),\
-               ("There is at >= non-unique site in {0}".format(fileName))
+            ("There is at >= non-unique site in {0}".format(fileName))
         assert max(df["divPressureValue"].abs()) <= 1,\
-               ("The scaling produced a diversifying pressure value with an "
-                "absolute value greater than one.")
+            ("The scaling produced a diversifying pressure value with an "
+             "absolute value greater than one.")
         sites = df['site'].tolist()
         divPressure = {}
         for r in sites:

--- a/phydmslib/file_io.py
+++ b/phydmslib/file_io.py
@@ -418,7 +418,7 @@ def readDivPressure(fileName):
                               .tolist()[0])
         return divPressure
     else:
-        raise ValueError('Could not file {0}'.format(fileName))
+        raise ValueError('Could not read file {0}'.format(fileName))
 
 
 if __name__ == '__main__':

--- a/phydmslib/file_io.py
+++ b/phydmslib/file_io.py
@@ -4,6 +4,7 @@ Module for input / output from files.
 
 
 import sys
+import io
 import re
 import time
 import platform

--- a/phydmslib/models.py
+++ b/phydmslib/models.py
@@ -41,7 +41,8 @@ class Model(six.with_metaclass(abc.ABCMeta)):
         """Log prior over current model.
 
         Is a float giving log prior over current model, or
-        0 if there is no prior defined over this model."""
+        0 if there is no prior defined over this model.
+        """
         pass
 
     @abc.abstractmethod
@@ -71,16 +72,16 @@ class Model(six.with_metaclass(abc.ABCMeta)):
     def dstationarystate(self, param):
         """Derivative of `stationarystate` with respect to `param`.
 
-            Args:
-                `param` (string in `freeparams`)
+        Args:
+            `param` (string in `freeparams`)
 
-            Returns:
-                `dstationarystate` (`numpy.ndarray` of floats or zero)
-                    If `param` is a float, then `dstationarystate[r][x]`
-                    is derivative of `stationarystate[r][x]` with respect
-                    to `param`. If `param` is an array, then
-                    `dstationarystate[i][r][x]` is derivative of
-                    `stationarystate[r][x]` with respect to `param[i]`.
+        Returns:
+            `dstationarystate` (`numpy.ndarray` of floats or zero)
+                If `param` is a float, then `dstationarystate[r][x]`
+                is derivative of `stationarystate[r][x]` with respect
+                to `param`. If `param` is an array, then
+                `dstationarystate[i][r][x]` is derivative of
+                `stationarystate[r][x]` with respect to `param[i]`.
         """
         pass
 
@@ -704,7 +705,8 @@ class ExpCM(Model):
         These are `pi_codon`, `ln_pi_codon`, `piAx_piAy`, `piAx_piAy_beta`,
         `ln_piAx_piAy_beta`.
 
-        Update using current `pi` and `beta`."""
+        Update using current `pi` and `beta`.
+        """
         with numpy.errstate(divide='raise', under='raise', over='raise',
                             invalid='raise'):
             for r in range(self.nsites):
@@ -718,7 +720,8 @@ class ExpCM(Model):
 
     def _update_Frxy(self):
         """
-        Update `Frxy` from `piAx_piAy_beta`,`ln_piAx_piAy_beta`,`omega`,`beta`.
+        Update `Frxy` from `piAx_piAy_beta`,`ln_piAx_piAy_beta`,
+        `omega`,`beta`.
         """
         self.Frxy.fill(1.0)
         self.Frxy_no_omega.fill(1.0)
@@ -879,7 +882,8 @@ class ExpCM(Model):
         codon `x` and differ from `x` by one nucleotide.
 
         When `norm` is `True`, the `omega_r` values above are divided by the
-        ExpCM `omega` value."""
+        ExpCM `omega` value.
+        """
 
         wr = []
         for r in range(self.nsites):
@@ -980,7 +984,6 @@ class ExpCM_fitprefs(ExpCM):
                 might differ from 1 if you already optimized `prefs` using
                 a fixed-preference `ExpCM` prior to initializing this model.
         """
-
         self.prior = prior
         if self.prior is None:
             pass
@@ -1036,7 +1039,8 @@ class ExpCM_fitprefs(ExpCM):
         `piAx_piAy`, `piAx_piAy_beta`, `ln_piAx_piAy_beta`, and `_logprior`.
 
         If `zeta` is undefined (as it will be on the first call), then create
-        `zeta` and `origpi` from `pi` and `origbeta`."""
+        `zeta` and `origpi` from `pi` and `origbeta`.
+        """
         minpi = self.PARAMLIMITS['pi'][0]
         if not hasattr(self, 'zeta'):
             # should only execute on first call to initialize zeta
@@ -1088,12 +1092,12 @@ class ExpCM_fitprefs(ExpCM):
                                              < ALMOST_ZERO))
 
         self._logprior = 0.0
-        self._dlogprior = dict([(param, 0.0) for param in self.freeparams])
+        self._dlogprior = {param: 0.0 for param in self.freeparams}
         if self.prior is None:
             pass
         elif self.prior[0] == 'invquadratic':
             (priorstr, c1, c2) = self.prior
-            self._dlogprior = dict([(param, 0.0) for param in self.freeparams])
+            self._dlogprior = {param" 0.0 for param in self.freeparams}
             self._dlogprior['zeta'] = numpy.zeros(self.zeta.shape,
                                                   dtype='float')
             j = 0
@@ -1179,7 +1183,8 @@ class ExpCM_fitprefs2(ExpCM_fitprefs):
         `piAx_piAy`, `piAx_piAy_beta`, `ln_piAx_piAy_beta`, and `_logprior`.
 
         If `zeta` is undefined (as it will be on the first call), then create
-        `zeta` and `origpi` from `pi` and `origbeta`."""
+        `zeta` and `origpi` from `pi` and `origbeta`.
+        """
         minpi = self.PARAMLIMITS['pi'][0]
         if not hasattr(self, 'zeta'):
             # should only execute on first call to initialize zeta
@@ -1228,12 +1233,12 @@ class ExpCM_fitprefs2(ExpCM_fitprefs):
                                          < ALMOST_ZERO)))
 
         self._logprior = 0.0
-        self._dlogprior = dict([(param, 0.0) for param in self.freeparams])
+        self._dlogprior = {param: 0.0 for param in self.freeparams}
         if self.prior is None:
             pass
         elif self.prior[0] == 'invquadratic':
             (priorstr, c1, c2) = self.prior
-            self._dlogprior = dict([(param, 0.0) for param in self.freeparams])
+            self._dlogprior = {param: 0.0 for param in self.freeparams}
             self._dlogprior['zeta'] = numpy.zeros(self.zeta.shape,
                                                   dtype='float')
             j = 0
@@ -1335,7 +1340,6 @@ class ExpCM_empirical_phi(ExpCM):
             `g`
                 Has the meaning described in the main class doc string.
         """
-
         _checkParam('g', g, self.PARAMLIMITS, self.PARAMTYPES)
         assert abs(1 - g.sum()) <= ALMOST_ZERO, "g doesn't sum to 1"
         self.g = g.copy()
@@ -1375,7 +1379,8 @@ class ExpCM_empirical_phi(ExpCM):
         Note that it uses the passed value of `beta`, **not**
         the current `beta` attribute.
 
-        Initial guess is current value of `phi` attribute."""
+        Initial guess is current value of `phi` attribute.
+        """
 
         def F(phishort):
             """Difference between `g` and expected `g` given `phishort`."""
@@ -1504,7 +1509,8 @@ class ExpCM_empirical_phi_divpressure(ExpCM_empirical_phi):
 
     def _update_Frxy(self):
         """
-        Update `Frxy` from `piAx_piAy_beta`, `omega`, `omega2`, and `beta`.
+        Update `Frxy` from `piAx_piAy_beta`, `omega`,
+        `omega2`, and `beta`.
         """
         self.Frxy.fill(1.0)
         self.Frxy_no_omega.fill(1.0)
@@ -1720,7 +1726,7 @@ class YNGKP_M0(Model):
         self._mu = value
 
     def _calculate_correctedF3X4(self):
-        '''Calculate `phi` based on the empirical `e_pw` values'''
+        """Calculate `phi` based on the empirical `e_pw` values"""
         def F(phi):
             phi_reshape = phi.reshape((3, N_NT))
             functionList = []
@@ -1949,14 +1955,16 @@ class DistributionModel(six.with_metaclass(abc.ABCMeta, Model)):
         drawn from a distribution. This gives such a base model.
         Parameters of this base model that are **not** distributed
         among sites will be current, but the distributed parameter
-        will not."""
+        will not.
+        """
         pass
 
     @abc.abstractproperty
     def distributedparam(self):
         """String giving name of parameter drawn from the distribution.
 
-        This parameter must be in `freeparams`."""
+        This parameter must be in `freeparams`.
+        """
         pass
 
     @abc.abstractproperty
@@ -2123,7 +2131,8 @@ class GammaDistributedModel(DistributionModel):
     def distributionparams(self):
         """Returns list of params defining distribution of `distributedparam`.
 
-        This list is `['alpha_lambda', 'beta_lambda']`."""
+        This list is `['alpha_lambda', 'beta_lambda']`.
+        """
         return ['alpha_lambda', 'beta_lambda']
 
     def __init__(self, model, lambda_param, ncats, alpha_lambda=1.0,
@@ -2248,7 +2257,7 @@ class GammaDistributedModel(DistributionModel):
                         newvalues_list[k][name] = getattr(self, name)
 
         assert len(newvalues_list) == len(self._models) == self.ncats
-        for (k, newvalues_k) in enumerate(newvalues_list):
+        for (_k, newvalues_k) in enumerate(newvalues_list):
             self._models[k].updateParams(newvalues_k)
 
         # check to make sure all models have same parameter values
@@ -2493,7 +2502,6 @@ class GammaDistributedBetaModel(GammaDistributedModel):
                 Meaning described in main class doc string for
                 `GammaDistributedModel`.
         """
-
         # set new limits so the maximum value of `beta` is equal to or
         # greater than the maximum `beta` inferred from the gamma distribution
         # with the constrained `alpha_beta` and `beta_beta` parameters

--- a/phydmslib/models.py
+++ b/phydmslib/models.py
@@ -430,7 +430,7 @@ class ExpCM(Model):
                 assert self.PARAMTYPES[param][0] == numpy.ndarray
                 paramshape = self.PARAMTYPES[param][1]
                 assert len(paramshape) == 1,\
-                       "Can't handle multi-dimensional ndarray"
+                    "Can't handle multi-dimensional ndarray"
                 paramlen = paramshape[0]
                 self.dPrxy[param] = numpy.zeros((paramlen, self.nsites,
                                                  N_CODON, N_CODON),

--- a/phydmslib/models.py
+++ b/phydmslib/models.py
@@ -41,8 +41,7 @@ class Model(six.with_metaclass(abc.ABCMeta)):
         """Log prior over current model.
 
         Is a float giving log prior over current model, or
-        0 if there is no prior defined over this model.
-        """
+        0 if there is no prior defined over this model."""
         pass
 
     @abc.abstractmethod
@@ -72,16 +71,16 @@ class Model(six.with_metaclass(abc.ABCMeta)):
     def dstationarystate(self, param):
         """Derivative of `stationarystate` with respect to `param`.
 
-        Args:
-            `param` (string in `freeparams`)
+            Args:
+                `param` (string in `freeparams`)
 
-        Returns:
-            `dstationarystate` (`numpy.ndarray` of floats or zero)
-                If `param` is a float, then `dstationarystate[r][x]`
-                is derivative of `stationarystate[r][x]` with respect
-                to `param`. If `param` is an array, then
-                `dstationarystate[i][r][x]` is derivative of
-                `stationarystate[r][x]` with respect to `param[i]`.
+            Returns:
+                `dstationarystate` (`numpy.ndarray` of floats or zero)
+                    If `param` is a float, then `dstationarystate[r][x]`
+                    is derivative of `stationarystate[r][x]` with respect
+                    to `param`. If `param` is an array, then
+                    `dstationarystate[i][r][x]` is derivative of
+                    `stationarystate[r][x]` with respect to `param[i]`.
         """
         pass
 
@@ -705,8 +704,7 @@ class ExpCM(Model):
         These are `pi_codon`, `ln_pi_codon`, `piAx_piAy`, `piAx_piAy_beta`,
         `ln_piAx_piAy_beta`.
 
-        Update using current `pi` and `beta`.
-        """
+        Update using current `pi` and `beta`."""
         with numpy.errstate(divide='raise', under='raise', over='raise',
                             invalid='raise'):
             for r in range(self.nsites):
@@ -720,8 +718,7 @@ class ExpCM(Model):
 
     def _update_Frxy(self):
         """
-        Update `Frxy` from `piAx_piAy_beta`,`ln_piAx_piAy_beta`,
-        `omega`,`beta`.
+        Update `Frxy` from `piAx_piAy_beta`,`ln_piAx_piAy_beta`,`omega`,`beta`.
         """
         self.Frxy.fill(1.0)
         self.Frxy_no_omega.fill(1.0)
@@ -882,8 +879,7 @@ class ExpCM(Model):
         codon `x` and differ from `x` by one nucleotide.
 
         When `norm` is `True`, the `omega_r` values above are divided by the
-        ExpCM `omega` value.
-        """
+        ExpCM `omega` value."""
 
         wr = []
         for r in range(self.nsites):
@@ -984,6 +980,7 @@ class ExpCM_fitprefs(ExpCM):
                 might differ from 1 if you already optimized `prefs` using
                 a fixed-preference `ExpCM` prior to initializing this model.
         """
+
         self.prior = prior
         if self.prior is None:
             pass
@@ -1039,8 +1036,7 @@ class ExpCM_fitprefs(ExpCM):
         `piAx_piAy`, `piAx_piAy_beta`, `ln_piAx_piAy_beta`, and `_logprior`.
 
         If `zeta` is undefined (as it will be on the first call), then create
-        `zeta` and `origpi` from `pi` and `origbeta`.
-        """
+        `zeta` and `origpi` from `pi` and `origbeta`."""
         minpi = self.PARAMLIMITS['pi'][0]
         if not hasattr(self, 'zeta'):
             # should only execute on first call to initialize zeta
@@ -1092,12 +1088,12 @@ class ExpCM_fitprefs(ExpCM):
                                              < ALMOST_ZERO))
 
         self._logprior = 0.0
-        self._dlogprior = {param: 0.0 for param in self.freeparams}
+        self._dlogprior = dict([(param, 0.0) for param in self.freeparams])
         if self.prior is None:
             pass
         elif self.prior[0] == 'invquadratic':
             (priorstr, c1, c2) = self.prior
-            self._dlogprior = {param: 0.0 for param in self.freeparams}
+            self._dlogprior = dict([(param, 0.0) for param in self.freeparams])
             self._dlogprior['zeta'] = numpy.zeros(self.zeta.shape,
                                                   dtype='float')
             j = 0
@@ -1183,8 +1179,7 @@ class ExpCM_fitprefs2(ExpCM_fitprefs):
         `piAx_piAy`, `piAx_piAy_beta`, `ln_piAx_piAy_beta`, and `_logprior`.
 
         If `zeta` is undefined (as it will be on the first call), then create
-        `zeta` and `origpi` from `pi` and `origbeta`.
-        """
+        `zeta` and `origpi` from `pi` and `origbeta`."""
         minpi = self.PARAMLIMITS['pi'][0]
         if not hasattr(self, 'zeta'):
             # should only execute on first call to initialize zeta
@@ -1233,12 +1228,12 @@ class ExpCM_fitprefs2(ExpCM_fitprefs):
                                          < ALMOST_ZERO)))
 
         self._logprior = 0.0
-        self._dlogprior = {param: 0.0 for param in self.freeparams}
+        self._dlogprior = dict([(param, 0.0) for param in self.freeparams])
         if self.prior is None:
             pass
         elif self.prior[0] == 'invquadratic':
             (priorstr, c1, c2) = self.prior
-            self._dlogprior = {param: 0.0 for param in self.freeparams}
+            self._dlogprior = dict([(param, 0.0) for param in self.freeparams])
             self._dlogprior['zeta'] = numpy.zeros(self.zeta.shape,
                                                   dtype='float')
             j = 0
@@ -1340,6 +1335,7 @@ class ExpCM_empirical_phi(ExpCM):
             `g`
                 Has the meaning described in the main class doc string.
         """
+
         _checkParam('g', g, self.PARAMLIMITS, self.PARAMTYPES)
         assert abs(1 - g.sum()) <= ALMOST_ZERO, "g doesn't sum to 1"
         self.g = g.copy()
@@ -1379,8 +1375,7 @@ class ExpCM_empirical_phi(ExpCM):
         Note that it uses the passed value of `beta`, **not**
         the current `beta` attribute.
 
-        Initial guess is current value of `phi` attribute.
-        """
+        Initial guess is current value of `phi` attribute."""
 
         def F(phishort):
             """Difference between `g` and expected `g` given `phishort`."""
@@ -1509,8 +1504,7 @@ class ExpCM_empirical_phi_divpressure(ExpCM_empirical_phi):
 
     def _update_Frxy(self):
         """
-        Update `Frxy` from `piAx_piAy_beta`, `omega`,
-        `omega2`, and `beta`.
+        Update `Frxy` from `piAx_piAy_beta`, `omega`, `omega2`, and `beta`.
         """
         self.Frxy.fill(1.0)
         self.Frxy_no_omega.fill(1.0)
@@ -1726,7 +1720,7 @@ class YNGKP_M0(Model):
         self._mu = value
 
     def _calculate_correctedF3X4(self):
-        """Calculate `phi` based on the empirical `e_pw` values"""
+        '''Calculate `phi` based on the empirical `e_pw` values'''
         def F(phi):
             phi_reshape = phi.reshape((3, N_NT))
             functionList = []
@@ -1955,16 +1949,14 @@ class DistributionModel(six.with_metaclass(abc.ABCMeta, Model)):
         drawn from a distribution. This gives such a base model.
         Parameters of this base model that are **not** distributed
         among sites will be current, but the distributed parameter
-        will not.
-        """
+        will not."""
         pass
 
     @abc.abstractproperty
     def distributedparam(self):
         """String giving name of parameter drawn from the distribution.
 
-        This parameter must be in `freeparams`.
-        """
+        This parameter must be in `freeparams`."""
         pass
 
     @abc.abstractproperty
@@ -2131,8 +2123,7 @@ class GammaDistributedModel(DistributionModel):
     def distributionparams(self):
         """Returns list of params defining distribution of `distributedparam`.
 
-        This list is `['alpha_lambda', 'beta_lambda']`.
-        """
+        This list is `['alpha_lambda', 'beta_lambda']`."""
         return ['alpha_lambda', 'beta_lambda']
 
     def __init__(self, model, lambda_param, ncats, alpha_lambda=1.0,
@@ -2257,7 +2248,7 @@ class GammaDistributedModel(DistributionModel):
                         newvalues_list[k][name] = getattr(self, name)
 
         assert len(newvalues_list) == len(self._models) == self.ncats
-        for (_k, newvalues_k) in enumerate(newvalues_list):
+        for (k, newvalues_k) in enumerate(newvalues_list):
             self._models[k].updateParams(newvalues_k)
 
         # check to make sure all models have same parameter values
@@ -2502,6 +2493,7 @@ class GammaDistributedBetaModel(GammaDistributedModel):
                 Meaning described in main class doc string for
                 `GammaDistributedModel`.
         """
+
         # set new limits so the maximum value of `beta` is equal to or
         # greater than the maximum `beta` inferred from the gamma distribution
         # with the constrained `alpha_beta` and `beta_beta` parameters

--- a/phydmslib/models.py
+++ b/phydmslib/models.py
@@ -337,7 +337,7 @@ class ExpCM(Model):
 
     def __init__(self, prefs, kappa=2.0, omega=0.5, beta=1.0, mu=1.0,
                  phi=numpy.ones(N_NT) / N_NT,
-                 freeparams=['kappa', 'omega', 'beta', 'mu', 'eta']):
+                 freeparams={'kappa', 'omega', 'beta', 'mu', 'eta'}):
         """Initialize an `ExpCM` object.
 
         Args:
@@ -964,7 +964,7 @@ class ExpCM_fitprefs(ExpCM):
     _REPORTPARAMS.append('pi')
 
     def __init__(self, prefs, prior, kappa, omega, phi, mu=1.0, origbeta=1.0,
-                 freeparams=['zeta']):
+                 freeparams={'zeta'}):
         """Initialize an `ExpCM_fitprefs` object.
 
         The calling parameters have the meaning described in the main class doc
@@ -1330,7 +1330,7 @@ class ExpCM_empirical_phi(ExpCM):
     PARAMTYPES['g'] = (numpy.ndarray, (N_NT,))
 
     def __init__(self, prefs, g, kappa=2.0, omega=0.5, beta=1.0, mu=1.0,
-                 freeparams=['kappa', 'omega', 'beta', 'mu']):
+                 freeparams={'kappa', 'omega', 'beta', 'mu'}):
         """Initialize an `ExpCM_empirical_phi` object.
 
         Args:
@@ -1465,7 +1465,7 @@ class ExpCM_empirical_phi_divpressure(ExpCM_empirical_phi):
 
     def __init__(self, prefs, g, divPressureValues, kappa=2.0, omega=0.5,
                  beta=1.0, mu=1.0, omega2=0.0,
-                 freeparams=['kappa', 'omega', 'beta', 'mu', 'omega2']):
+                 freeparams={'kappa', 'omega', 'beta', 'mu', 'omega2'}):
         """Initialize an `ExpCM_empirical_phi_divpressure` object.
 
         Args:
@@ -1608,7 +1608,7 @@ class YNGKP_M0(Model):
         return 0.0
 
     def __init__(self, e_pw, nsites, kappa=2.0, omega=0.5, mu=1.0,
-                 freeparams=['kappa', 'omega', 'mu']):
+                 freeparams={'kappa', 'omega', 'mu'}):
         """Initialize an `YNGKP_M0` object.
 
         Args:
@@ -2134,7 +2134,7 @@ class GammaDistributedModel(DistributionModel):
         return ['alpha_lambda', 'beta_lambda']
 
     def __init__(self, model, lambda_param, ncats, alpha_lambda=1.0,
-                 beta_lambda=2.0, freeparams=['alpha_lambda', 'beta_lambda']):
+                 beta_lambda=2.0, freeparams={'alpha_lambda', 'beta_lambda'}):
         """Initialize a `GammaDistributedModel`.
 
         Args:
@@ -2462,7 +2462,7 @@ class GammaDistributedOmegaModel(GammaDistributedModel):
     """
 
     def __init__(self, model, ncats, alpha_lambda=1.0, beta_lambda=2.0,
-                 freeparams=['alpha_lambda', 'beta_lambda']):
+                 freeparams={'alpha_lambda', 'beta_lambda'}):
         """Initialize an `GammaDistributedModel` object.
 
         The `lambda_param` is set to "omega".
@@ -2490,7 +2490,7 @@ class GammaDistributedBetaModel(GammaDistributedModel):
     """
 
     def __init__(self, model, ncats, alpha_lambda=1.0, beta_lambda=2.0,
-                 freeparams=['alpha_lambda', 'beta_lambda']):
+                 freeparams={'alpha_lambda', 'beta_lambda'}):
         """Initialize an `GammaDistributedModel` object.
 
         The `lambda_param` is set to "beta".

--- a/phydmslib/models.py
+++ b/phydmslib/models.py
@@ -522,7 +522,7 @@ class ExpCM(Model):
         assert all(map(lambda x: x in self.freeparams, newvalues.keys())),\
             "Invalid entry in newvalues: {0}\nfreeparams: {1}".format(
                 ', '.join(newvalues.keys()), ', '.join(self.freeparams))
-        changed = set([])  # contains string names of changed params
+        changed = set()  # contains string names of changed params
         for (name, value) in newvalues.items():
             _checkParam(name, value, self.PARAMLIMITS, self.PARAMTYPES)
             if isinstance(value, numpy.ndarray):
@@ -1765,7 +1765,7 @@ class YNGKP_M0(Model):
         assert all(map(lambda x: x in self.freeparams, newvalues.keys())), (
              "Invalid entry in newvalues: {0}\nfreeparams: {1}"
              .format(', '.join(newvalues.keys()), ', '.join(self.freeparams)))
-        changed = set([])  # contains string names of changed params
+        changed = set()  # contains string names of changed params
         for (name, value) in newvalues.items():
             _checkParam(name, value, self.PARAMLIMITS, self.PARAMTYPES)
             if isinstance(value, numpy.ndarray):

--- a/phydmslib/models.py
+++ b/phydmslib/models.py
@@ -41,7 +41,8 @@ class Model(six.with_metaclass(abc.ABCMeta)):
         """Log prior over current model.
 
         Is a float giving log prior over current model, or
-        0 if there is no prior defined over this model."""
+        0 if there is no prior defined over this model.
+        """
         pass
 
     @abc.abstractmethod
@@ -71,16 +72,16 @@ class Model(six.with_metaclass(abc.ABCMeta)):
     def dstationarystate(self, param):
         """Derivative of `stationarystate` with respect to `param`.
 
-            Args:
-                `param` (string in `freeparams`)
+        Args:
+            `param` (string in `freeparams`)
 
-            Returns:
-                `dstationarystate` (`numpy.ndarray` of floats or zero)
-                    If `param` is a float, then `dstationarystate[r][x]`
-                    is derivative of `stationarystate[r][x]` with respect
-                    to `param`. If `param` is an array, then
-                    `dstationarystate[i][r][x]` is derivative of
-                    `stationarystate[r][x]` with respect to `param[i]`.
+        Returns:
+            `dstationarystate` (`numpy.ndarray` of floats or zero)
+                If `param` is a float, then `dstationarystate[r][x]`
+                is derivative of `stationarystate[r][x]` with respect
+                to `param`. If `param` is an array, then
+                `dstationarystate[i][r][x]` is derivative of
+                `stationarystate[r][x]` with respect to `param[i]`.
         """
         pass
 
@@ -260,7 +261,7 @@ class ExpCM(Model):
         `ln_pi_codon` (`numpy.ndarray` floats, shape `(nsites, N_CODON)`)
             Natural logarithm of `pi_codon`.
         `piAx_piAy`
-             (`numpy.ndarray` floats, shape `(nsites, N_CODON, N_CODON)`)
+            (`numpy.ndarray` floats, shape `(nsites, N_CODON, N_CODON)`)
             `piAx_piAy[r][x][y]` is ratio of preference for amino acid
             encoded by codon `x` divided by pref for that encoded by `y`.
         `piAx_piAy_beta`
@@ -361,7 +362,7 @@ class ExpCM(Model):
         # put prefs in pi
         self.pi = numpy.ndarray((self.nsites, N_AA), dtype='float')
         assert (isinstance(prefs, list) and
-                all([isinstance(x, dict) for x in prefs])),\
+                all((isinstance(x, dict) for x in prefs))),\
             "prefs is not a list of dicts"
         for r in range(self.nsites):
             assert set(prefs[r].keys()) == set(AA_TO_INDEX.keys()),\
@@ -521,7 +522,7 @@ class ExpCM(Model):
         assert all(map(lambda x: x in self.freeparams, newvalues.keys())),\
             "Invalid entry in newvalues: {0}\nfreeparams: {1}".format(
                 ', '.join(newvalues.keys()), ', '.join(self.freeparams))
-        changed = set([])   # contains string names of changed params
+        changed = set([])  # contains string names of changed params
         for (name, value) in newvalues.items():
             _checkParam(name, value, self.PARAMLIMITS, self.PARAMTYPES)
             if isinstance(value, numpy.ndarray):
@@ -542,7 +543,7 @@ class ExpCM(Model):
         # Note also that not all attributes need to be updated
         # for all possible parameter changes, but just doing it
         # this way is much simpler and adds negligible cost.
-        if update_all or (changed and changed != set(['mu'])):
+        if update_all or (changed and changed != {'mu'}):
             self._update_pi_vars()
             self._update_phi()
             self._update_prx()
@@ -704,7 +705,8 @@ class ExpCM(Model):
         These are `pi_codon`, `ln_pi_codon`, `piAx_piAy`, `piAx_piAy_beta`,
         `ln_piAx_piAy_beta`.
 
-        Update using current `pi` and `beta`."""
+        Update using current `pi` and `beta`.
+        """
         with numpy.errstate(divide='raise', under='raise', over='raise',
                             invalid='raise'):
             for r in range(self.nsites):
@@ -718,7 +720,8 @@ class ExpCM(Model):
 
     def _update_Frxy(self):
         """
-        Update `Frxy` from `piAx_piAy_beta`,`ln_piAx_piAy_beta`,`omega`,`beta`.
+        Update `Frxy` from `piAx_piAy_beta`,`ln_piAx_piAy_beta`,
+        `omega`,`beta`.
         """
         self.Frxy.fill(1.0)
         self.Frxy_no_omega.fill(1.0)
@@ -879,8 +882,8 @@ class ExpCM(Model):
         codon `x` and differ from `x` by one nucleotide.
 
         When `norm` is `True`, the `omega_r` values above are divided by the
-        ExpCM `omega` value."""
-
+        ExpCM `omega` value.
+        """
         wr = []
         for r in range(self.nsites):
             num = 0
@@ -980,14 +983,13 @@ class ExpCM_fitprefs(ExpCM):
                 might differ from 1 if you already optimized `prefs` using
                 a fixed-preference `ExpCM` prior to initializing this model.
         """
-
         self.prior = prior
         if self.prior is None:
             pass
         elif (isinstance(self.prior, tuple) and len(self.prior) == 3 and
                 self.prior[0] == 'invquadratic'):
-            assert all([isinstance(c, (float, int)) and c > 0 for c
-                        in self.prior[1:]]),\
+            assert all((isinstance(c, (float, int)) and c > 0 for c
+                        in self.prior[1:])),\
               ("Invalid C values in elements in prior: {0}".format(self.prior))
         else:
             raise ValueError("Invalid prior: {0}".format(self.prior))
@@ -1036,7 +1038,8 @@ class ExpCM_fitprefs(ExpCM):
         `piAx_piAy`, `piAx_piAy_beta`, `ln_piAx_piAy_beta`, and `_logprior`.
 
         If `zeta` is undefined (as it will be on the first call), then create
-        `zeta` and `origpi` from `pi` and `origbeta`."""
+        `zeta` and `origpi` from `pi` and `origbeta`.
+        """
         minpi = self.PARAMLIMITS['pi'][0]
         if not hasattr(self, 'zeta'):
             # should only execute on first call to initialize zeta
@@ -1093,7 +1096,7 @@ class ExpCM_fitprefs(ExpCM):
             pass
         elif self.prior[0] == 'invquadratic':
             (priorstr, c1, c2) = self.prior
-            self._dlogprior = dict([(param, 0.0) for param in self.freeparams])
+            self._dlogprior = {param: 0.0 for param in self.freeparams}
             self._dlogprior['zeta'] = numpy.zeros(self.zeta.shape,
                                                   dtype='float')
             j = 0
@@ -1179,7 +1182,8 @@ class ExpCM_fitprefs2(ExpCM_fitprefs):
         `piAx_piAy`, `piAx_piAy_beta`, `ln_piAx_piAy_beta`, and `_logprior`.
 
         If `zeta` is undefined (as it will be on the first call), then create
-        `zeta` and `origpi` from `pi` and `origbeta`."""
+        `zeta` and `origpi` from `pi` and `origbeta`.
+        """
         minpi = self.PARAMLIMITS['pi'][0]
         if not hasattr(self, 'zeta'):
             # should only execute on first call to initialize zeta
@@ -1228,12 +1232,12 @@ class ExpCM_fitprefs2(ExpCM_fitprefs):
                                          < ALMOST_ZERO)))
 
         self._logprior = 0.0
-        self._dlogprior = dict([(param, 0.0) for param in self.freeparams])
+        self._dlogprior = {param: 0.0 for param in self.freeparams}
         if self.prior is None:
             pass
         elif self.prior[0] == 'invquadratic':
             (priorstr, c1, c2) = self.prior
-            self._dlogprior = dict([(param, 0.0) for param in self.freeparams])
+            self._dlogprior = {param: 0.0 for param in self.freeparams}
             self._dlogprior['zeta'] = numpy.zeros(self.zeta.shape,
                                                   dtype='float')
             j = 0
@@ -1335,7 +1339,6 @@ class ExpCM_empirical_phi(ExpCM):
             `g`
                 Has the meaning described in the main class doc string.
         """
-
         _checkParam('g', g, self.PARAMLIMITS, self.PARAMTYPES)
         assert abs(1 - g.sum()) <= ALMOST_ZERO, "g doesn't sum to 1"
         self.g = g.copy()
@@ -1376,7 +1379,6 @@ class ExpCM_empirical_phi(ExpCM):
         the current `beta` attribute.
 
         Initial guess is current value of `phi` attribute."""
-
         def F(phishort):
             """Difference between `g` and expected `g` given `phishort`."""
             phifull = numpy.append(phishort, 1 - phishort.sum())
@@ -1504,7 +1506,8 @@ class ExpCM_empirical_phi_divpressure(ExpCM_empirical_phi):
 
     def _update_Frxy(self):
         """
-        Update `Frxy` from `piAx_piAy_beta`, `omega`, `omega2`, and `beta`.
+        Update `Frxy` from `piAx_piAy_beta`, `omega`,
+        `omega2`, and `beta`.
         """
         self.Frxy.fill(1.0)
         self.Frxy_no_omega.fill(1.0)
@@ -1720,7 +1723,7 @@ class YNGKP_M0(Model):
         self._mu = value
 
     def _calculate_correctedF3X4(self):
-        '''Calculate `phi` based on the empirical `e_pw` values'''
+        """Calculate `phi` based on the empirical `e_pw` values"""
         def F(phi):
             phi_reshape = phi.reshape((3, N_NT))
             functionList = []
@@ -1782,7 +1785,7 @@ class YNGKP_M0(Model):
         # Note also that not all attributes need to be updated
         # for all possible parameter changes, but just doing it
         # this way is much simpler and adds negligible cost.
-        if update_all or (changed and changed != set(['mu'])):
+        if update_all or (changed and changed != {'mu'}):
             self._update_Pxy()
             self._update_Pxy_diag()
             self._update_dPxy()
@@ -1949,14 +1952,16 @@ class DistributionModel(six.with_metaclass(abc.ABCMeta, Model)):
         drawn from a distribution. This gives such a base model.
         Parameters of this base model that are **not** distributed
         among sites will be current, but the distributed parameter
-        will not."""
+        will not.
+        """
         pass
 
     @abc.abstractproperty
     def distributedparam(self):
         """String giving name of parameter drawn from the distribution.
 
-        This parameter must be in `freeparams`."""
+        This parameter must be in `freeparams`.
+        """
         pass
 
     @abc.abstractproperty
@@ -2116,14 +2121,15 @@ class GammaDistributedModel(DistributionModel):
 
     @property
     def distributedparam(self):
-        """Returns name of the distributed parameter. """
+        """Returns name of the distributed parameter."""
         return self._lambda_param
 
     @property
     def distributionparams(self):
         """Returns list of params defining distribution of `distributedparam`.
 
-        This list is `['alpha_lambda', 'beta_lambda']`."""
+        This list is `['alpha_lambda', 'beta_lambda']`.
+        """
         return ['alpha_lambda', 'beta_lambda']
 
     def __init__(self, model, lambda_param, ncats, alpha_lambda=1.0,
@@ -2157,7 +2163,7 @@ class GammaDistributedModel(DistributionModel):
         self.alpha_lambda = alpha_lambda
         self.beta_lambda = beta_lambda
         self._models = []  # holds array of models for each category
-        for k in range(self.ncats):
+        for _k in range(self.ncats):
             self._models.append(copy.deepcopy(model))
 
         self._freeparams = copy.copy(freeparams)
@@ -2223,8 +2229,8 @@ class GammaDistributedModel(DistributionModel):
 
         newvalues_list = [{} for k in range(self.ncats)]
 
-        if update_all or any([param in self.distributionparams for param
-                              in newvalues.keys()]):
+        if update_all or any((param in self.distributionparams for param
+                              in newvalues.keys())):
             self._d_distributionparams = {}
             for param in self.distributionparams:
                 if param in newvalues:
@@ -2255,8 +2261,8 @@ class GammaDistributedModel(DistributionModel):
         for param in self.freeparams:
             if param not in self.distributionparams:
                 pvalue = getattr(self, param)
-                assert all([numpy.allclose(pvalue, getattr(model, param))
-                           for model in self._models]), (
+                assert all((numpy.allclose(pvalue, getattr(model, param))
+                           for model in self._models)), (
                            "{0}\n{1}".format(pvalue,
                                              '\n'.join([str(getattr(model,
                                                                     param)) for
@@ -2302,7 +2308,7 @@ class GammaDistributedModel(DistributionModel):
     def mu(self):
         """See docs for `Model` abstract base class."""
         mu = self._models[0].mu
-        assert all([mu == model.mu for model in self._models])
+        assert all((mu == model.mu for model in self._models))
         return mu
 
     @mu.setter
@@ -2493,7 +2499,6 @@ class GammaDistributedBetaModel(GammaDistributedModel):
                 Meaning described in main class doc string for
                 `GammaDistributedModel`.
         """
-
         # set new limits so the maximum value of `beta` is equal to or
         # greater than the maximum `beta` inferred from the gamma distribution
         # with the constrained `alpha_beta` and `beta_beta` parameters
@@ -2508,8 +2513,8 @@ class GammaDistributedBetaModel(GammaDistributedModel):
          .__init__(model, "beta", ncats, alpha_lambda=1.0, beta_lambda=2.0,
                    freeparams=['alpha_lambda', 'beta_lambda']))
 
-        assert all([numpy.allclose(new_max_beta, m.PARAMLIMITS["beta"][1])
-                   for m in self._models]), (
+        assert all((numpy.allclose(new_max_beta, m.PARAMLIMITS["beta"][1])
+                   for m in self._models)), (
                    "{0}\n{1}".format(new_max_beta,
                                      '\n'.join([m.PARAMLIMITS["beta"][1]
                                                 for m in self._models])))

--- a/phydmslib/models.py
+++ b/phydmslib/models.py
@@ -337,7 +337,7 @@ class ExpCM(Model):
 
     def __init__(self, prefs, kappa=2.0, omega=0.5, beta=1.0, mu=1.0,
                  phi=numpy.ones(N_NT) / N_NT,
-                 freeparams=('kappa', 'omega', 'beta', 'mu', 'eta')):
+                 freeparams={'kappa', 'omega', 'beta', 'mu', 'eta'}):
         """Initialize an `ExpCM` object.
 
         Args:
@@ -964,7 +964,7 @@ class ExpCM_fitprefs(ExpCM):
     _REPORTPARAMS.append('pi')
 
     def __init__(self, prefs, prior, kappa, omega, phi, mu=1.0, origbeta=1.0,
-                 freeparams=('zeta')):
+                 freeparams={'zeta'}):
         """Initialize an `ExpCM_fitprefs` object.
 
         The calling parameters have the meaning described in the main class doc
@@ -1330,7 +1330,7 @@ class ExpCM_empirical_phi(ExpCM):
     PARAMTYPES['g'] = (numpy.ndarray, (N_NT,))
 
     def __init__(self, prefs, g, kappa=2.0, omega=0.5, beta=1.0, mu=1.0,
-                 freeparams=('kappa', 'omega', 'beta', 'mu')):
+                 freeparams={'kappa', 'omega', 'beta', 'mu'}):
         """Initialize an `ExpCM_empirical_phi` object.
 
         Args:
@@ -1465,7 +1465,7 @@ class ExpCM_empirical_phi_divpressure(ExpCM_empirical_phi):
 
     def __init__(self, prefs, g, divPressureValues, kappa=2.0, omega=0.5,
                  beta=1.0, mu=1.0, omega2=0.0,
-                 freeparams=('kappa', 'omega', 'beta', 'mu', 'omega2')):
+                 freeparams={'kappa', 'omega', 'beta', 'mu', 'omega2'}):
         """Initialize an `ExpCM_empirical_phi_divpressure` object.
 
         Args:
@@ -1608,7 +1608,7 @@ class YNGKP_M0(Model):
         return 0.0
 
     def __init__(self, e_pw, nsites, kappa=2.0, omega=0.5, mu=1.0,
-                 freeparams=('kappa', 'omega', 'mu')):
+                 freeparams={'kappa', 'omega', 'mu'}):
         """Initialize an `YNGKP_M0` object.
 
         Args:
@@ -2134,7 +2134,7 @@ class GammaDistributedModel(DistributionModel):
         return ['alpha_lambda', 'beta_lambda']
 
     def __init__(self, model, lambda_param, ncats, alpha_lambda=1.0,
-                 beta_lambda=2.0, freeparams=('alpha_lambda', 'beta_lambda')):
+                 beta_lambda=2.0, freeparams={'alpha_lambda', 'beta_lambda'}):
         """Initialize a `GammaDistributedModel`.
 
         Args:
@@ -2462,7 +2462,7 @@ class GammaDistributedOmegaModel(GammaDistributedModel):
     """
 
     def __init__(self, model, ncats, alpha_lambda=1.0, beta_lambda=2.0,
-                 freeparams=('alpha_lambda', 'beta_lambda')):
+                 freeparams={'alpha_lambda', 'beta_lambda'}):
         """Initialize an `GammaDistributedModel` object.
 
         The `lambda_param` is set to "omega".
@@ -2490,7 +2490,7 @@ class GammaDistributedBetaModel(GammaDistributedModel):
     """
 
     def __init__(self, model, ncats, alpha_lambda=1.0, beta_lambda=2.0,
-                 freeparams=('alpha_lambda', 'beta_lambda')):
+                 freeparams={'alpha_lambda', 'beta_lambda'}):
         """Initialize an `GammaDistributedModel` object.
 
         The `lambda_param` is set to "beta".

--- a/phydmslib/models.py
+++ b/phydmslib/models.py
@@ -875,8 +875,8 @@ class ExpCM(Model):
             num = 0
             den = 0
             for i in range(N_CODON):
-                j = numpy.intersect1d(numpy.where(CODON_SINGLEMUT[i] is True)[0],
-                                      numpy.where(CODON_NONSYN[i] is True)[0])
+                # indices where single mut and non syn true
+                j = numpy.where((CODON_SINGLEMUT[i] * CODON_NONSYN[i]) == 1)[0]
                 p_i = self.stationarystate[r][i]
                 P_xy = self.Prxy[r][i][j].sum()
                 if norm:

--- a/phydmslib/models.py
+++ b/phydmslib/models.py
@@ -11,11 +11,7 @@ import six
 import abc
 import warnings
 import numpy
-<<<<<<< HEAD
 
-=======
-import scipy
->>>>>>> first pass linting models.py
 import scipy.misc
 import scipy.optimize
 import scipy.linalg

--- a/phydmslib/models.py
+++ b/phydmslib/models.py
@@ -1097,7 +1097,7 @@ class ExpCM_fitprefs(ExpCM):
             pass
         elif self.prior[0] == 'invquadratic':
             (priorstr, c1, c2) = self.prior
-            self._dlogprior = {param" 0.0 for param in self.freeparams}
+            self._dlogprior = {param: 0.0 for param in self.freeparams}
             self._dlogprior['zeta'] = numpy.zeros(self.zeta.shape,
                                                   dtype='float')
             j = 0

--- a/phydmslib/models.py
+++ b/phydmslib/models.py
@@ -337,7 +337,7 @@ class ExpCM(Model):
 
     def __init__(self, prefs, kappa=2.0, omega=0.5, beta=1.0, mu=1.0,
                  phi=numpy.ones(N_NT) / N_NT,
-                 freeparams={'kappa', 'omega', 'beta', 'mu', 'eta'}):
+                 freeparams=('kappa', 'omega', 'beta', 'mu', 'eta')):
         """Initialize an `ExpCM` object.
 
         Args:
@@ -964,7 +964,7 @@ class ExpCM_fitprefs(ExpCM):
     _REPORTPARAMS.append('pi')
 
     def __init__(self, prefs, prior, kappa, omega, phi, mu=1.0, origbeta=1.0,
-                 freeparams={'zeta'}):
+                 freeparams=('zeta')):
         """Initialize an `ExpCM_fitprefs` object.
 
         The calling parameters have the meaning described in the main class doc
@@ -1330,7 +1330,7 @@ class ExpCM_empirical_phi(ExpCM):
     PARAMTYPES['g'] = (numpy.ndarray, (N_NT,))
 
     def __init__(self, prefs, g, kappa=2.0, omega=0.5, beta=1.0, mu=1.0,
-                 freeparams={'kappa', 'omega', 'beta', 'mu'}):
+                 freeparams=('kappa', 'omega', 'beta', 'mu')):
         """Initialize an `ExpCM_empirical_phi` object.
 
         Args:
@@ -1465,7 +1465,7 @@ class ExpCM_empirical_phi_divpressure(ExpCM_empirical_phi):
 
     def __init__(self, prefs, g, divPressureValues, kappa=2.0, omega=0.5,
                  beta=1.0, mu=1.0, omega2=0.0,
-                 freeparams={'kappa', 'omega', 'beta', 'mu', 'omega2'}):
+                 freeparams=('kappa', 'omega', 'beta', 'mu', 'omega2')):
         """Initialize an `ExpCM_empirical_phi_divpressure` object.
 
         Args:
@@ -1608,7 +1608,7 @@ class YNGKP_M0(Model):
         return 0.0
 
     def __init__(self, e_pw, nsites, kappa=2.0, omega=0.5, mu=1.0,
-                 freeparams={'kappa', 'omega', 'mu'}):
+                 freeparams=('kappa', 'omega', 'mu')):
         """Initialize an `YNGKP_M0` object.
 
         Args:
@@ -2134,7 +2134,7 @@ class GammaDistributedModel(DistributionModel):
         return ['alpha_lambda', 'beta_lambda']
 
     def __init__(self, model, lambda_param, ncats, alpha_lambda=1.0,
-                 beta_lambda=2.0, freeparams={'alpha_lambda', 'beta_lambda'}):
+                 beta_lambda=2.0, freeparams=('alpha_lambda', 'beta_lambda')):
         """Initialize a `GammaDistributedModel`.
 
         Args:
@@ -2462,7 +2462,7 @@ class GammaDistributedOmegaModel(GammaDistributedModel):
     """
 
     def __init__(self, model, ncats, alpha_lambda=1.0, beta_lambda=2.0,
-                 freeparams={'alpha_lambda', 'beta_lambda'}):
+                 freeparams=('alpha_lambda', 'beta_lambda')):
         """Initialize an `GammaDistributedModel` object.
 
         The `lambda_param` is set to "omega".
@@ -2490,7 +2490,7 @@ class GammaDistributedBetaModel(GammaDistributedModel):
     """
 
     def __init__(self, model, ncats, alpha_lambda=1.0, beta_lambda=2.0,
-                 freeparams={'alpha_lambda', 'beta_lambda'}):
+                 freeparams=('alpha_lambda', 'beta_lambda')):
         """Initialize an `GammaDistributedModel` object.
 
         The `lambda_param` is set to "beta".

--- a/phydmslib/models.py
+++ b/phydmslib/models.py
@@ -337,7 +337,7 @@ class ExpCM(Model):
 
     def __init__(self, prefs, kappa=2.0, omega=0.5, beta=1.0, mu=1.0,
                  phi=numpy.ones(N_NT) / N_NT,
-                 freeparams={'kappa', 'omega', 'beta', 'mu', 'eta'}):
+                 freeparams=('kappa', 'omega', 'beta', 'mu', 'eta')):
         """Initialize an `ExpCM` object.
 
         Args:
@@ -964,7 +964,7 @@ class ExpCM_fitprefs(ExpCM):
     _REPORTPARAMS.append('pi')
 
     def __init__(self, prefs, prior, kappa, omega, phi, mu=1.0, origbeta=1.0,
-                 freeparams={'zeta'}):
+                 freeparams=('zeta',)):
         """Initialize an `ExpCM_fitprefs` object.
 
         The calling parameters have the meaning described in the main class doc
@@ -1330,7 +1330,7 @@ class ExpCM_empirical_phi(ExpCM):
     PARAMTYPES['g'] = (numpy.ndarray, (N_NT,))
 
     def __init__(self, prefs, g, kappa=2.0, omega=0.5, beta=1.0, mu=1.0,
-                 freeparams={'kappa', 'omega', 'beta', 'mu'}):
+                 freeparams=('kappa', 'omega', 'beta', 'mu')):
         """Initialize an `ExpCM_empirical_phi` object.
 
         Args:
@@ -1465,7 +1465,7 @@ class ExpCM_empirical_phi_divpressure(ExpCM_empirical_phi):
 
     def __init__(self, prefs, g, divPressureValues, kappa=2.0, omega=0.5,
                  beta=1.0, mu=1.0, omega2=0.0,
-                 freeparams={'kappa', 'omega', 'beta', 'mu', 'omega2'}):
+                 freeparams=('kappa', 'omega', 'beta', 'mu', 'omega2')):
         """Initialize an `ExpCM_empirical_phi_divpressure` object.
 
         Args:
@@ -1608,7 +1608,7 @@ class YNGKP_M0(Model):
         return 0.0
 
     def __init__(self, e_pw, nsites, kappa=2.0, omega=0.5, mu=1.0,
-                 freeparams={'kappa', 'omega', 'mu'}):
+                 freeparams=('kappa', 'omega', 'mu')):
         """Initialize an `YNGKP_M0` object.
 
         Args:
@@ -2134,7 +2134,7 @@ class GammaDistributedModel(DistributionModel):
         return ['alpha_lambda', 'beta_lambda']
 
     def __init__(self, model, lambda_param, ncats, alpha_lambda=1.0,
-                 beta_lambda=2.0, freeparams={'alpha_lambda', 'beta_lambda'}):
+                 beta_lambda=2.0, freeparams=('alpha_lambda', 'beta_lambda')):
         """Initialize a `GammaDistributedModel`.
 
         Args:
@@ -2462,7 +2462,7 @@ class GammaDistributedOmegaModel(GammaDistributedModel):
     """
 
     def __init__(self, model, ncats, alpha_lambda=1.0, beta_lambda=2.0,
-                 freeparams={'alpha_lambda', 'beta_lambda'}):
+                 freeparams=('alpha_lambda', 'beta_lambda')):
         """Initialize an `GammaDistributedModel` object.
 
         The `lambda_param` is set to "omega".
@@ -2490,7 +2490,7 @@ class GammaDistributedBetaModel(GammaDistributedModel):
     """
 
     def __init__(self, model, ncats, alpha_lambda=1.0, beta_lambda=2.0,
-                 freeparams={'alpha_lambda', 'beta_lambda'}):
+                 freeparams=('alpha_lambda', 'beta_lambda')):
         """Initialize an `GammaDistributedModel` object.
 
         The `lambda_param` is set to "beta".

--- a/phydmslib/models.py
+++ b/phydmslib/models.py
@@ -632,9 +632,9 @@ class ExpCM(Model):
                 expDxx = numpy.array([expDyy[r].transpose() for r in
                                      range(self.nsites)])
                 V = (expDxx - expDyy) / Dxx_Dyy
-            with numpy.errstate(under='ignore'): # OK if some values 0
-                numpy.copyto(V, self.mu * t * expDxx, where=
-                        Dxx_Dyy_lt_ALMOST_ZERO)
+            with numpy.errstate(under='ignore'):  # OK if some values 0
+                numpy.copyto(V, self.mu * t * expDxx,
+                             where=Dxx_Dyy_lt_ALMOST_ZERO)
             self._cached[('V', t)] = V
         V = self._cached[('V', t)]
 
@@ -654,7 +654,7 @@ class ExpCM(Model):
                                        )
             else:
                 if not paramisvec:
-                    dM_param = (broadcastMatrixVectorMultiply(self.A, broadcastGetCols(broadcastMatrixMultiply(self.B[param] * V,self.Ainv), tips)))
+                    dM_param = (broadcastMatrixVectorMultiply(self.A, broadcastGetCols(broadcastMatrixMultiply(self.B[param] * V, self.Ainv), tips)))
                 else:
                     dM_param = numpy.ndarray((paramlength, self.nsites,
                                               N_CODON), dtype='float')
@@ -717,10 +717,13 @@ class ExpCM(Model):
         self.Frxy_no_omega.fill(1.0)
         with numpy.errstate(divide='raise', under='raise', over='raise',
                             invalid='ignore'):
-            numpy.copyto(self.Frxy_no_omega, -self.ln_piAx_piAy_beta /
-                         (1 - self.piAx_piAy_beta),
-                         where=numpy.logical_and(CODON_NONSYN,
-                                                 numpy.fabs(1 - self.piAx_piAy_beta) > ALMOST_ZERO))
+            (numpy
+             .copyto(self.Frxy_no_omega, -self.ln_piAx_piAy_beta /
+                     (1 - self.piAx_piAy_beta),
+                     where=numpy.logical_and(CODON_NONSYN,
+                                             numpy.fabs(1 -
+                                                        self.piAx_piAy_beta)
+                                             > ALMOST_ZERO)))
         numpy.copyto(self.Frxy, self.Frxy_no_omega * self.omega,
                      where=CODON_NONSYN)
 
@@ -734,13 +737,15 @@ class ExpCM(Model):
         for r in range(self.nsites):
             pr_half = self.prx[r]**0.5
             pr_neghalf = self.prx[r]**-0.5
-            # symm_pr = numpy.dot(numpy.diag(pr_half), numpy.dot(self.Prxy[r], numpy.diag(pr_neghalf)))
+            # symm_pr = numpy.dot(numpy.diag(pr_half), numpy.dot(self.Prxy[r],
+            # numpy.diag(pr_neghalf)))
             symm_pr = ((pr_half * (self.Prxy[r] * pr_neghalf).transpose())
                        .transpose())
             # assert numpy.allclose(symm_pr, symm_pr.transpose())
             (evals, evecs) = scipy.linalg.eigh(symm_pr)
             # assert numpy.allclose(scipy.linalg.inv(evecs), evecs.transpose())
-            # assert numpy.allclose(symm_pr, numpy.dot(evecs, numpy.dot(numpy.diag(evals), evecs.transpose())))
+            # assert numpy.allclose(symm_pr, numpy.dot(evecs,
+            # numpy.dot(numpy.diag(evals), evecs.transpose())))
             self.D[r] = evals
             self.Ainv[r] = evecs.transpose() * pr_half
             self.A[r] = (pr_neghalf * evecs.transpose()).transpose()
@@ -1210,10 +1215,11 @@ class ExpCM_fitprefs2(ExpCM_fitprefs):
                           (self.ln_piAx_piAy_beta - 1) + 1) /
                          (1 - self.piAx_piAy_beta) ** 2,
                          where=CODON_NONSYN)
-        numpy.copyto(self.tildeFrxy, self.omega * self.beta / 2.0,
-                     where=numpy.logical_and(CODON_NONSYN,
-                                             numpy.fabs(1 - self.piAx_piAy_beta)
-                                             < ALMOST_ZERO))
+        (numpy
+         .copyto(self.tildeFrxy, self.omega * self.beta / 2.0,
+                 where=numpy.logical_and(CODON_NONSYN,
+                                         numpy.fabs(1 - self.piAx_piAy_beta)
+                                         < ALMOST_ZERO)))
 
         self._logprior = 0.0
         self._dlogprior = dict([(param, 0.0) for param in self.freeparams])
@@ -1464,11 +1470,9 @@ class ExpCM_empirical_phi_divpressure(ExpCM_empirical_phi):
         self.deltar = numpy.array(divPressureValues.copy())
         assert (max(numpy.absolute(self.deltar))) <= 1, (
                 "A scaled deltar value is > 1 or < -1.")
-        super(ExpCM_empirical_phi_divpressure, self).__init__(prefs, g,
-                                                              kappa=kappa,
-                                                              omega=omega,
-                                                              beta=beta, mu=mu,
-                                                              freeparams=freeparams)
+        (super(ExpCM_empirical_phi_divpressure, self)
+         .__init__(prefs, g, kappa=kappa, omega=omega, beta=beta, mu=mu,
+                   freeparams=freeparams))
 
     def _update_dPrxy(self):
         """Update `dPrxy`, accounting for dependence of `Prxy` on `omega2`."""
@@ -1482,11 +1486,12 @@ class ExpCM_empirical_phi_divpressure(ExpCM_empirical_phi):
                               self.omega /
                               (1 - self.piAx_piAy_beta)),
                              where=CODON_NONSYN)
-            numpy.copyto(self.dPrxy['omega2'], self.Qxy * self.omega,
-                         where=numpy.logical_and(CODON_NONSYN,
-                                                 numpy.fabs(1 -
-                                                            self.piAx_piAy_beta)
-                                                 < ALMOST_ZERO))
+            (numpy
+             .copyto(self.dPrxy['omega2'], self.Qxy * self.omega,
+                     where=numpy.logical_and(CODON_NONSYN,
+                                             numpy.fabs(1 -
+                                                        self.piAx_piAy_beta)
+                                             < ALMOST_ZERO)))
             for r in range(self.nsites):
                 self.dPrxy['omega2'][r] *= self.deltar[r]
             _fill_diagonals(self.dPrxy['omega2'], self._diag_indices)
@@ -1499,12 +1504,13 @@ class ExpCM_empirical_phi_divpressure(ExpCM_empirical_phi):
         self.Frxy_no_omega.fill(1.0)
         with numpy.errstate(divide='raise', under='raise', over='raise',
                             invalid='ignore'):
-            numpy.copyto(self.Frxy_no_omega,
-                         -self.ln_piAx_piAy_beta / (1 - self.piAx_piAy_beta),
-                         where=numpy.logical_and(CODON_NONSYN,
-                                                 numpy.fabs(1 -
-                                                            self.piAx_piAy_beta)
-                                                 > ALMOST_ZERO))
+            (numpy
+             .copyto(self.Frxy_no_omega, -self.ln_piAx_piAy_beta / (1 -
+                     self.piAx_piAy_beta),
+                     where=numpy.logical_and(CODON_NONSYN,
+                                             numpy.fabs(1 -
+                                                        self.piAx_piAy_beta)
+                                             > ALMOST_ZERO)))
         for r in range(self.nsites):
             numpy.copyto(self.Frxy_no_omega[r], self.Frxy_no_omega[r] *
                          (1 + self.omega2 * self.deltar[r]),
@@ -1894,13 +1900,15 @@ class YNGKP_M0(Model):
         for r in range(1):
             Phi_x_half = self.Phi_x**0.5
             Phi_x_neghalf = self.Phi_x**-0.5
-            # symm_p = numpy.dot(numpy.diag(Phi_x_half), numpy.dot(self.Pxy[r], numpy.diag(Phi_x_neghalf)))
+            # symm_p = numpy.dot(numpy.diag(Phi_x_half),
+            # numpy.dot(self.Pxy[r], numpy.diag(Phi_x_neghalf)))
             symm_p = ((Phi_x_half * (self.Pxy[r] * Phi_x_neghalf)
                       .transpose()).transpose())
             # assert numpy.allclose(symm_p, symm_p.transpose())
             (evals, evecs) = scipy.linalg.eigh(symm_p)
             # assert numpy.allclose(scipy.linalg.inv(evecs), evecs.transpose())
-            # assert numpy.allclose(symm_pr, numpy.dot(evecs, numpy.dot(numpy.diag(evals), evecs.transpose())))
+            # assert numpy.allclose(symm_pr, numpy.dot(evecs,
+            # numpy.dot(numpy.diag(evals), evecs.transpose())))
             self.D[r] = evals
             self.Ainv[r] = evecs.transpose() * Phi_x_half
             self.A[r] = (Phi_x_neghalf * evecs.transpose()).transpose()
@@ -2401,12 +2409,15 @@ def DiscreteGamma(alpha, beta, ncats):
     for k in range(ncats):
         if k == 0:
             gammainc_lower = 0.0
-        else:
+            upper = scipy.stats.gamma.ppf((k + 1) / float(ncats), alpha,
+                                          scale=scale)
+            gammainc_upper = scipy.special.gammainc(alpha + 1, upper * beta)
+        elif k == ncats - 1:
             gammainc_lower = gammainc_upper
-        if k == ncats - 1:
             upper = float('inf')
             gammainc_upper = 1.0
         else:
+            gammainc_lower = gammainc_upper
             upper = scipy.stats.gamma.ppf((k + 1) / float(ncats), alpha,
                                           scale=scale)
             gammainc_upper = scipy.special.gammainc(alpha + 1, upper * beta)
@@ -2445,12 +2456,9 @@ class GammaDistributedOmegaModel(GammaDistributedModel):
                 Meaning described in main class doc string for
                 `GammaDistributedModel`.
         """
-        super(GammaDistributedOmegaModel, self).__init__(model, "omega",
-                                                         ncats,
-                                                         alpha_lambda=1.0,
-                                                         beta_lambda=2.0,
-                                                         freeparams=[
-                                                                     'alpha_lambda', 'beta_lambda'])
+        (super(GammaDistributedOmegaModel, self)
+         .__init__(model, "omega", ncats, alpha_lambda=1.0, beta_lambda=2.0,
+                   freeparams=['alpha_lambda', 'beta_lambda']))
 
 
 class GammaDistributedBetaModel(GammaDistributedModel):
@@ -2487,11 +2495,9 @@ class GammaDistributedBetaModel(GammaDistributedModel):
         new_limits["beta"] = (new_limits["beta"][0], new_max_beta)
         model.PARAMLIMITS = new_limits
 
-        super(GammaDistributedBetaModel, self).__init__(model, "beta",
-                                                        ncats,
-                                                        alpha_lambda=1.0,
-                                                        beta_lambda=2.0,
-                                                        freeparams=['alpha_lambda', 'beta_lambda'])
+        (super(GammaDistributedBetaModel, self)
+         .__init__(model, "beta", ncats, alpha_lambda=1.0, beta_lambda=2.0,
+                   freeparams=['alpha_lambda', 'beta_lambda']))
 
         assert all([numpy.allclose(new_max_beta, m.PARAMLIMITS["beta"][1])
                    for m in self._models]), (

--- a/phydmslib/models.py
+++ b/phydmslib/models.py
@@ -1091,7 +1091,7 @@ class ExpCM_fitprefs(ExpCM):
                                              < ALMOST_ZERO))
 
         self._logprior = 0.0
-        self._dlogprior = dict([(param, 0.0) for param in self.freeparams])
+        self._dlogprior = {param: 0.0 for param in self.freeparams}
         if self.prior is None:
             pass
         elif self.prior[0] == 'invquadratic':
@@ -1378,7 +1378,8 @@ class ExpCM_empirical_phi(ExpCM):
         Note that it uses the passed value of `beta`, **not**
         the current `beta` attribute.
 
-        Initial guess is current value of `phi` attribute."""
+        Initial guess is current value of `phi` attribute.
+        """
         def F(phishort):
             """Difference between `g` and expected `g` given `phishort`."""
             phifull = numpy.append(phishort, 1 - phishort.sum())

--- a/phydmslib/models.py
+++ b/phydmslib/models.py
@@ -2401,10 +2401,8 @@ def DiscreteGamma(alpha, beta, ncats):
             `0 <= k < ncats`.
 
     Check that we get values in Figure 1 of Yang, J Mol Evol, 39:306-314
-    >>> catmeans = DiscreteGamma(0.5, 0.5, 4)
-    >>> numpy.allclose(catmeans, numpy.array(\
-                                            [0.0334, 0.2519, 0.8203, 2.8944]),\
-                                            atol=1e-4)
+    >>> catmeans = DiscreteGamma(0.5, 0.5, 3)
+    >>> numpy.allclose(catmeans, numpy.array([0.0603,0.4894,2.4502]),atol=1e-4)
     True
 
     Make sure we get expected mean of alpha / beta

--- a/phydmslib/numutils.pyx
+++ b/phydmslib/numutils.pyx
@@ -7,7 +7,7 @@ cimport numpy
 
 
 def broadcastMatrixMultiply(numpy.ndarray a, numpy.ndarray b,
-        float alpha=1.0):
+                            float alpha=1.0):
     """Broadcast square matrix multiplication using `blas` for speed.
 
     Args:
@@ -53,7 +53,7 @@ def broadcastMatrixMultiply(numpy.ndarray a, numpy.ndarray b,
 
 
 def broadcastMatrixVectorMultiply(numpy.ndarray m, numpy.ndarray v,
-        float alpha=1.0):
+                                  float alpha=1.0):
     """Broadcast matrix vector multiplication using `blas` for speed.
 
     Args:
@@ -100,7 +100,7 @@ def broadcastMatrixVectorMultiply(numpy.ndarray m, numpy.ndarray v,
     for i in range(r):
         mv[i] = scipy.linalg.blas.dgemv(alpha, m[i], v[i])
     return mv
-    #return numpy.sum(m * v[:, None, :], axis=2)
+    # return numpy.sum(m * v[:, None, :], axis=2)
 
 
 def broadcastGetCols(numpy.ndarray m, numpy.ndarray cols):

--- a/phydmslib/parsearguments.py
+++ b/phydmslib/parsearguments.py
@@ -1,6 +1,4 @@
-"""
-Module for parsing arguments.
-"""
+"""Module for parsing arguments."""
 
 
 import sys
@@ -17,6 +15,7 @@ yngkp_modelvariants = ['M0', 'M5']
 
 class ArgumentParserNoArgHelp(argparse.ArgumentParser):
     """Like *argparse.ArgumentParser*, but prints help when no arguments."""
+
     def error(self, message):
         """Prints error message, then help."""
         sys.stderr.write('error: %s\n\n' % message)
@@ -31,6 +30,7 @@ class ArgDefaultsRawDescriptFormatter(argparse.ArgumentDefaultsHelpFormatter,
     Based on this:
     http://stackoverflow.com/questions/18462610/argumentparser-epilog-and-description-formatting-in-conjunction-with-argumentdef
     """
+
     pass
 
 
@@ -595,7 +595,7 @@ def PhyDMSParser():
 
 
 def PhyDMSTestdivpressureParser():
-    """Returns *argparse.ArgumentParser* for ``phdyms_testdivpressure`."""
+    """Returns *argparse.ArgumentParser* for ``phdyms_testdivpressure``."""
     parser = (ArgumentParserNoArgHelp(
              description="Test different models of diversifying pressure. {0} "
              "Version {1}. Full documentation at "

--- a/phydmslib/parsearguments.py
+++ b/phydmslib/parsearguments.py
@@ -24,9 +24,8 @@ class ArgumentParserNoArgHelp(argparse.ArgumentParser):
         sys.exit(2)
 
 
-class ArgumentDefaultsRawDescriptionFormatter(
-                                              argparse.ArgumentDefaultsHelpFormatter,
-                                              argparse.RawDescriptionHelpFormatter):
+class ArgDefaultsRawDescriptFormatter(argparse.ArgumentDefaultsHelpFormatter,
+                                      argparse.RawDescriptionHelpFormatter):
     """Print default arguments and raw text description formatter.
 
     Based on this:
@@ -208,7 +207,7 @@ def ModelOption(model):
 def PhyDMSPrepAlignmentParser():
     """Returns *argparse.ArgumentParser* for ``phydms_prepalignment``."""
     parser = (ArgumentParserNoArgHelp(
-             formatter_class=ArgumentDefaultsRawDescriptionFormatter,
+             formatter_class=ArgDefaultsRawDescriptFormatter,
              description=("Prepare alignment of protein-coding DNA "
                           "sequences.\n"
                           "Steps:\n"

--- a/phydmslib/simulate.py
+++ b/phydmslib/simulate.py
@@ -43,7 +43,7 @@ def pyvolvePartitions(model, divselection=None):
     else:
         divsites = []
 
-    assert all([1 <= r <= model.nsites for r in divsites])
+    assert all((1 <= r <= model.nsites for r in divsites))
 
     partitions = []
     for r in range(model.nsites):

--- a/phydmslib/simulate.py
+++ b/phydmslib/simulate.py
@@ -69,7 +69,8 @@ def pyvolvePartitions(model, divselection=None):
                             fxy *= model.omega
                     if type(model) in [phydmslib.models.ExpCM,
                                        phydmslib.models.ExpCM_empirical_phi,
-                                       phydmslib.models.ExpCM_empirical_phi_divpressure]:
+                                       (phydmslib.models
+                                        .ExpCM_empirical_phi_divpressure)]:
                         qxy *= model.phi[NT_TO_INDEX[ynt]]
                         pix = model.pi[r][AA_TO_INDEX[xaa]]**model.beta
                         piy = model.pi[r][AA_TO_INDEX[yaa]]**model.beta

--- a/phydmslib/treelikelihood.py
+++ b/phydmslib/treelikelihood.py
@@ -232,7 +232,7 @@ class TreeLikelihood(object):
             self._Lshape = (self.model.ncats, self.nsites, N_CODON)
         else:
             self._Lshape = (self.nsites, N_CODON)
-        self.dL_dt = dict([(n, {}) for n in range(self.nnodes - 1)])
+        self.dL_dt = {n: {} for n in range(self.nnodes - 1)}
         self.L = {}
         self.dL = {}
         self._dLshape = {}
@@ -319,11 +319,11 @@ class TreeLikelihood(object):
                 self._index_to_param[i] = param
                 i += 1
             else:
-                for (pindex, pvalue) in enumerate(paramvalue):
+                for (pindex, _pvalue) in enumerate(paramvalue):
                     self._index_to_param[i] = (param, pindex)
                     i += 1
-        self._param_to_index = dict([(y, x) for (x, y) in
-                                     self._index_to_param.items()])
+        self._param_to_index = {y: x for (x, y) in
+                                self._index_to_param.items()}
         assert i == len(self._index_to_param)
 
         # now update internal attributes related to likelihood
@@ -539,7 +539,7 @@ class TreeLikelihood(object):
     def paramsarraybounds(self):
         """Bounds for parameters in `paramsarray`."""
         bounds = []
-        for (i, param) in self._index_to_param.items():
+        for (_i, param) in self._index_to_param.items():
             if isinstance(param, str):
                 bounds.append(self.model.PARAMLIMITS[param])
             elif isinstance(param, tuple):
@@ -556,7 +556,8 @@ class TreeLikelihood(object):
         """All free model parameters as 1-dimensional `numpy.ndarray`.
 
         You are allowed to update model parameters by direct
-        assignment of this property."""
+        assignment of this property.
+        """
         # Return copy of `_paramsarray` because setter checks if changed
         if self._paramsarray is not None:
             return self._paramsarray.copy()
@@ -689,7 +690,7 @@ class TreeLikelihood(object):
                 value to set. Each parameter name must either be a
                 valid model parameter (in `model.freeparams`).
         """
-        for (param, value) in newvalues.items():
+        for (param, _value) in newvalues.items():
             if param not in self.model.freeparams:
                 raise RuntimeError("Can't handle param: {0}".format(
                         param))

--- a/phydmslib/treelikelihood.py
+++ b/phydmslib/treelikelihood.py
@@ -485,15 +485,15 @@ class TreeLikelihood(object):
                     if not approx_grad:
                         self.dparamscurrent = False
                         self.dtcurrent = True
-                    result = scipy.optimize.minimize(tfunc,
-                                                     self.t,
-                                                     method='L-BFGS-B',
-                                                     jac=tdfunc,
-                                                     options=options,
-                                                     bounds=[
-                                                            (ALMOST_ZERO, None)
-                                                            ]
-                                                     * len(self.t))
+                    result = (scipy.optimize
+                              .minimize(tfunc,
+                                        self.t,
+                                        method='L-BFGS-B',
+                                        jac=tdfunc,
+                                        options=options,
+                                        bounds=([(ALMOST_ZERO, None)]
+                                                * len(self.t))
+                                        ))
                     _printResult('branches', result, i, oldloglik, self.loglik)
                     summary.append('Step {0}: optimized branches, loglik went '
                                    'from {1:.2f} to {2:.2f} ({3} iterations, '
@@ -874,8 +874,10 @@ class TreeLikelihood(object):
                                     dM_dt, self.L[nx][k])
                         self.dL_dt[nx][n][k] = LdM_dt * MLxother
                         for ndx in self.descendants[nx]:
-                            self.dL_dt[ndx][n][k] = broadcastMatrixVectorMultiply(
-                                    Mx, self.dL_dt[ndx][nx][k]) * MLxother
+                            # placeholder to avoid long, hard to read line
+                            x = self.dL_dt[ndx][nx][k]
+                            y = broadcastMatrixVectorMultiply(Mx, x)
+                            self.dL_dt[ndx][n][k] = y * MLxother
 
                 if self.dparamscurrent:
                     for param in self._paramlist_PartialLikelihoods:

--- a/phydmslib/treelikelihood.py
+++ b/phydmslib/treelikelihood.py
@@ -5,18 +5,16 @@ using the indexing schemes defined in `phydmslib.constants`.
 """
 
 
-import sys
-import math
 import copy
 import warnings
-warnings.simplefilter('always')
-warnings.simplefilter('ignore', ImportWarning)
 import numpy
 import scipy.optimize
 import Bio.Phylo
 import phydmslib.models
-from phydmslib.numutils import *
-from phydmslib.constants import *
+from phydmslib.numutils import broadcastMatrixVectorMultiply
+from phydmslib.constants import ALMOST_ZERO, CODON_TO_INDEX, N_CODON
+warnings.simplefilter('always')
+warnings.simplefilter('ignore', ImportWarning)
 
 
 class TreeLikelihood(object):
@@ -126,7 +124,7 @@ class TreeLikelihood(object):
             and not used, which is why `t` is of length `nnodes - 1` rather
             than `nnodes`.
         `L` (`dict`)
-            `L[n]` is a `numpy.ndarray` of `float` of shape `(nsites, N_CODON)`.
+            `L[n]` is a `numpy.ndarray` of `float` of shape `(nsites, N_CODON)`
             for each node `n`. `L[n][r][x] is the partial condition likelihood
             of codon `x` at site `r` at node `n`. Note that these
             must be corrected by adding `underflowlogscale`.
@@ -154,7 +152,7 @@ class TreeLikelihood(object):
     """
 
     def __init__(self, tree, alignment, model, underflowfreq=3,
-            dparamscurrent=True, dtcurrent=False, branchScale=None):
+                 dparamscurrent=True, dtcurrent=False, branchScale=None):
         """Initialize a `TreeLikelihood` object.
 
         Args:
@@ -198,11 +196,12 @@ class TreeLikelihood(object):
         self.nsites = self.model.nsites
 
         assert isinstance(alignment, list) and all([isinstance(tup, tuple)
-                and len(tup) == 2 for tup in alignment]), ("alignment is "
-                "not list of (head, seq) 2-tuples")
+               and len(tup) == 2 for tup in alignment]), ("alignment is not "
+                                                          "list of (head, seq)"
+                                                          " 2-tuples")
         assert all([len(seq) == 3 * self.nsites for (head, seq) in alignment])
-        assert set([head for (head, seq) in alignment]) == set([clade.name for
-                clade in tree.get_terminals()])
+        assert set([head for (head, seq) in alignment]) ==\
+               (set([clade.name for clade in tree.get_terminals()]))
         self.alignment = copy.deepcopy(alignment)
         self.nseqs = len(alignment)
         alignment_d = dict(self.alignment)
@@ -213,7 +212,7 @@ class TreeLikelihood(object):
         assert isinstance(tree, Bio.Phylo.BaseTree.Tree), "invalid tree"
         self._tree = copy.deepcopy(tree)
         assert self._tree.count_terminals() == self.nseqs
-        if branchScale == None:
+        if branchScale is None:
             branchScale = self.model.branchScale
         else:
             assert isinstance(branchScale, float) and branchScale > 0
@@ -239,20 +238,22 @@ class TreeLikelihood(object):
         self._dLshape = {}
         for param in self._paramlist_PartialLikelihoods:
             self.dL[param] = {}
-            if self._distributionmodel and param == self.model.distributedparam:
+            if self._distributionmodel and\
+               (param == self.model.distributedparam):
                 self._dLshape[param] = self._Lshape
             else:
                 paramvalue = getattr(self.model, param)
                 if isinstance(paramvalue, float):
                     self._dLshape[param] = self._Lshape
-                elif isinstance(paramvalue, numpy.ndarray) and (paramvalue.ndim
-                        == 1):
+                elif (isinstance(paramvalue, numpy.ndarray) and
+                      (paramvalue.ndim == 1)):
                     if self._distributionmodel:
                         self._dLshape[param] = (self.model.ncats,
-                                len(paramvalue), self.nsites, N_CODON)
+                                                len(paramvalue),
+                                                self.nsites, N_CODON)
                     else:
                         self._dLshape[param] = (len(paramvalue),
-                                self.nsites, N_CODON)
+                                                self.nsites, N_CODON)
                 else:
                     raise ValueError("Cannot handle param: {0}, {1}".format(
                             param, paramvalue))
@@ -277,36 +278,40 @@ class TreeLikelihood(object):
                 seq = alignment_d[node.name]
                 nodegaps = []
                 for r in range(self.nsites):
-                    codon = seq[3 * r : 3 * r + 3]
+                    codon = seq[3 * r:3 * r + 3]
                     if codon == '---':
                         nodegaps.append(r)
                     elif codon in CODON_TO_INDEX:
                         self.tips[n][r] = CODON_TO_INDEX[codon]
                     else:
                         raise ValueError("Bad codon {0} in {1}".format(codon,
-                                node.name))
+                                         node.name))
                 self.gaps.append(numpy.array(nodegaps, dtype='int'))
             else:
-                assert n >= self.ntips, "n = {0}, ntips = {1}".format(
-                        n, self.ntips)
+                assert n >= self.ntips, ("n = {0}, "
+                                         "ntips = {1}".format(n, self.ntips))
                 assert len(node.clades) == 2, ("not 2 children: {0} has {1}\n"
-                        "Is this the root node? -- {2}\n"
-                        "Try `tree.root_at_midpoint()` before passing "
-                        "to `TreeLikelihood`.").format(
-                        node.name, len(node.clades), node == self._tree.root)
+                                               "Is this the root node? -- {2}"
+                                               "\nTry `tree"
+                                               ".root_at_midpoint()` before "
+                                               "passing to `TreeLikelihood`"
+                                               ".".format(node.name,
+                                                          len(node.clades),
+                                                          node ==
+                                                          self._tree.root))
                 ni = n - self.ntips
                 self.rdescend[ni] = self.name_to_nodeindex[node.clades[0]]
                 self.ldescend[ni] = self.name_to_nodeindex[node.clades[1]]
                 self.descendants.append([self.name_to_nodeindex[nx] for nx
-                        in node.find_clades() if nx != node])
+                                         in node.find_clades() if nx != node])
             self.name_to_nodeindex[node] = n
         self.gaps = numpy.array(self.gaps)
         assert len(self.gaps) == self.ntips
 
         # _index_to_param defines internal mapping of
         # `paramsarray` indices and parameters
-        self._paramsarray = None # set by `paramsarray` property as needed
-        self._index_to_param = {} # value is parameter associated with index
+        self._paramsarray = None  # set by `paramsarray` property as needed
+        self._index_to_param = {}  # value is parameter associated with index
         i = 0
         for param in self.model.freeparams:
             paramvalue = getattr(self.model, param)
@@ -318,15 +323,14 @@ class TreeLikelihood(object):
                     self._index_to_param[i] = (param, pindex)
                     i += 1
         self._param_to_index = dict([(y, x) for (x, y) in
-                self._index_to_param.items()])
+                                     self._index_to_param.items()])
         assert i == len(self._index_to_param)
 
         # now update internal attributes related to likelihood
         self._updateInternals()
 
-    def maximizeLikelihood(self, optimize_brlen=False,
-            approx_grad=False, logliktol=1.0e-2, nparamsretry=1,
-            printfunc=None):
+    def maximizeLikelihood(self, optimize_brlen=False, approx_grad=False,
+                           logliktol=1.0e-2, nparamsretry=1, printfunc=None):
         """Maximize the log likelihood.
 
         Maximizes log likelihood with respect to model parameters
@@ -400,14 +404,14 @@ class TreeLikelihood(object):
                 printfunc('Step {0}, optimized {1}.\n'
                           'Likelihood went from {2} to {3}.\n'
                           'Max magnitude in Jacobian is {4}.\n'
-                          'Full optimization result:\n{5}\n'.format(
-                          i, opttype, old, new,
-                          numpy.absolute(result.jac).max(), result))
+                          'Full optimization result:\n{5}\n'
+                          .format(i, opttype, old, new,
+                                  numpy.absolute(result.jac).max(), result))
 
         oldloglik = self.loglik
         converged = False
         firstbrlenpass = True
-        options = {'ftol':1.0e-7} # optimization options
+        options = {'ftol': 1.0e-7}  # optimization options
         summary = []
         i = 1
         while not converged:
@@ -418,29 +422,35 @@ class TreeLikelihood(object):
             origparamsarray = self.paramsarray.copy()
             paramsconverged = False
             while not paramsconverged:
-                result = scipy.optimize.minimize(paramsfunc, self.paramsarray,
-                        method='L-BFGS-B', jac=paramsdfunc,
-                        bounds=self.paramsarraybounds, options=options)
+                result = scipy.optimize.minimize(paramsfunc,
+                                                 self.paramsarray,
+                                                 method='L-BFGS-B',
+                                                 jac=paramsdfunc,
+                                                 bounds=self.paramsarraybounds,
+                                                 options=options)
                 _printResult('params', result, i, oldloglik, self.loglik)
                 msg = ('Step {0}: optimized parameters, loglik went from '
-                        '{1:.2f} to {2:.2f} ({3} iterations, {4} function '
-                        'evals)'.format(i, oldloglik, self.loglik, result.nit,
-                        result.nfev))
+                       '{1:.2f} to {2:.2f} ({3} iterations, {4} function '
+                       'evals)'.format(i, oldloglik, self.loglik, result.nit,
+                                       result.nfev))
                 summary.append(msg)
-                if result.success and (not (oldloglik - self.loglik > logliktol)):
+                if result.success and\
+                   (not (oldloglik - self.loglik > logliktol)):
                     paramsconverged = True
                     jacmax = numpy.absolute(result.jac).max()
-                    if (jacmax > 1000) and not (firstbrlenpass and optimize_brlen):
+                    if (jacmax > 1000) and not\
+                       (firstbrlenpass and optimize_brlen):
                         warnings.warn("Optimizer reports convergence, "
-                                "but max element in Jacobian is {0}\n"
-                                "Summary of optimization:\n{1}".format(
-                                jacmax, summary))
+                                      "but max element in Jacobian is {0}\n"
+                                      "Summary of optimization:\n{1}"
+                                      .format(jacmax, summary))
                 else:
                     if not result.success:
                         resultmessage = result.message
                     else:
-                        resultmessage = ('loglik increased in param optimization '
-                                'from {0} to {1}'.format(oldloglik, self.loglik))
+                        resultmessage = ('loglik increased in param '
+                                         'optimization from {0} to {1}'
+                                         .format(oldloglik, self.loglik))
                     nparamstry += 1
                     failmsg = ("Optimization failure {0}\n{1}\n{2}".format(
                             nparamstry, resultmessage, '\n'.join(summary)))
@@ -448,17 +458,20 @@ class TreeLikelihood(object):
                         raise RuntimeError(failmsg)
                     else:
                         warnings.warn(failmsg + '\n\n' +
-                                "Re-trying with different initial params.")
+                                      "Re-trying with different "
+                                      "initial params.")
                         numpy.random.seed(nparamstry)
                         # seed at geometric mean of original value, max
-                        # bound, min bound, and random number between max and min
-                        minarray = numpy.array([self.paramsarraybounds[j][0] for
-                                j in range(len(self.paramsarray))])
-                        maxarray = numpy.array([self.paramsarraybounds[j][1] for
-                                j in range(len(self.paramsarray))])
+                        # bound, min bound, & random number between max and min
+                        minarray = numpy.array([self.paramsarraybounds[j][0]
+                                               for j in
+                                               range(len(self.paramsarray))])
+                        maxarray = numpy.array([self.paramsarraybounds[j][1]
+                                               for j in
+                                               range(len(self.paramsarray))])
                         randarray = numpy.random.uniform(minarray, maxarray)
                         newarray = (minarray * maxarray * randarray *
-                                origparamsarray)**(1 / 4.) # geometric mean
+                                    origparamsarray) ** (1 / 4.)
                         assert newarray.shape == self.paramsarray.shape
                         assert (newarray > minarray).all()
                         assert (newarray < maxarray).all()
@@ -472,22 +485,30 @@ class TreeLikelihood(object):
                     if not approx_grad:
                         self.dparamscurrent = False
                         self.dtcurrent = True
-                    result = scipy.optimize.minimize(tfunc, self.t,
-                            method='L-BFGS-B', jac=tdfunc, options=options,
-                            bounds=[(ALMOST_ZERO, None)] * len(self.t))
+                    result = scipy.optimize.minimize(tfunc,
+                                                     self.t,
+                                                     method='L-BFGS-B',
+                                                     jac=tdfunc,
+                                                     options=options,
+                                                     bounds=[
+                                                            (ALMOST_ZERO, None)
+                                                            ]
+                                                     * len(self.t))
                     _printResult('branches', result, i, oldloglik, self.loglik)
-                    summary.append('Step {0}: optimized branches, loglik '
-                            'went from {1:.2f} to {2:.2f} ({3} iterations, '
-                            '{4} function evals)'.format(i, oldloglik,
-                            self.loglik, result.nit, result.nfev))
+                    summary.append('Step {0}: optimized branches, loglik went '
+                                   'from {1:.2f} to {2:.2f} ({3} iterations, '
+                                   '{4} function evals)'
+                                   .format(i, oldloglik, self.loglik,
+                                           result.nit, result.nfev))
                     i += 1
-                    assert result.success, ("Optimization failed\n{0}"
-                            "\n{1}\n{2}".format(result.message, self.t,
-                            '\n'.join(summary)))
+                    assert result.success, ("Optimization failed\n"
+                                            "{0}\n{1}\n{2}"
+                                            .format(result.message, self.t,
+                                                    '\n'.join(summary)))
                     if oldloglik - self.loglik > logliktol:
                         raise RuntimeError("loglik increased during t "
-                                "optimization: {0} to {1}".format(
-                                oldloglik, self.loglik))
+                                           "optimization: {0} to {1}"
+                                           .format(oldloglik, self.loglik))
                     elif self.loglik - oldloglik >= logliktol:
                         oldloglik = self.loglik
                     else:
@@ -525,7 +546,8 @@ class TreeLikelihood(object):
                 bounds.append(self.model.PARAMLIMITS[param[0]])
             else:
                 raise ValueError("Invalid param type")
-        bounds = [(tup[0] + ALMOST_ZERO, tup[1] - ALMOST_ZERO) for tup in bounds]
+        bounds = [(tup[0] + ALMOST_ZERO, tup[1] - ALMOST_ZERO)
+                  for tup in bounds]
         assert len(bounds) == len(self._index_to_param)
         return tuple(bounds)
 
@@ -556,9 +578,9 @@ class TreeLikelihood(object):
         assert (isinstance(value, numpy.ndarray) and value.ndim == 1), (
                 "paramsarray must be 1-dim ndarray")
         assert len(value) == nparams, ("Assigning paramsarray to ndarray "
-                "of the wrong length.")
+                                       "of the wrong length.")
         if (self._paramsarray is not None) and all(value == self._paramsarray):
-            return # do not need to do anything if value has not changed
+            return  # do not need to do anything if value has not changed
         # build `newvalues` to pass to `updateParams`
         newvalues = {}
         vectorized_params = {}
@@ -571,13 +593,14 @@ class TreeLikelihood(object):
                     assert iparamindex not in vectorized_params[iparam]
                     vectorized_params[iparam][iparamindex] = float(value[i])
                 else:
-                    vectorized_params[iparam] = {iparamindex:float(value[i])}
+                    vectorized_params[iparam] = {iparamindex: float(value[i])}
             else:
                 raise ValueError("Invalid param type")
         for (param, paramd) in vectorized_params.items():
             assert set(paramd.keys()) == set(range(len(paramd)))
-            newvalues[param] = numpy.array([paramd[i] for i in range(len(paramd))],
-                    dtype='float')
+            newvalues[param] = numpy.array([paramd[i] for i in
+                                            range(len(paramd))],
+                                           dtype='float')
         self.updateParams(newvalues)
         self._paramsarray = self.paramsarray
 
@@ -591,7 +614,8 @@ class TreeLikelihood(object):
         """Set value of `dparamscurrent`, update derivatives if needed."""
         assert isinstance(value, bool)
         if value and self.dtcurrent:
-            raise RuntimeError("Can't set both dparamscurrent and dtcurrent True")
+            raise RuntimeError("Can't set both dparamscurrent and "
+                               "dtcurrent True")
         if value != self.dparamscurrent:
             self._dparamscurrent = value
             self._updateInternals()
@@ -606,7 +630,8 @@ class TreeLikelihood(object):
         """Set value of `dtcurrent`, update derivatives if needed."""
         assert isinstance(value, bool)
         if value and self.dparamscurrent:
-            raise RuntimeError("Can't set both dparamscurrent and dtcurrent True")
+            raise RuntimeError("Can't set both dparamscurrent and "
+                               "dtcurrent True")
         if value != self.dtcurrent:
             self._dtcurrent = value
             self._updateInternals()
@@ -640,7 +665,8 @@ class TreeLikelihood(object):
     @property
     def dloglikarray(self):
         """Derivative of `loglik` with respect to `paramsarray`."""
-        assert self.dparamscurrent, "dloglikarray requires paramscurrent == True"
+        assert self.dparamscurrent, ("dloglikarray requires paramscurrent "
+                                     "== True")
         nparams = len(self._index_to_param)
         dloglikarray = numpy.ndarray(shape=(nparams,), dtype='float')
         for (i, param) in self._index_to_param.items():
@@ -690,14 +716,15 @@ class TreeLikelihood(object):
         # zero.
         undererrstate = 'ignore' if len(catweights) > 1 else 'raise'
         with numpy.errstate(over='raise', under=undererrstate,
-                divide='raise', invalid='raise'):
+                            divide='raise', invalid='raise'):
             self.underflowlogscale.fill(0.0)
             self._computePartialLikelihoods()
             sitelik = numpy.zeros(self.nsites, dtype='float')
             assert (self.L[rootnode] >= 0).all(), str(self.L[rootnode])
             for k in self._catindices:
-                sitelik += numpy.sum(self._stationarystate(k) *
-                        self.L[rootnode][k], axis=1) * catweights[k]
+                sitelik += (numpy.sum(self._stationarystate(k) *
+                                      self.L[rootnode][k], axis=1) *
+                            catweights[k])
             assert (sitelik > 0).all(), "Underflow:\n{0}\n{1}".format(
                     sitelik, self.underflowlogscale)
             self.siteloglik = numpy.log(sitelik) + self.underflowlogscale
@@ -705,11 +732,11 @@ class TreeLikelihood(object):
             if self.dparamscurrent:
                 self._dloglik = {}
                 for param in self.model.freeparams:
-                    if self._distributionmodel and (param in
-                            self.model.distributionparams):
+                    if self._distributionmodel and\
+                       (param in self.model.distributionparams):
                         name = self.model.distributedparam
                         weighted_dk = (self.model.d_distributionparams[param]
-                                * catweights)
+                                       * catweights)
                     else:
                         name = param
                         weighted_dk = catweights
@@ -717,16 +744,17 @@ class TreeLikelihood(object):
                     for k in self._catindices:
                         dsiteloglik += (numpy.sum(
                                 self._dstationarystate(k, name) *
-                                self.L[rootnode][k] + self.dL[name][rootnode][k] *
+                                self.L[rootnode][k] +
+                                self.dL[name][rootnode][k] *
                                 self._stationarystate(k), axis=-1) *
                                 weighted_dk[k])
                     dsiteloglik /= sitelik
                     self._dloglik[param] = (numpy.sum(dsiteloglik, axis=-1)
-                            + self.model.dlogprior(param))
+                                            + self.model.dlogprior(param))
             if self.dtcurrent:
                 self._dloglik_dt = 0
                 dLnroot_dt = numpy.array([self.dL_dt[n2][rootnode] for
-                        n2 in sorted(self.dL_dt.keys())])
+                                          n2 in sorted(self.dL_dt.keys())])
                 for k in self._catindices:
                     if isinstance(k, int):
                         dLnrootk_dt = dLnroot_dt.swapaxes(0, 1)[k]
@@ -789,7 +817,7 @@ class TreeLikelihood(object):
     def _computePartialLikelihoods(self):
         """Update `L`, `dL`, `dL_dt`."""
         for n in range(self.ntips, self.nnodes):
-            ni = n - self.ntips # internal node number
+            ni = n - self.ntips  # internal node number
             nright = self.rdescend[ni]
             nleft = self.ldescend[ni]
             if nright < self.ntips:
@@ -806,25 +834,27 @@ class TreeLikelihood(object):
             if self.dparamscurrent:
                 for param in self._paramlist_PartialLikelihoods:
                     self.dL[param][n] = numpy.ndarray(self._dLshape[param],
-                            dtype='float')
+                                                      dtype='float')
             if self.dtcurrent:
                 for n2 in self.dL_dt.keys():
-                    self.dL_dt[n2][n] = numpy.zeros(self._Lshape, dtype='float')
+                    self.dL_dt[n2][n] = numpy.zeros(self._Lshape,
+                                                    dtype='float')
             for k in self._catindices:
                 if istipr:
-                    Mright = MLright = self._M(k, tright,
-                            self.tips[nright], self.gaps[nright])
+                    Mright = MLright = self._M(k, tright, self.tips[nright],
+                                               self.gaps[nright])
                 else:
                     Mright = self._M(k, tright)
                     MLright = broadcastMatrixVectorMultiply(Mright,
-                            self.L[nright][k])
+                                                            self.L[nright][k])
                 if istipl:
                     Mleft = MLleft = self._M(k, tleft,
-                            self.tips[nleft], self.gaps[nleft])
+                                             self.tips[nleft],
+                                             self.gaps[nleft])
                 else:
                     Mleft = self._M(k, tleft)
                     MLleft = broadcastMatrixVectorMultiply(Mleft,
-                            self.L[nleft][k])
+                                                           self.L[nleft][k])
                 self.L[n][k] = MLright * MLleft
 
                 if self.dtcurrent:
@@ -851,12 +881,14 @@ class TreeLikelihood(object):
                     for param in self._paramlist_PartialLikelihoods:
                         if istipr:
                             dMright = self._dM(k, tright, param, Mright,
-                                    self.tips[nright], self.gaps[nright])
+                                               self.tips[nright],
+                                               self.gaps[nright])
                         else:
                             dMright = self._dM(k, tright, param, Mright)
                         if istipl:
                             dMleft = self._dM(k, tleft, param, Mleft,
-                                    self.tips[nleft], self.gaps[nleft])
+                                              self.tips[nleft],
+                                              self.gaps[nleft])
                         else:
                             dMleft = self._dM(k, tleft, param, Mleft)
                         for j in self._sub_index_param(param):
@@ -876,13 +908,16 @@ class TreeLikelihood(object):
                                         dMleft[j], self.L[nleft][k])
                                 MdLleft = broadcastMatrixVectorMultiply(
                                         Mleft, self.dL[param][nleft][k][j])
-                            self.dL[param][n][k][j] = ((dMLright + MdLright)
-                                    * MLleft + MLright * (dMLleft + MdLleft))
+                            self.dL[param][n][k][j] = ((dMLright + MdLright) *
+                                                       MLleft + MLright *
+                                                       (dMLleft + MdLleft))
 
             if ni > 0 and ni % self.underflowfreq == 0:
                 # rescale by same amount for each category k
                 scale = numpy.amax(numpy.array([numpy.amax(self.L[n][k],
-                        axis=1) for k in self._catindices]), axis=0)
+                                                           axis=1)
+                                                for k in self._catindices]),
+                                   axis=0)
                 assert scale.shape == (self.nsites,)
                 self.underflowlogscale += numpy.log(scale)
                 for k in self._catindices:
@@ -893,7 +928,7 @@ class TreeLikelihood(object):
                     if self.dparamscurrent:
                         for param in self._paramlist_PartialLikelihoods:
                             for j in self._sub_index_param(param):
-                                self.dL[param][n][k][j] /= scale[:, numpy.newaxis]
+                                self.dL[param][n][k][j] /= scale[:,numpy.newaxis]
 
             # free unneeded memory by deleting already used values
             for ntodel in [nright, nleft]:
@@ -913,7 +948,7 @@ class TreeLikelihood(object):
 
         Used in computing partial likelihoods; loop over these indices."""
         if self._distributionmodel and (param ==
-                self.model.distributedparam):
+                                        self.model.distributedparam):
             indices = [()]
         else:
             paramvalue = getattr(self.model, param)
@@ -926,7 +961,6 @@ class TreeLikelihood(object):
                 raise RuntimeError("Invalid param: {0}, {1}".format(
                         param, paramvalue))
         return indices
-
 
 
 if __name__ == '__main__':

--- a/phydmslib/treelikelihood.py
+++ b/phydmslib/treelikelihood.py
@@ -200,7 +200,7 @@ class TreeLikelihood(object):
                                                           "list of (head, seq)"
                                                           " 2-tuples")
         assert all({len(seq) == 3 * self.nsites for (head, seq) in alignment})
-        assert set((head for (head, seq) in alignment)
+        assert set({head for (head, seq) in alignment}
                    ) == {clade.name for clade in tree.get_terminals()}
         self.alignment = copy.deepcopy(alignment)
         self.nseqs = len(alignment)

--- a/phydmslib/treelikelihood.py
+++ b/phydmslib/treelikelihood.py
@@ -195,13 +195,13 @@ class TreeLikelihood(object):
         self.model = copy.deepcopy(model)
         self.nsites = self.model.nsites
 
-        assert isinstance(alignment, list) and all([isinstance(tup, tuple)
-               and len(tup) == 2 for tup in alignment]), ("alignment is not "
+        assert isinstance(alignment, list) and all((isinstance(tup, tuple)
+               and len(tup) == 2 for tup in alignment)), ("alignment is not "
                                                           "list of (head, seq)"
                                                           " 2-tuples")
-        assert all([len(seq) == 3 * self.nsites for (head, seq) in alignment])
-        assert set([head for (head, seq) in alignment]) ==\
-               (set([clade.name for clade in tree.get_terminals()]))
+        assert all((len(seq) == 3 * self.nsites for (head, seq) in alignment))
+        assert set((head for (head, seq) in alignment)) ==\
+               (set((clade.name for clade in tree.get_terminals())))
         self.alignment = copy.deepcopy(alignment)
         self.nseqs = len(alignment)
         alignment_d = dict(self.alignment)
@@ -950,7 +950,8 @@ class TreeLikelihood(object):
     def _sub_index_param(self, param):
         """Returns list of sub-indexes for `param`.
 
-        Used in computing partial likelihoods; loop over these indices."""
+        Used in computing partial likelihoods; loop over these indices.
+        """
         if self._distributionmodel and (param ==
                                         self.model.distributedparam):
             indices = [()]

--- a/phydmslib/treelikelihood.py
+++ b/phydmslib/treelikelihood.py
@@ -195,10 +195,9 @@ class TreeLikelihood(object):
         self.model = copy.deepcopy(model)
         self.nsites = self.model.nsites
 
-        assert isinstance(alignment, list) and all((isinstance(tup, tuple)
-               and len(tup) == 2 for tup in alignment)), ("alignment is not "
-                                                          "list of (head, seq)"
-                                                          " 2-tuples")
+        assert isinstance(alignment, list) and all(
+            (isinstance(tup, tuple) and len(tup) == 2 for tup in alignment)), (
+                "alignment is not list of (head, seq) 2-tuples")
         assert all({len(seq) == 3 * self.nsites for (head, seq) in alignment})
         assert set({head for (head, seq) in alignment}
                    ) == {clade.name for clade in tree.get_terminals()}
@@ -290,15 +289,11 @@ class TreeLikelihood(object):
             else:
                 assert n >= self.ntips, ("n = {0}, "
                                          "ntips = {1}".format(n, self.ntips))
-                assert len(node.clades) == 2, ("not 2 children: {0} has {1}\n"
-                                               "Is this the root node? -- {2}"
-                                               "\nTry `tree"
-                                               ".root_at_midpoint()` before "
-                                               "passing to `TreeLikelihood`"
-                                               ".".format(node.name,
-                                                          len(node.clades),
-                                                          node ==
-                                                          self._tree.root))
+                assert len(node.clades) == 2, (
+                    "not 2 children: {0} has {1}\n Is this the root node? -- "
+                    "{2}\nTry `tree.root_at_midpoint()` before passing to "
+                    "`TreeLikelihood`.".format(node.name, len(node.clades),
+                                               node == self._tree.root))
                 ni = n - self.ntips
                 self.rdescend[ni] = self.name_to_nodeindex[node.clades[0]]
                 self.ldescend[ni] = self.name_to_nodeindex[node.clades[1]]
@@ -501,14 +496,13 @@ class TreeLikelihood(object):
                                    .format(i, oldloglik, self.loglik,
                                            result.nit, result.nfev))
                     i += 1
-                    assert result.success, ("Optimization failed\n"
-                                            "{0}\n{1}\n{2}"
-                                            .format(result.message, self.t,
-                                                    '\n'.join(summary)))
+                    assert result.success, (
+                        "Optimization failed\n{0}\n{1}\n{2}".format(
+                            result.message, self.t, '\n'.join(summary)))
                     if oldloglik - self.loglik > logliktol:
-                        raise RuntimeError("loglik increased during t "
-                                           "optimization: {0} to {1}"
-                                           .format(oldloglik, self.loglik))
+                        raise RuntimeError(
+                            "loglik increased during t optimization: {0} to "
+                            "{1}".format(oldloglik, self.loglik))
                     elif self.loglik - oldloglik >= logliktol:
                         oldloglik = self.loglik
                     else:
@@ -875,10 +869,7 @@ class TreeLikelihood(object):
                                     dM_dt, self.L[nx][k])
                         self.dL_dt[nx][n][k] = LdM_dt * MLxother
                         for ndx in self.descendants[nx]:
-                            # placeholder to avoid long, hard to read line
-                            x = self.dL_dt[ndx][nx][k]
-                            y = broadcastMatrixVectorMultiply(Mx, x)
-                            self.dL_dt[ndx][n][k] = y * MLxother
+                            self.dL_dt[ndx][n][k] = broadcastMatrixVectorMultiply(Mx, self.dL_dt[ndx][nx][k]) * MLxother  # noqa: E501
 
                 if self.dparamscurrent:
                     for param in self._paramlist_PartialLikelihoods:

--- a/phydmslib/treelikelihood.py
+++ b/phydmslib/treelikelihood.py
@@ -928,7 +928,8 @@ class TreeLikelihood(object):
                     if self.dparamscurrent:
                         for param in self._paramlist_PartialLikelihoods:
                             for j in self._sub_index_param(param):
-                                self.dL[param][n][k][j] /= scale[:,numpy.newaxis]
+                                self.dL[param][n][k][j] /= (scale[:,
+                                                            numpy.newaxis])
 
             # free unneeded memory by deleting already used values
             for ntodel in [nright, nleft]:

--- a/phydmslib/treelikelihood.py
+++ b/phydmslib/treelikelihood.py
@@ -199,9 +199,9 @@ class TreeLikelihood(object):
                and len(tup) == 2 for tup in alignment)), ("alignment is not "
                                                           "list of (head, seq)"
                                                           " 2-tuples")
-        assert all((len(seq) == 3 * self.nsites for (head, seq) in alignment))
-        assert set((head for (head, seq) in alignment)) ==\
-               (set((clade.name for clade in tree.get_terminals())))
+        assert all({len(seq) == 3 * self.nsites for (head, seq) in alignment})
+        assert set((head for (head, seq) in alignment)
+                   ) == {clade.name for clade in tree.get_terminals()}
         self.alignment = copy.deepcopy(alignment)
         self.nseqs = len(alignment)
         alignment_d = dict(self.alignment)

--- a/phydmslib/utils.py
+++ b/phydmslib/utils.py
@@ -59,7 +59,7 @@ def modelComparisonDataFrame(modelcomparisonfile, splitparams):
 
     paramsdict = {}
     if splitparams:
-        for (i, paramstr) in df['ParamValues'].iteritems():
+        for (i, paramstr) in df['ParamValues'].iteritems():  # noqa: F401
             paramsdict[i] = dict(map(lambda tup: (tup[0], float(tup[1])),
                                  (param.strip().split('=') for param in
                                  paramstr.split(','))))

--- a/phydmslib/utils.py
+++ b/phydmslib/utils.py
@@ -1,10 +1,9 @@
 """Utilities for ``phydmslib``."""
 
 
-import math
+import pandas
 import tempfile
 import numpy
-import pandas
 
 
 def modelComparisonDataFrame(modelcomparisonfile, splitparams):
@@ -28,10 +27,10 @@ def modelComparisonDataFrame(modelcomparisonfile, splitparams):
 
     >>> with tempfile.NamedTemporaryFile(mode='w') as f:
     ...     _ = f.write('\\n'.join([
-    ...         '| Model | deltaAIC | LogLikelihood | nParams | ParamValues  |',
-    ...         '|-------|----------|---------------|---------|--------------|',
-    ...         '| ExpCM | 0.00     | -1000.00      | 7       | x=1.0, y=2.0 |',
-    ...         '| YNGKP | 10.2     | -1005.10      | 7       | x=1.3, z=0.1 |',
+    ...        '| Model | deltaAIC | LogLikelihood | nParams | ParamValues  |',
+    ...        '|-------|----------|---------------|---------|--------------|',
+    ...        '| ExpCM | 0.00     | -1000.00      | 7       | x=1.0, y=2.0 |',
+    ...        '| YNGKP | 10.2     | -1005.10      | 7       | x=1.3, z=0.1 |',
     ...         ]))
     ...     f.flush()
     ...     df_split = modelComparisonDataFrame(f.name, splitparams=True)

--- a/phydmslib/utils.py
+++ b/phydmslib/utils.py
@@ -61,8 +61,8 @@ def modelComparisonDataFrame(modelcomparisonfile, splitparams):
     if splitparams:
         for (i, paramstr) in df['ParamValues'].iteritems():
             paramsdict[i] = dict(map(lambda tup: (tup[0], float(tup[1])),
-                                 [param.strip().split('=') for param in
-                                 paramstr.split(',')]))
+                                 (param.strip().split('=') for param in
+                                 paramstr.split(','))))
         params_df = pandas.DataFrame.from_dict(paramsdict, orient='index')
         params_df = params_df[sorted(params_df.columns)]
         df = (df.join(params_df)

--- a/phydmslib/utils.py
+++ b/phydmslib/utils.py
@@ -95,7 +95,7 @@ def BenjaminiHochbergCorrection(pvals, fdr):
     # find maximum rank for which p <= (rank/num_tests)*FDR
     max_rank = 0
     pcutoff = None
-    for (rank, (label, p)) in enumerate(sorted_tests):
+    for (rank, (_label, p)) in enumerate(sorted_tests):
         rank = rank + 1  # rank begins w/ 1 for smallest p-value ( no rank 0)
         bh_threshold = fdr * float(rank) / num_tests
         if p <= bh_threshold:

--- a/phydmslib/utils.py
+++ b/phydmslib/utils.py
@@ -2,8 +2,8 @@
 
 
 import pandas
-import tempfile
-import numpy
+import tempfile  # noqa: F401
+import numpy  # noqa: F401
 
 
 def modelComparisonDataFrame(modelcomparisonfile, splitparams):

--- a/phydmslib/weblogo.py
+++ b/phydmslib/weblogo.py
@@ -384,10 +384,10 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
             ydatamax *= 2.0
             f.write('ID ID\nBF BF\nP0 %s\n' % ' '.join(chars_for_string))
             for (isite, r) in enumerate(sites):
-                positivesum = sum([data[r][x] for x in characters
-                                   if data[r][x] > 0]) + separatorheight / 2.0
-                negativesum = sum([data[r][x] for x in characters
-                                   if data[r][x] < 0]) - separatorheight / 2.0
+                positivesum = sum((data[r][x] for x in characters
+                                   if data[r][x] > 0)) + separatorheight / 2.0
+                negativesum = sum((data[r][x] for x in characters
+                                   if data[r][x] < 0)) - separatorheight / 2.0
                 if abs(positivesum + negativesum) > 1.0e-3:
                     raise ValueError("Differential preferences sum of %s is "
                                      "not close to zero for site %s"
@@ -433,10 +433,10 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
             f.write('ID ID\nBF BF\nP0 {0}\n'
                     .format(' '.join(chars_for_string)))
             for (isite, r) in enumerate(sites):
-                positivesum = sum([data[r][x] for x in characters
-                                  if data[r][x] > 0]) + separatorheight / 2.0
-                negativesum = sum([data[r][x] for x in characters
-                                  if data[r][x] < 0]) - separatorheight / 2.0
+                positivesum = sum((data[r][x] for x in characters
+                                  if data[r][x] > 0)) + separatorheight / 2.0
+                negativesum = sum((data[r][x] for x in characters
+                                  if data[r][x] < 0)) - separatorheight / 2.0
                 assert positivesum <= dataymax, ("Data exceeds ylimits in "
                                                  "positive direction")
                 assert negativesum >= dataymin, ("Data exceeds ylimits in "
@@ -635,7 +635,7 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
 
 # Replicates README.txt
 def _my_pdf_formatter(data, pdfformat, ordered_alphabets):
-    """ Generate a logo in PDF format.
+    """Generate a logo in PDF format.
 
     Modified from weblogo version 3.4 source code.
     """
@@ -645,7 +645,7 @@ def _my_pdf_formatter(data, pdfformat, ordered_alphabets):
 
 
 def _my_eps_formatter(logodata, format, ordered_alphabets):
-    """ Generate a logo in Encapsulated Postscript (EPS)
+    """Generate a logo in Encapsulated Postscript (EPS)
 
     Modified from weblogo version 3.4 source code.
 
@@ -865,10 +865,9 @@ class _my_Motif(corebio.matrix.AlphabeticArray):
 
     @staticmethod  # TODO: should be classmethod?
     def read_transfac(fin, alphabet=None):
-        """ Parse a sequence matrix from a file.
+        """Parse a sequence matrix from a file.
         Returns a tuple of (alphabet, matrix)
         """
-
         items = []
 
         start = True
@@ -1053,18 +1052,18 @@ def LogoOverlay(sites, overlayfile, overlay, nperline, sitewidth, rmargin,
     prop_types = {}
     for (prop_d, shortname, longname) in overlay:
         if shortname == longname == 'wildtype':
-            assert all([(isinstance(prop, str) and len(prop) == 1) for
-                        prop in prop_d.values()]),\
+            assert all(((isinstance(prop, str) and len(prop) == 1) for
+                        prop in prop_d.values())),\
                         'prop_d does not give letters'
             proptype = 'wildtype'
             (vmin, vmax) = (0, 1)  # not used, but need to be assigned
             propcategories = None  # not used, but needs to be assigned
-        elif all([isinstance(prop, str) for prop in prop_d.values()]):
+        elif all((isinstance(prop, str) for prop in prop_d.values())):
             proptype = 'discrete'
             propcategories = list(set(prop_d.values()))
             propcategories.sort()
             (vmin, vmax) = (0, len(propcategories) - 1)
-        elif all([isinstance(prop, (int, float)) for prop in prop_d.values()]):
+        elif all((isinstance(prop, (int, float)) for prop in prop_d.values())):
             proptype = 'continuous'
             propcategories = None
             (vmin, vmax) = (min(prop_d.values()), max(prop_d.values()))
@@ -1238,7 +1237,7 @@ def LogoOverlay(sites, overlayfile, overlay, nperline, sitewidth, rmargin,
                                 orientation='horizontal',
                                 boundaries=list(range(len(propcategories) + 1)
                                                 ),
-                                values=[i for i in range(len(propcategories))])
+                                values=list(range(len(propcategories))))
             cb.set_ticks([i + 0.5 for i in range(len(propcategories))])
             cb.set_ticklabels(propcategories)
         else:

--- a/phydmslib/weblogo.py
+++ b/phydmslib/weblogo.py
@@ -158,10 +158,10 @@ def FunctionalGroupColorMapping(maptype='jet', reverse=False):
 
 def LogoPlot(sites, datatype, data, plotfile, nperline,
              numberevery=10, allowunsorted=False, ydatamax=1.01,
-             overlay=None, fix_limits={}, fixlongname=False,
-             overlay_cmap=None, ylimits=None, relativestackheight=1,
-             custom_cmap='jet', map_metric='kd', noseparator=False,
-             underlay=False, scalebar=False):
+             overlay=None, fix_limits={},  # noqa: F401
+             fixlongname=False, overlay_cmap=None, ylimits=None,
+             relativestackheight=1, custom_cmap='jet', map_metric='kd',
+             noseparator=False, underlay=False, scalebar=False):
     """Create sequence logo showing amino-acid or nucleotide preferences.
 
     The heights of each letter is equal to the preference of
@@ -284,7 +284,7 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
       colormapping.
 
     * *noseparator* is only meaningful if *datatype* is 'diffsel' or
-      'diffprefs'.  If it set to *True*, then we do **not** print a black
+      'diffprefs'.  If it set to *True*, then we do **not** a black
       horizontal line to separate positive and negative values.
 
     * *underlay* if `True` then make an underlay rather than an overlay.
@@ -976,7 +976,7 @@ class _my_Motif(corebio.matrix.AlphabeticArray):
 
 
 def LogoOverlay(sites, overlayfile, overlay, nperline, sitewidth, rmargin,
-                logoheight, barheight, barspacing, fix_limits={},
+                logoheight, barheight, barspacing, fix_limits={},  # noqa: F401
                 fixlongname=False, overlay_cmap=None, underlay=False,
                 scalebar=False):
     """Makes overlay for *LogoPlot*.

--- a/phydmslib/weblogo.py
+++ b/phydmslib/weblogo.py
@@ -24,11 +24,12 @@ matplotlib.use('pdf')
 import pylab
 import PyPDF2
 # the following are part of the weblogo library
-import weblogolib # weblogo library
-import weblogolib.colorscheme # weblogo library
-import corebio.matrix # weblogo library
-import corebio.utils # weblogo library
-from phydmslib.constants import *
+import weblogolib  # weblogo library
+import weblogolib.colorscheme  # weblogo library
+import corebio.matrix  # weblogo library
+import corebio.utils  # weblogo library
+from phydmslib.constants import AA_TO_INDEX, NT_TO_INDEX
+matplotlib.use('pdf', warn=False)
 
 
 def KyteDoolittleColorMapping(maptype='jet', reverse=True):
@@ -37,11 +38,11 @@ def KyteDoolittleColorMapping(maptype='jet', reverse=True):
     Uses the Kyte-Doolittle hydrophobicity scale defined by::
 
         J. Kyte & R. F. Doolittle:
-        "A simple method for displaying the hydropathic character of a protein."
-        J Mol Biol, 157, 105-132
+        "A simple method for displaying the hydropathic character of a
+        protein." J Mol Biol, 157, 105-132
 
-    More positive values indicate higher hydrophobicity, while more negative values
-    indicate lower hydrophobicity.
+    More positive values indicate higher hydrophobicity,
+    while more negative values indicate lower hydrophobicity.
 
     The returned variable is the 3-tuple *(cmap, mapping_d, mapper)*:
 
@@ -54,25 +55,25 @@ def KyteDoolittleColorMapping(maptype='jet', reverse=True):
 
         * *mapper* is the actual *pylab.cm.ScalarMappable* object.
 
-    The optional calling argument *maptype* should specify a valid ``pylab`` color map.
+    The optional argument *maptype* should specify a valid ``pylab`` color map.
 
     The optional calling argument *reverse* specifies that we set up the color
     map so that the most hydrophobic residue comes first (in the Kyte-Doolittle
-    scale the most hydrophobic comes last as it has the largest value). This option
-    is *True* by default as it seems more intuitive to have charged residues red
-    and hydrophobic ones blue.
+    scale the most hydrophobic comes last as it has the largest value).
+    This option is *True* by default as it seems more intuitive to have
+    charged residues red and hydrophobic ones blue.
     """
-    d = {'A':1.8, 'C':2.5, 'D':-3.5, 'E':-3.5, 'F':2.8, 'G':-0.4,\
-         'H':-3.2, 'I':4.5, 'K':-3.9, 'L':3.8, 'M':1.9, 'N':-3.5,\
-         'P':-1.6, 'Q':-3.5, 'R':-4.5, 'S':-0.8, 'T':-0.7,\
-         'V':4.2, 'W':-0.9, 'Y':-1.3}
+    d = {'A': 1.8, 'C': 2.5, 'D': -3.5, 'E': -3.5, 'F': 2.8, 'G': -0.4,
+         'H': -3.2, 'I': 4.5, 'K': -3.9, 'L': 3.8, 'M': 1.9, 'N': -3.5,
+         'P': -1.6, 'Q': -3.5, 'R': -4.5, 'S': -0.8, 'T': -0.7, 'V': 4.2,
+         'W': -0.9, 'Y': -1.3}
     aas = sorted(AA_TO_INDEX.keys())
     hydrophobicities = [d[aa] for aa in aas]
     if reverse:
         hydrophobicities = [-1 * x for x in hydrophobicities]
     mapper = pylab.cm.ScalarMappable(cmap=maptype)
     mapper.set_clim(min(hydrophobicities), max(hydrophobicities))
-    mapping_d = {'*':'#000000'}
+    mapping_d = {'*': '#000000'}
     for (aa, h) in zip(aas, hydrophobicities):
         tup = mapper.to_rgba(h, bytes=True)
         (red, green, blue, alpha) = tup
@@ -81,21 +82,22 @@ def KyteDoolittleColorMapping(maptype='jet', reverse=True):
     cmap = mapper.get_cmap()
     return (cmap, mapping_d, mapper)
 
+
 def MWColorMapping(maptype='jet', reverse=True):
     """Maps amino-acid molecular weights to colors. Otherwise, this
     function is identical to *KyteDoolittleColorMapping*
     """
-    d = {'A':89,'R':174,'N':132,'D':133,'C':121,'Q':146,'E':147,\
-         'G':75,'H':155,'I':131,'L':131,'K':146,'M':149,'F':165,\
-         'P':115,'S':105,'T':119,'W':204,'Y':181,'V':117}
+    d = {'A': 89, 'R': 174, 'N': 132, 'D': 133, 'C': 121, 'Q': 146, 'E': 147,
+         'G': 75, 'H': 155, 'I': 131, 'L': 131, 'K': 146, 'M': 149, 'F': 165,
+         'P': 115, 'S': 105, 'T': 119, 'W': 204, 'Y': 181, 'V': 117}
 
     aas = sorted(AA_TO_INDEX.keys())
-    mws  = [d[aa] for aa in aas]
+    mws = [d[aa] for aa in aas]
     if reverse:
         mws = [-1 * x for x in mws]
     mapper = pylab.cm.ScalarMappable(cmap=maptype)
     mapper.set_clim(min(mws), max(mws))
-    mapping_d = {'*':'#000000'}
+    mapping_d = {'*': '#000000'}
     for (aa, h) in zip(aas, mws):
         tup = mapper.to_rgba(h, bytes=True)
         (red, green, blue, alpha) = tup
@@ -104,9 +106,11 @@ def MWColorMapping(maptype='jet', reverse=True):
     cmap = mapper.get_cmap()
     return (cmap, mapping_d, mapper)
 
+
 def SingleColorMapping(maptype="#999999"):
     """Maps all amino acids to the single color given by `maptype`."""
     return (None, collections.defaultdict(lambda: maptype), None)
+
 
 def ChargeColorMapping(maptype='jet', reverse=False):
     """Maps amino-acid charge at neutral pH to colors.
@@ -118,15 +122,16 @@ def ChargeColorMapping(maptype='jet', reverse=False):
     neg_color = '#0000FF'
     neut_color = '#000000'
 
-    mapping_d = {'A':neut_color,'R':pos_color,'N':neut_color,\
-                 'D':neg_color,'C':neut_color,'Q':neut_color,\
-                 'E':neg_color,'G':neut_color,'H':pos_color,\
-                 'I':neut_color,'L':neut_color,'K':pos_color,\
-                 'M':neut_color,'F':neut_color,'P':neut_color,\
-                 'S':neut_color,'T':neut_color,'W':neut_color,\
-                 'Y':neut_color,'V':neut_color}
+    mapping_d = {'A': neut_color, 'R': pos_color, 'N': neut_color,
+                 'D': neg_color, 'C': neut_color, 'Q': neut_color,
+                 'E': neg_color, 'G': neut_color, 'H': pos_color,
+                 'I': neut_color, 'L': neut_color, 'K': pos_color,
+                 'M': neut_color, 'F': neut_color, 'P': neut_color,
+                 'S': neut_color, 'T':  neut_color, 'W': neut_color,
+                 'Y': neut_color, 'V': neut_color}
 
     return (None, mapping_d, None)
+
 
 def FunctionalGroupColorMapping(maptype='jet', reverse=False):
     """Maps amino-acid functional groups to colors.
@@ -143,23 +148,25 @@ def FunctionalGroupColorMapping(maptype='jet', reverse=False):
     amide_color = '#972aa8'
     basic_color = '#3c58e5'
 
-    mapping_d = {'G':small_color, 'A':small_color,
-                 'S':nucleophilic_color, 'T':nucleophilic_color, 'C':nucleophilic_color,
-                 'V':hydrophobic_color, 'L':hydrophobic_color, 'I':hydrophobic_color, 'M':hydrophobic_color, 'P':hydrophobic_color,
-                 'F':aromatic_color, 'Y':aromatic_color, 'W':aromatic_color,
-                 'D':acidic_color, 'E':acidic_color,
-                 'H':basic_color, 'K':basic_color, 'R':basic_color,
-                 'N':amide_color, 'Q':amide_color,
-                 '*':'#000000'}
+    mapping_d = {'G': small_color, 'A': small_color,
+                 'S': nucleophilic_color, 'T': nucleophilic_color,
+                 'C': nucleophilic_color, 'V': hydrophobic_color,
+                 'L': hydrophobic_color, 'I': hydrophobic_color,
+                 'M': hydrophobic_color, 'P': hydrophobic_color,
+                 'F': aromatic_color, 'Y': aromatic_color,
+                 'W': aromatic_color, 'D': acidic_color, 'E': acidic_color,
+                 'H': basic_color, 'K': basic_color, 'R': basic_color,
+                 'N': amide_color, 'Q': amide_color,
+                 '*': '#000000'}
     return (None, mapping_d, None)
 
 
 def LogoPlot(sites, datatype, data, plotfile, nperline,
-        numberevery=10, allowunsorted=False, ydatamax=1.01,
-        overlay=None, fix_limits={}, fixlongname=False,
-        overlay_cmap=None, ylimits=None, relativestackheight=1,
-        custom_cmap='jet', map_metric='kd', noseparator=False,
-        underlay=False, scalebar=False):
+             numberevery=10, allowunsorted=False, ydatamax=1.01,
+             overlay=None, fix_limits={}, fixlongname=False,
+             overlay_cmap=None, ylimits=None, relativestackheight=1,
+             custom_cmap='jet', map_metric='kd', noseparator=False,
+             underlay=False, scalebar=False):
     """Create sequence logo showing amino-acid or nucleotide preferences.
 
     The heights of each letter is equal to the preference of
@@ -196,7 +203,8 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
       of the logo plot.
       It must end in the extension ``.pdf``.
 
-    * *nperline* is the number of sites per line. Often 40 to 80 are good values.
+    * *nperline* is the number of sites per line. Often 40 to 80 are
+       good values.
 
     * *numberevery* is specifies how frequently we put labels for the sites on
       x-axis.
@@ -205,9 +213,10 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
       **not** be sorted. This means that the logo plot will **not** have
       sites in sorted order.
 
-    * *ydatamax* : meaningful only if *datatype* is 'diffprefs'. In this case, it gives
-      the maximum that the logo stacks extend in the positive and negative directions.
-      Cannot be smaller than the maximum extent of the differential preferences.
+    * *ydatamax* : meaningful only if *datatype* is 'diffprefs'. In this case,
+      it gives the maximum that the logo stacks extend in the positive and
+      negative directions. Cannot be smaller than the maximum extent of the
+      differential preferences.
 
     * *ylimits*: is **mandatory** if *datatype* is 'diffsel', and meaningless
       otherwise. It is *(ymin, ymax)* where *ymax > 0 > ymin*, and gives extent
@@ -241,41 +250,47 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
           right the one-character wildtype identity in `prop_d` for each
           site.
 
-    * *fix_limits* is only meaningful if *overlay* is being used. In this case, for any
-      *shortname* in *overlay* that also keys an entry in *fix_limits*, we use
-      *fix_limits[shortname]* to set the limits for *shortname*. Specifically,
-      *fix_limits[shortname]* should be the 2-tuple *(ticks, ticknames)*. *ticks*
-      should be a list of tick locations (numbers) and *ticknames* should be a list of
-      the corresponding tick label for that tick.
+    * *fix_limits* is only meaningful if *overlay* is being used. In this case,
+       for any *shortname* in *overlay* that also keys an entry in
+       *fix_limits*, we use *fix_limits[shortname]* to set the limits for
+       *shortname*. Specifically, *fix_limits[shortname]* should be the 2-tuple
+       *(ticks, ticknames)*. *ticks* should be a list of tick locations
+       (numbers) and *ticknames* should be a list of the corresponding tick
+       label for that tick.
 
-    * If *fixlongname* is *True*, then we use the *longname* in *overlay* exactly as written;
-      otherwise we add a parenthesis indicating the *shortname* for which this *longname*
-      stands.
+    * If *fixlongname* is *True*, then we use the *longname* in *overlay*
+      exactly as written; otherwise we add a parenthesis indicating the
+      *shortname* for which this *longname* stands.
 
-    * *overlay_cmap* can be the name of a valid *matplotlib.colors.Colormap*, such as the
-      string *jet* or *bwr*. Otherwise, it can be *None* and a (hopefully) good choice will
-      be made for you.
+    * *overlay_cmap* can be the name of a valid *matplotlib.colors.Colormap*,
+      such as the string *jet* or *bwr*. Otherwise, it can be *None* and a
+      (hopefully) good choice will be made for you.
 
-    * *custom_cmap* can be the name of a valid *matplotlib.colors.Colormap* which will be
-      used to color amino-acid one-letter codes in the logoplot by the *map_metric* when
-      either 'kd' or 'mw' is used as *map_metric*. If *map_metric* is 'singlecolor',
-      then should be string giving the color to plot.
+    * *custom_cmap* can be the name of a valid *matplotlib.colors.Colormap*
+      which will be used to color amino-acid one-letter codes in the logoplot
+      by the *map_metric* when either 'kd' or 'mw' is used as *map_metric*.
+      If *map_metric* is 'singlecolor', then should be string giving the color
+      to plot.
 
     * *relativestackheight* indicates how high the letter stack is relative to
       the default. The default is multiplied by this number, so make it > 1
       for a higher letter stack.
 
-    * *map_metric* specifies the amino-acid property metric used to map colors to amino-acid
-      letters. Valid options are 'kd' (Kyte-Doolittle hydrophobicity scale, default), 'mw'
-      (molecular weight), 'functionalgroup' (functional groups: small, nucleophilic, hydrophobic,
-      aromatic, basic, acidic, and amide), 'charge' (charge at neutral pH), and
-      'singlecolor'. If 'charge' is used, then the
-      argument for *custom_cmap* will no longer be meaningful, since 'charge' uses its own
-      blue/black/red colormapping. Similarly, 'functionalgroup' uses its own colormapping.
+    * *map_metric* specifies the amino-acid property metric used to map colors
+      to amino-acid letters. Valid options are
+      'kd'(Kyte-Doolittle hydrophobicity scale, default),
+      'mw' (molecular weight),
+      'functionalgroup' (functional groups: small, nucleophilic, hydrophobic,
+      aromatic, basic, acidic, and amide),
+      'charge' (charge at neutral pH), and
+      'singlecolor'. If 'charge' is used, then the argument for *custom_cmap*
+      will no longer be meaningful, since 'charge' uses its own
+      blue/black/red colormapping. Similarly, 'functionalgroup' uses its own
+      colormapping.
 
-    * *noseparator* is only meaningful if *datatype* is 'diffsel' or 'diffprefs'.
-      If it set to *True*, then we do **not** print a black horizontal line to
-      separate positive and negative values.
+    * *noseparator* is only meaningful if *datatype* is 'diffsel' or
+      'diffprefs'.  If it set to *True*, then we do **not** print a black
+      horizontal line to separate positive and negative values.
 
     * *underlay* if `True` then make an underlay rather than an overlay.
 
@@ -283,11 +298,14 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
       should be a 2-tuple of `(scalebarlen, scalebarlabel)`. Currently only
       works when data is `diffsel`.
     """
-    assert datatype in ['prefs', 'diffprefs', 'diffsel'], "Invalid datatype {0}".format(datatype)
+    assert datatype in ['prefs', 'diffprefs', 'diffsel'], ("Invalid datatype "
+                                                           "{0}"
+                                                           .format(datatype))
 
     # check data, and get characters
     assert sites, "No sites specified"
-    assert set(sites) == set(data.keys()), "Not a match between sites and the keys of data"
+    assert set(sites) == set(data.keys()), ("Not a match between "
+                                            "sites and the keys of data")
     characters = list(data[sites[0]].keys())
     aas = sorted(AA_TO_INDEX.keys())
     if set(characters) == set(NT_TO_INDEX.keys()):
@@ -295,75 +313,97 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
     elif set(characters) == set(aas) or set(characters) == set(aas + ['*']):
         alphabet_type = 'aa'
     else:
-        raise ValueError("Invalid set of characters in data. Does not specify either nucleotides or amino acids:\n%s" % str(characters))
+        raise ValueError("Invalid set of characters in data. Does not specify "
+                         "either nucleotides or amino acids:\n{0}"
+                         .format(str(characters)))
     for r in sites:
         if set(data[r].keys()) != set(characters):
-            raise ValueError("Not all sites in data have the same set of characters")
+            raise ValueError("Not all sites in data have the same "
+                             "set of characters")
 
-    firstblankchar = 'B' # character for first blank space for diffprefs / diffsel
+    firstblankchar = 'B'  # char for first blank space for diffprefs / diffsel
     assert firstblankchar not in characters, "firstblankchar in characters"
-    lastblankchar = 'b' # character for last blank space for diffprefs / diffsel
+    lastblankchar = 'b'  # char for last blank space for diffprefs / diffsel
     assert lastblankchar not in characters, "lastblankchar in characters"
-    separatorchar = '-' # separates positive and negative for diffprefs / diffsel
+    separatorchar = '-'  # separates pos and neg for diffprefs / diffsel
     assert separatorchar not in characters, "lastblankchar in characters"
-    if noseparator:
-        separatorheight = 0
-    else:
-        separatorheight = 0.02 # height of separator as frac of total for diffprefs / diffsel
+    # height of separator as frac of total for diffprefs / diffsel
+    separatorheight = 0 if noseparator else 0.02
 
     if os.path.splitext(plotfile)[1].lower() != '.pdf':
         raise ValueError("plotfile must end in .pdf: %s" % plotfile)
     if os.path.isfile(plotfile):
-        os.remove(plotfile) # remove existing plot
+        os.remove(plotfile)  # remove existing plot
 
     if not allowunsorted:
         sorted_sites = natsort.natsorted([r for r in sites])
         if sorted_sites != sites:
             raise ValueError("sites is not properly sorted")
 
-    # Following are specifications of weblogo sizing taken from its documentation
-    stackwidth = 9.5 # stack width in points, not default size of 10.8, but set to this in weblogo call below
-    barheight = 5.5 # height of bars in points if using overlay
-    barspacing = 2.0 # spacing between bars in points if using overlay
-    stackaspectratio = 4.4 # ratio of stack height:width, doesn't count part going over maximum value of 1
+    # Following are specifications of weblogo sizing taken from its docs
+    # stack width in points, set to this in weblogo call below (default 10.8)
+    stackwidth = 9.5
+    barheight = 5.5  # height of bars in points if using overlay
+    barspacing = 2.0  # spacing between bars in points if using overlay
+    # ratio of stack height:width, doesn't count part going over max value of 1
+    stackaspectratio = 4.4
     assert relativestackheight > 0, "relativestackheight must be > 0"
     stackaspectratio *= relativestackheight
     if overlay:
         if len(overlay) > 3:
             raise ValueError("overlay cannot have more than 3 entries")
-        ymax = (stackaspectratio * stackwidth + len(overlay) * (barspacing + barheight)) / float(stackaspectratio * stackwidth)
-        aspectratio = ymax * stackaspectratio # effective aspect ratio for full range
+        ymax = ((stackaspectratio * stackwidth + len(overlay) *
+                (barspacing + barheight)) /
+                float(stackaspectratio * stackwidth))
+        # effective aspect ratio for full range
+        aspectratio = ymax * stackaspectratio
     else:
         ymax = 1.0
         aspectratio = stackaspectratio
-    rmargin = 11.5 # right margin in points, fixed by weblogo
-    stackheightmargin = 16 # margin between stacks in points, fixed by weblogo
+    rmargin = 11.5  # right margin in points, fixed by weblogo
+    stackheightmargin = 16  # margin between stacks in points, fixed by weblogo
 
     showscalebar = False
     try:
         # write data into transfacfile (a temporary file)
         (fd, transfacfile) = tempfile.mkstemp()
         f = os.fdopen(fd, 'w')
-        ordered_alphabets = {} # keyed by site index (0, 1, ...) with values ordered lists for characters from bottom to top
+        # keyed by site index (0, 1, ...)
+        # with values ordered lists for characters from bottom to top
+        ordered_alphabets = {}
         if datatype == 'prefs':
             chars_for_string = characters
             f.write('ID ID\nBF BF\nP0 %s\n' % ' '.join(chars_for_string))
             for (isite, r) in enumerate(sites):
-                f.write('%d %s\n' % (isite, ' '.join([str(data[r][x]) for x in characters])))
+                f.write('%d %s\n' % (isite, ' '.join([str(data[r][x])
+                                                      for x in characters])))
                 pi_r = [(data[r][x], x) for x in characters]
                 pi_r.sort()
-                ordered_alphabets[isite] = [tup[1] for tup in pi_r] # order from smallest to biggest
+                # order from smallest to biggest
+                ordered_alphabets[isite] = [tup[1] for tup in pi_r]
         elif datatype == 'diffprefs':
-            chars_for_string = characters + [firstblankchar, lastblankchar, separatorchar]
-            ydatamax *= 2.0 # maximum possible range of data, multiply by two for range
+            chars_for_string = characters + [firstblankchar,
+                                             lastblankchar,
+                                             separatorchar]
+            # maximum possible range of data, multiply by two for range
+            ydatamax *= 2.0
             f.write('ID ID\nBF BF\nP0 %s\n' % ' '.join(chars_for_string))
             for (isite, r) in enumerate(sites):
-                positivesum = sum([data[r][x] for x in characters if data[r][x] > 0]) + separatorheight / 2.0
-                negativesum = sum([data[r][x] for x in characters if data[r][x] < 0]) - separatorheight / 2.0
+                positivesum = sum([data[r][x] for x in characters
+                                   if data[r][x] > 0]) + separatorheight / 2.0
+                negativesum = sum([data[r][x] for x in characters
+                                   if data[r][x] < 0]) - separatorheight / 2.0
                 if abs(positivesum + negativesum) > 1.0e-3:
-                    raise ValueError("Differential preferences sum of %s is not close to zero for site %s" % (positivesum + negativesum, r))
+                    raise ValueError("Differential preferences sum of %s is "
+                                     "not close to zero for site %s"
+                                     % (positivesum + negativesum, r))
                 if 2.0 * positivesum > ydatamax:
-                    raise ValueError("You need to increase ydatamax: the total differential preferences sum to more than the y-axis limits. Right now, ydatamax is %.3f while the total differential preferences are %.3f" % (ydatamax, 2.0 * positivesum))
+                    raise ValueError("You need to increase ydatamax: the "
+                                     "total differential preferences sum to "
+                                     "more than the y-axis limits. Right now, "
+                                     "ydatamax is %.3f while the total "
+                                     "differential preferences are %.3f"
+                                     % (ydatamax, 2.0 * positivesum))
                 f.write('%d' % isite)
                 deltapi_r = []
                 for x in characters:
@@ -373,21 +413,39 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
                 firstpositiveindex = 0
                 while deltapi_r[firstpositiveindex][0] < 0:
                     firstpositiveindex += 1
-                ordered_alphabets[isite] = [firstblankchar] + [tup[1] for tup in deltapi_r[ : firstpositiveindex]] + [separatorchar] + [tup[1] for tup in deltapi_r[firstpositiveindex : ]] + [lastblankchar] # order from most negative to most positive with blank characters and separators
-                f.write(' %g %g %g\n' % (0.5 * (ydatamax + 2.0 * negativesum) / ydatamax, 0.5 * (ydatamax + 2.0 * negativesum) / ydatamax, separatorheight)) # heights for blank charactors and separators
+                # order from most neg to most pos w/ blank characters and seps
+                ordered_alphabets[isite] = ([firstblankchar] +
+                                            [tup[1] for tup in
+                                             deltapi_r[:firstpositiveindex]] +
+                                            [separatorchar] +
+                                            [tup[1] for tup in
+                                             deltapi_r[firstpositiveindex:]] +
+                                            [lastblankchar])
+                f.write(' %g %g %g\n'
+                        % (0.5 * (ydatamax + 2.0 * negativesum) / ydatamax,
+                           0.5 * (ydatamax + 2.0 * negativesum) / ydatamax,
+                           separatorheight))  # heights for blank chars & seps
         elif datatype == 'diffsel':
             assert ylimits, "You must specify ylimits if using diffsel"
             (dataymin, dataymax) = ylimits
-            assert dataymax > 0 > dataymin, "Invalid ylimits of {0}".format(ylimits)
+            assert dataymax > 0 > dataymin, ("Invalid ylimits of {0}"
+                                             .format(ylimits))
             yextent = float(dataymax - dataymin)
             separatorheight *= yextent
-            chars_for_string = characters + [firstblankchar, lastblankchar, separatorchar]
-            f.write('ID ID\nBF BF\nP0 {0}\n'.format(' '.join(chars_for_string)))
+            chars_for_string = characters + [firstblankchar,
+                                             lastblankchar,
+                                             separatorchar]
+            f.write('ID ID\nBF BF\nP0 {0}\n'
+                    .format(' '.join(chars_for_string)))
             for (isite, r) in enumerate(sites):
-                positivesum = sum([data[r][x] for x in characters if data[r][x] > 0]) + separatorheight / 2.0
-                negativesum = sum([data[r][x] for x in characters if data[r][x] < 0]) - separatorheight / 2.0
-                assert positivesum <= dataymax, "Data exceeds ylimits in positive direction"
-                assert negativesum >= dataymin, "Data exceeds ylimits in negative direction"
+                positivesum = sum([data[r][x] for x in characters
+                                  if data[r][x] > 0]) + separatorheight / 2.0
+                negativesum = sum([data[r][x] for x in characters
+                                  if data[r][x] < 0]) - separatorheight / 2.0
+                assert positivesum <= dataymax, ("Data exceeds ylimits in "
+                                                 "positive direction")
+                assert negativesum >= dataymin, ("Data exceeds ylimits in "
+                                                 "negative direction")
                 f.write('{0}'.format(isite))
                 diffsel_r = []
                 for x in characters:
@@ -397,8 +455,19 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
                 firstpositiveindex = 0
                 while diffsel_r[firstpositiveindex][0] < 0:
                     firstpositiveindex += 1
-                ordered_alphabets[isite] = [firstblankchar] + [tup[1] for tup in diffsel_r[ : firstpositiveindex]] + [separatorchar] + [tup[1] for tup in diffsel_r[firstpositiveindex : ]] + [lastblankchar] # order from most negative to most positive with blank characters and separators
-                f.write(' %g %g %g\n' % ((negativesum - dataymin) / yextent, (dataymax - positivesum) / yextent, separatorheight / yextent)) # heights for blank charactors and separators
+                # order from most neg to most pos with blank chars and seps
+                ordered_alphabets[isite] = ([firstblankchar] +
+                                            [tup[1] for tup in
+                                             diffsel_r[:firstpositiveindex]] +
+                                            [separatorchar] +
+                                            [tup[1] for tup in
+                                             diffsel_r[firstpositiveindex:]] +
+                                            [lastblankchar])
+                # heights for blank charactors and separators
+                f.write(' %g %g %g\n'
+                        % ((negativesum - dataymin) / yextent,
+                           (dataymax - positivesum) / yextent,
+                           separatorheight / yextent))
             # height of one unit on y-axis in points
             heightofone = stackwidth * stackaspectratio / yextent
             assert heightofone > 0
@@ -410,10 +479,15 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
 
         # create web logo
         charstring = ''.join(chars_for_string)
-        assert len(charstring) == len(chars_for_string), "Length of charstring doesn't match length of chars_for_string. Do you have unallowable multi-letter characters?\n%s" % (str(chars_for_string))
+        assert len(charstring) == len(chars_for_string),\
+               ("Length of charstring doesn't match length of "
+                "chars_for_string. Do you have unallowable multi-letter "
+                "characters?\n%s"
+                % (str(chars_for_string)))
         logoprior = weblogolib.parse_prior('equiprobable', charstring, 0)
         motif = _my_Motif.read_transfac(open(transfacfile), charstring)
-        logodata = weblogolib.LogoData.from_counts(motif.alphabet, motif, logoprior)
+        logodata = weblogolib.LogoData.from_counts(motif.alphabet,
+                                                   motif, logoprior)
         logo_options = weblogolib.LogoOptions()
         logo_options.fineprint = None
         logo_options.stacks_per_line = nperline
@@ -423,10 +497,10 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
         logo_options.show_yaxis = False
         logo_options.yaxis_scale = ymax
         if alphabet_type == 'aa':
-            map_functions = {'kd':KyteDoolittleColorMapping,
+            map_functions = {'kd': KyteDoolittleColorMapping,
                              'mw': MWColorMapping,
-                             'charge' : ChargeColorMapping,
-                             'functionalgroup':FunctionalGroupColorMapping,
+                             'charge': ChargeColorMapping,
+                             'functionalgroup': FunctionalGroupColorMapping,
                              'singlecolor': SingleColorMapping}
             map_fcn = map_functions[map_metric]
             (cmap, colormapping, mapper) = map_fcn(maptype=custom_cmap)
@@ -438,24 +512,29 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
             colormapping['G'] = '#FFA500'
         else:
             raise ValueError("Invalid alphabet_type %s" % alphabet_type)
-        colormapping[firstblankchar] = colormapping[lastblankchar] = '#000000' # black, but color doesn't matter as modified weblogo code replaces with empty space
-        colormapping[separatorchar] = '#000000' # black
+        # black but doesn't matter. modified weblogo code replaces w/ empty ' '
+        colormapping[firstblankchar] = colormapping[lastblankchar] = '#000000'
+        colormapping[separatorchar] = '#000000'  # black
         color_scheme = weblogolib.colorscheme.ColorScheme()
         for x in chars_for_string:
             if hasattr(color_scheme, 'rules'):
-                color_scheme.rules.append(weblogolib.colorscheme.SymbolColor(x, colormapping[x], "'%s'" % x))
+                color_scheme.rules.append((weblogolib.colorscheme.SymbolColor(
+                                           x, colormapping[x], "'%s'" % x)))
             else:
                 # this part is needed for weblogo 3.4
-                color_scheme.groups.append(weblogolib.colorscheme.ColorGroup(x, colormapping[x], "'%s'" % x))
+                color_scheme.groups.append((weblogolib.colorscheme.ColorGroup(
+                                            x, colormapping[x], "'%s'" % x)))
         logo_options.color_scheme = color_scheme
-        logo_options.annotate = [{True:r, False:''}[0 == isite % numberevery] for (isite, r) in enumerate(sites)]
+        logo_options.annotate = [{True: r, False: ''}[0 == isite % numberevery]
+                                 for (isite, r) in enumerate(sites)]
         logoformat = weblogolib.LogoFormat(logodata, logo_options)
         # _my_pdf_formatter is modified from weblogo version 3.4 source code
         # to allow custom ordering of the symbols.
         pdf = _my_pdf_formatter(logodata, logoformat, ordered_alphabets)
         with open(plotfile, 'wb') as f:
             f.write(pdf)
-        assert os.path.isfile(plotfile), "Failed to find expected plotfile %s" % plotfile
+        assert os.path.isfile(plotfile), ("Failed to find expected plotfile %s"
+                                          % plotfile)
     finally:
         # close if still open
         try:
@@ -472,10 +551,15 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
             (fdoverlay, overlayfile) = tempfile.mkstemp(suffix='.pdf')
             (fdmerged, mergedfile) = tempfile.mkstemp(suffix='.pdf')
             foverlay = os.fdopen(fdoverlay, 'wb')
-            foverlay.close() # close, but we still have the path overlayfile...
+            foverlay.close()  # close, but we still have the path overlayfile
             fmerged = os.fdopen(fdmerged, 'wb')
             logoheight = stackwidth * stackaspectratio + stackheightmargin
-            LogoOverlay(sites, overlayfile, overlay, nperline, sitewidth=stackwidth, rmargin=rmargin, logoheight=logoheight, barheight=barheight, barspacing=barspacing, fix_limits=fix_limits, fixlongname=fixlongname, overlay_cmap=overlay_cmap, underlay=underlay, scalebar=showscalebar)
+            LogoOverlay(sites, overlayfile, overlay, nperline,
+                        sitewidth=stackwidth, rmargin=rmargin,
+                        logoheight=logoheight, barheight=barheight,
+                        barspacing=barspacing, fix_limits=fix_limits,
+                        fixlongname=fixlongname, overlay_cmap=overlay_cmap,
+                        underlay=underlay, scalebar=showscalebar)
             plotfile_f = open(plotfile, 'rb')
             plot = PyPDF2.PdfFileReader(plotfile_f).getPage(0)
             overlayfile_f = open(overlayfile, 'rb')
@@ -483,7 +567,7 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
             xshift = overlaypdf.artBox[2] - plot.artBox[2]
             yshift = (barheight + barspacing) * len(overlay) - 0.5 * barspacing
             overlaypdf.mergeTranslatedPage(plot, xshift,
-                    yshift * int(underlay), expand=True)
+                                           yshift * int(underlay), expand=True)
             overlaypdf.compressContentStreams()
             output = PyPDF2.PdfFileWriter()
             output.addPage(overlaypdf)
@@ -520,9 +604,9 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
 
 #  Copyright (c) 2003-2004 The Regents of the University of California.
 #  Copyright (c) 2005 Gavin E. Crooks
-#  Copyright (c) 2006-2011, The Regents of the University of California, through
-#  Lawrence Berkeley National Laboratory (subject to receipt of any required
-#  approvals from the U.S. Dept. of Energy).  All rights reserved.
+#  Copyright (c) 2006-2011, The Regents of the University of California,
+#  through Lawrence Berkeley National Laboratory (subject to receipt of any
+#  required approvals from the U.S. Dept. of Energy).  All rights reserved.
 
 #  This software is distributed under the new BSD Open Source License.
 #  <http://www.opensource.org/licenses/bsd-license.html>
@@ -555,8 +639,7 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
 #  POSSIBILITY OF SUCH DAMAGE.
 
 # Replicates README.txt
-
-def _my_pdf_formatter(data, format, ordered_alphabets) :
+def _my_pdf_formatter(data, format, ordered_alphabets):
     """ Generate a logo in PDF format.
 
     Modified from weblogo version 3.4 source code.
@@ -566,7 +649,7 @@ def _my_pdf_formatter(data, format, ordered_alphabets) :
     return gs.convert('pdf', eps, format.logo_width, format.logo_height)
 
 
-def _my_eps_formatter(logodata, format, ordered_alphabets) :
+def _my_eps_formatter(logodata, format, ordered_alphabets):
     """ Generate a logo in Encapsulated Postscript (EPS)
 
     Modified from weblogo version 3.4 source code.
@@ -576,10 +659,10 @@ def _my_eps_formatter(logodata, format, ordered_alphabets) :
     from bottom to top.
     """
     substitutions = {}
-    from_format =[
+    from_format = [
         "creation_date",    "logo_width",           "logo_height",
         "lines_per_logo",   "line_width",           "line_height",
-        "line_margin_right","line_margin_left",     "line_margin_bottom",
+        "line_margin_right", "line_margin_left",     "line_margin_bottom",
         "line_margin_top",  "title_height",         "xaxis_label_height",
         "creator_text",     "logo_title",           "logo_margin",
         "stroke_width",     "tic_length",
@@ -599,16 +682,15 @@ def _my_eps_formatter(logodata, format, ordered_alphabets) :
         "stack_width"
         ]
 
-    for s in from_format :
-        substitutions[s] = getattr(format,s)
+    for s in from_format:
+        substitutions[s] = getattr(format, s)
 
     substitutions["shrink"] = str(format.show_boxes).lower()
 
-
     # --------- COLORS --------------
     def format_color(color):
-        return  " ".join( ("[",str(color.red) , str(color.green),
-            str(color.blue), "]"))
+        return " ".join(("[", str(color.red), str(color.green),
+                         str(color.blue), "]"))
 
     substitutions["default_color"] = format_color(format.default_color)
 
@@ -620,40 +702,39 @@ def _my_eps_formatter(logodata, format, ordered_alphabets) :
         grouplist = format.color_scheme.groups
     for group in grouplist:
         cf = format_color(group.color)
-        for s in group.symbols :
-            colors.append( "  ("+s+") " + cf )
+        for s in group.symbols:
+            colors.append("  ("+s+") " + cf)
     substitutions["color_dict"] = "\n".join(colors)
 
     data = []
 
     # Unit conversion. 'None' for probability units
-    conv_factor = None #JDB
-    #JDB conv_factor = std_units[format.unit_name]
+    conv_factor = None  # JDB
+    # JDB conv_factor = std_units[format.unit_name]
 
     data.append("StartLine")
 
-    seq_from = format.logo_start- format.first_index
-    seq_to = format.logo_end - format.first_index +1
+    seq_from = format.logo_start - format.first_index
+    seq_to = format.logo_end - format.first_index + 1
 
     # seq_index : zero based index into sequence data
-    # logo_index : User visible coordinate, first_index based
     # stack_index : zero based index of visible stacks
-    for seq_index in range(seq_from, seq_to) :
-        logo_index = seq_index + format.first_index
+    for seq_index in range(seq_from, seq_to):
         stack_index = seq_index - seq_from
 
-        if stack_index!=0 and (stack_index % format.stacks_per_line) ==0 :
+        if stack_index != 0 and (stack_index % format.stacks_per_line) == 0:
             data.append("")
             data.append("EndLine")
             data.append("StartLine")
             data.append("")
 
-        data.append("(%s) StartStack" % format.annotate[seq_index] )
+        data.append("(%s) StartStack" % format.annotate[seq_index])
 
         if conv_factor:
-            stack_height = logodata.entropy[seq_index] * std_units[format.unit_name]
-        else :
-            stack_height = 1.0 # Probability
+            stack_height = (logodata.entropy[seq_index] *
+                            std_units[format.unit_name])
+        else:
+            stack_height = 1.0  # Probability
 
         # The following code modified by JDB to use ordered_alphabets
         # and also to replace the "blank" characters 'b' and 'B'
@@ -670,34 +751,36 @@ def _my_eps_formatter(logodata, format, ordered_alphabets) :
         # Sort by frequency. If equal frequency then reverse alphabetic
         # (So sort reverse alphabetic first, then frequencty)
         # TODO: doublecheck this actual works
-        #s = list(zip(logodata.counts[seq_index], logodata.alphabet))
-        #s.sort(key= lambda x: x[1])
-        #s.reverse()
-        #s.sort(key= lambda x: x[0])
-        #if not format.reverse_stacks: s.reverse()
+        # s = list(zip(logodata.counts[seq_index], logodata.alphabet))
+        # s.sort(key= lambda x: x[1])
+        # s.reverse()
+        # s.sort(key= lambda x: x[0])
+        # if not format.reverse_stacks: s.reverse()
 
         C = float(sum(logodata.counts[seq_index]))
-        if C > 0.0 :
+        if C > 0.0:
             fraction_width = 1.0
-            if format.scale_width :
+            if format.scale_width:
                 fraction_width = logodata.weight[seq_index]
             # print(fraction_width, file=sys.stderr)
             for c in s:
-                data.append(" %f %f (%s) ShowSymbol" % (fraction_width, c[0]*stack_height/C, c[1]) )
+                data.append(" %f %f (%s) ShowSymbol"
+                            % (fraction_width, c[0]*stack_height/C, c[1]))
 
         # Draw error bar on top of logo. Replaced by DrawErrorbarFirst above.
-        if logodata.entropy_interval is not None and conv_factor and C>0.0:
+        if logodata.entropy_interval is not None and conv_factor and C > 0.0:
 
             low, high = logodata.entropy_interval[seq_index]
             center = logodata.entropy[seq_index]
             low *= conv_factor
             high *= conv_factor
-            center *=conv_factor
-            if high> format.yaxis_scale : high = format.yaxis_scale
+            center *= conv_factor
+            if high > format.yaxis_scale:
+                high = format.yaxis_scale
 
             down = (center - low)
-            up   = (high - center)
-            data.append(" %f %f DrawErrorbar" % (down, up) )
+            up = (high - center)
+            data.append(" %f %f DrawErrorbar" % (down, up))
 
         data.append("EndStack")
         data.append("")
@@ -705,9 +788,10 @@ def _my_eps_formatter(logodata, format, ordered_alphabets) :
     data.append("EndLine")
     substitutions["logo_data"] = "\n".join(data)
 
-
     # Create and output logo
-    template = corebio.utils.resource_string( __name__, '_weblogo_template.eps', __file__).decode()
+    template = corebio.utils.resource_string(__name__,
+                                             '_weblogo_template.eps',
+                                             __file__).decode()
     logo = string.Template(template).substitute(substitutions)
 
     return logo.encode()
@@ -744,7 +828,7 @@ def _my_eps_formatter(logodata, format, ordered_alphabets) :
 #  IN THE SOFTWARE.
 
 
-class _my_Motif(corebio.matrix.AlphabeticArray) :
+class _my_Motif(corebio.matrix.AlphabeticArray):
     """A two dimensional array where the second dimension is indexed by an
     Alphabet. Used to represent sequence motifs and similar information.
 
@@ -758,8 +842,9 @@ class _my_Motif(corebio.matrix.AlphabeticArray) :
     """
 
     def __init__(self, alphabet, array=None, dtype=None, name=None,
-            description = None, scale=None) :
-        corebio.matrix.AlphabeticArray.__init__(self, (None, alphabet), array, dtype)
+                 description=None, scale=None):
+        corebio.matrix.AlphabeticArray.__init__(self,
+                                                (None, alphabet), array, dtype)
         self.name = name
         self.description = description
         self.scale = scale
@@ -768,35 +853,41 @@ class _my_Motif(corebio.matrix.AlphabeticArray) :
     def alphabet(self):
         return self.alphabets[1]
 
-    def reindex(self, alphabet) :
-        return  _my_Motif(alphabet, corebio.matrix.AlphabeticArray.reindex(self, (None, alphabet)))
+    def reindex(self, alphabet):
+        return _my_Motif(alphabet,
+                         corebio.matrix.AlphabeticArray.reindex(self,
+                                                                (None,
+                                                                 alphabet)))
 
     # These methods alter self, and therefore do not return a value.
-    # (Compare to Seq objects, where the data is immutable and therefore methods return a new Seq.)
+    # (Compare to Seq objects, where the data is immutable and
+    # therefore methods return a new Seq.)
     # TODO: Should reindex (above) also act on self?
 
     def reverse(self):
         """Reverse sequence data"""
-#        self.array = na.array(self.array[::-1]) # This is a view into the origional numpy array.
-        self.array = self.array[::-1] # This is a view into the origional numpy array.
+        self.array = self.array[::-1]  # view into the origional numpy array.
 
-    @staticmethod #TODO: should be classmethod?
-    def read_transfac( fin, alphabet = None) :
+    @staticmethod  # TODO: should be classmethod?
+    def read_transfac(fin, alphabet=None):
         """ Parse a sequence matrix from a file.
         Returns a tuple of (alphabet, matrix)
         """
 
         items = []
 
-        start=True
-        for line in fin :
-            if line.isspace() or line[0] =='#' : continue
+        start = True
+        for line in fin:
+            if line.isspace() or line[0] == '#':
+                continue
             stuff = line.split()
-            if start and stuff[0] != 'PO' and stuff[0] != 'P0': continue
-            if stuff[0]=='XX' or stuff[0]=='//': break
+            if start and stuff[0] != 'PO' and stuff[0] != 'P0':
+                continue
+            if stuff[0] == 'XX' or stuff[0] == '//':
+                break
             start = False
             items.append(stuff)
-        if len(items) < 2  :
+        if len(items) < 2:
             raise ValueError("Vacuous file.")
 
         # Is the first line a header line?
@@ -804,43 +895,45 @@ class _my_Motif(corebio.matrix.AlphabeticArray) :
         hcols = len(header)
         rows = len(items)
         cols = len(items[0])
-        if not( header[0] == 'PO' or header[0] =='P0' or hcols == cols-1 or hcols == cols-2) :
+        if not(header[0] == 'PO' or header[0] == 'P0' or
+               hcols == cols-1 or hcols == cols-2):
             raise ValueError("Missing header line!")
 
         # Do all lines (except the first) contain the same number of items?
         cols = len(items[0])
-        for i in range(1, len(items)) :
-            if cols != len(items[i]) :
+        for i in range(1, len(items)):
+            if cols != len(items[i]):
                 raise ValueError("Inconsistant length, row %d: " % i)
 
         # Vertical or horizontal arrangement?
-        if header[0] == 'PO' or header[0] == 'P0': header.pop(0)
+        if header[0] == 'PO' or header[0] == 'P0':
+            header.pop(0)
 
         position_header = True
         alphabet_header = True
-        for h in header :
-            if not corebio.utils.isint(h) : position_header = False
-#allow non-alphabetic            if not str.isalpha(h) : alphabet_header = False
+        for h in header:
+            if not corebio.utils.isint(h):
+                position_header = False
+# allow non-alphabetic if not str.isalpha(h) : alphabet_header = False
 
-        if not position_header and not alphabet_header :
+        if not position_header and not alphabet_header:
             raise ValueError("Can't parse header: %s" % str(header))
 
-        if position_header and alphabet_header :
+        if position_header and alphabet_header:
             raise ValueError("Can't parse header")
 
-
         # Check row headers
-        if alphabet_header :
-            for i,r in enumerate(items) :
-                if not corebio.utils.isint(r[0]) and r[0][0]!='P' :
+        if alphabet_header:
+            for i, r in enumerate(items):
+                if not corebio.utils.isint(r[0]) and r[0][0] != 'P':
                     raise ValueError(
                         "Expected position as first item on line %d" % i)
                 r.pop(0)
                 defacto_alphabet = ''.join(header)
-        else :
+        else:
             a = []
-            for i,r in enumerate(items) :
-                if not ischar(r[0]) and r[0][0]!='P' :
+            for i, r in enumerate(items):
+                if not ischar(r[0]) and r[0][0] != 'P':
                     raise ValueError(
                         "Expected position as first item on line %d" % i)
                 a.append(r.pop(0))
@@ -849,46 +942,47 @@ class _my_Motif(corebio.matrix.AlphabeticArray) :
         # Check defacto_alphabet
         defacto_alphabet = corebio.seq.Alphabet(defacto_alphabet)
 
-        if alphabet :
-            if not defacto_alphabet.alphabetic(alphabet) :
+        if alphabet:
+            if not defacto_alphabet.alphabetic(alphabet):
                 raise ValueError("Incompatible alphabets: %s , %s (defacto)"
                                  % (alphabet, defacto_alphabet))
-        else :
+        else:
             alphabets = (unambiguous_rna_alphabet,
-                        unambiguous_dna_alphabet,
-                        unambiguous_protein_alphabet,
-                      )
-            for a in alphabets :
-                if defacto_alphabet.alphabetic(a) :
+                         unambiguous_dna_alphabet,
+                         unambiguous_protein_alphabet,
+                         )
+            for a in alphabets:
+                if defacto_alphabet.alphabetic(a):
                     alphabet = a
                     break
-            if not alphabet :
+            if not alphabet:
                 alphabet = defacto_alphabet
 
-
         # The last item of each row may be extra cruft. Remove
-        if len(items[0]) == len(header) +1 :
-            for r in items :
+        if len(items[0]) == len(header) + 1:
+            for r in items:
                 r.pop()
 
         # items should now be a list of lists of numbers (as strings)
         rows = len(items)
         cols = len(items[0])
-        matrix = numpy.zeros( (rows,cols) , dtype=numpy.float64)
-        for r in range( rows) :
+        matrix = numpy.zeros((rows, cols), dtype=numpy.float64)
+        for r in range(rows):
             for c in range(cols):
-                matrix[r,c] = float( items[r][c])
+                matrix[r, c] = float(items[r][c])
 
-        if position_header :
+        if position_header:
             matrix.transpose()
 
         return _my_Motif(defacto_alphabet, matrix).reindex(alphabet)
-
 # End of code modified from weblogo version 3.4
-#==============================================================
+# ==============================================================
 
 
-def LogoOverlay(sites, overlayfile, overlay, nperline, sitewidth, rmargin, logoheight, barheight, barspacing, fix_limits={}, fixlongname=False, overlay_cmap=None, underlay=False, scalebar=False):
+def LogoOverlay(sites, overlayfile, overlay, nperline, sitewidth, rmargin,
+                logoheight, barheight, barspacing, fix_limits={},
+                fixlongname=False, overlay_cmap=None, underlay=False,
+                scalebar=False):
     """Makes overlay for *LogoPlot*.
 
     This function creates colored bars overlay bars showing up to two
@@ -917,11 +1011,11 @@ def LogoOverlay(sites, overlayfile, overlay, nperline, sitewidth, rmargin, logoh
 
     * *barspacing* is the vertical spacing between bars in points.
 
-    * *fix_limits* has the same meaning of the variable of this name used by *LogoPlot*.
+    * *fix_limits* has the same meaning as in  *LogoPlot*.
 
-    * *fixlongname* has the same meaning of the variable of this name used by *LogoPlot*.
+    * *fixlongname* has the same meaning as in *LogoPlot*.
 
-    * *overlay_cmap* has the same meaning of the variable of this name used by *LogoPlot*.
+    * *overlay_cmap* has the same meaning as in *LogoPlot*.
 
     * *underlay* is a bool. If `True`, make an underlay rather than an overlay.
 
@@ -935,7 +1029,7 @@ def LogoOverlay(sites, overlayfile, overlay, nperline, sitewidth, rmargin, logoh
     else:
         mapper = pylab.cm.ScalarMappable(cmap=overlay_cmap)
         cmap = mapper.get_cmap()
-    pts_per_inch = 72.0 # to convert between points and inches
+    pts_per_inch = 72.0  # to convert between points and inches
     # some general properties of the plot
     matplotlib.rc('text', usetex=True)
     matplotlib.rc('xtick', labelsize=8)
@@ -945,54 +1039,72 @@ def LogoOverlay(sites, overlayfile, overlay, nperline, sitewidth, rmargin, logoh
     matplotlib.rc('ytick.major', size=3)
     matplotlib.rc('xtick.major', size=2.5)
     # define sizes (still in points)
-    colorbar_bmargin = 20 # margin below color bars in points
-    colorbar_tmargin = 15 # margin above color bars in points
+    colorbar_bmargin = 20  # margin below color bars in points
+    colorbar_tmargin = 15  # margin above color bars in points
     nlines = int(math.ceil(len(sites) / float(nperline)))
-    lmargin = 25 # left margin in points
+    lmargin = 25  # left margin in points
     barwidth = nperline * sitewidth
     figwidth = lmargin + rmargin + barwidth
-    figheight = nlines * (logoheight + len(overlay) * (barheight +
-            barspacing)) + (barheight + colorbar_bmargin + colorbar_tmargin) + (
-            int(underlay) * len(overlay) * (barheight + barspacing))
+    figheight = (nlines *
+                 (logoheight + len(overlay) * (barheight + barspacing)) +
+                 (barheight + colorbar_bmargin + colorbar_tmargin) +
+                 (int(underlay) * len(overlay) * (barheight + barspacing)))
     # set up the figure and axes
-    fig = pylab.figure(figsize=(figwidth / pts_per_inch, figheight / pts_per_inch))
+    fig = pylab.figure(figsize=(figwidth / pts_per_inch,
+                                figheight / pts_per_inch))
     # determine property types
     prop_types = {}
     for (prop_d, shortname, longname) in overlay:
         if shortname == longname == 'wildtype':
             assert all([(isinstance(prop, str) and len(prop) == 1) for
-                    prop in prop_d.values()]), 'prop_d does not give letters'
+                        prop in prop_d.values()]),\
+                        'prop_d does not give letters'
             proptype = 'wildtype'
-            (vmin, vmax) = (0, 1) # not used, but need to be assigned
-            propcategories = None # not used, but needs to be assigned
+            (vmin, vmax) = (0, 1)  # not used, but need to be assigned
+            propcategories = None  # not used, but needs to be assigned
         elif all([isinstance(prop, str) for prop in prop_d.values()]):
             proptype = 'discrete'
             propcategories = list(set(prop_d.values()))
             propcategories.sort()
             (vmin, vmax) = (0, len(propcategories) - 1)
-        elif all ([isinstance(prop, (int, float)) for prop in prop_d.values()]):
+        elif all([isinstance(prop, (int, float)) for prop in prop_d.values()]):
             proptype = 'continuous'
             propcategories = None
             (vmin, vmax) = (min(prop_d.values()), max(prop_d.values()))
-            # If vmin is slightly greater than zero, set it to zero. This helps for RSA properties.
+            # If vmin is slightly greater than zero, set it to zero.
+            # This helps for RSA properties.
             if vmin >= 0 and vmin / float(vmax - vmin) < 0.05:
                 vmin = 0.0
                 # And if vmax is just a bit less than one, set it to that...
                 if 0.9 <= vmax <= 1.0:
                     vmax = 1.0
         else:
-            raise ValueError("Property %s is neither continuous or discrete. Values are:\n%s" % (shortname, str(prop_d.items())))
+            raise ValueError("Property %s is neither continuous or discrete. "
+                             "Values are:\n%s"
+                             % (shortname, str(prop_d.items())))
         if shortname in fix_limits:
-            (vmin, vmax) = (min(fix_limits[shortname][0]), max(fix_limits[shortname][0]))
-        assert vmin < vmax, "vmin >= vmax, did you incorrectly use fix_vmin and fix_vmax?"
+            (vmin, vmax) = (min(fix_limits[shortname][0]),
+                            max(fix_limits[shortname][0]))
+        assert vmin < vmax, ("vmin >= vmax, did you incorrectly use "
+                             "fix_vmin and fix_vmax?")
         prop_types[shortname] = (proptype, vmin, vmax, propcategories)
-    assert len(prop_types) == len(overlay), "Not as many property types as overlays. Did you give the same name (shortname) to multiple properties in the overlay?"
+    assert len(prop_types) == len(overlay), ("Not as many property types as "
+                                             "overlays. Did you give the same "
+                                             "name (shortname) to multiple "
+                                             "properties in the overlay?")
     # loop over each line of the multi-lined plot
     prop_image = {}
     for iline in range(nlines):
-        isites = sites[iline * nperline : min(len(sites), (iline + 1) * nperline)]
+        isites = sites[iline * nperline: min(len(sites),
+                       (iline + 1) * nperline)]
         xlength = len(isites) * sitewidth
-        logo_ax = pylab.axes([lmargin / figwidth, ((nlines - iline - 1) * (logoheight + len(overlay) * (barspacing + barheight))) / figheight, xlength / figwidth, logoheight / figheight], frameon=False)
+        logo_ax = pylab.axes([lmargin / figwidth,
+                             (((nlines - iline - 1) *
+                                 (logoheight + len(overlay) *
+                                  (barspacing + barheight))) /
+                                 figheight),
+                              xlength / figwidth,
+                              logoheight / figheight], frameon=False)
         logo_ax.yaxis.set_ticks_position('none')
         logo_ax.xaxis.set_ticks_position('none')
         pylab.yticks([])
@@ -1000,16 +1112,18 @@ def LogoOverlay(sites, overlayfile, overlay, nperline, sitewidth, rmargin, logoh
         pylab.xticks([])
         for (iprop, (prop_d, shortname, longname)) in enumerate(overlay):
             (proptype, vmin, vmax, propcategories) = prop_types[shortname]
-            prop_ax = pylab.axes([
-                    lmargin / figwidth,
-                    ((nlines - iline - 1) * (logoheight +
-                        len(overlay) * (barspacing + barheight)) +
-                        (1 - int(underlay)) * logoheight + int(underlay) *
-                        barspacing + iprop * (barspacing + barheight))
-                        / figheight,
-                    xlength / figwidth,
-                    barheight / figheight],
-                    frameon=(proptype != 'wildtype'))
+            prop_ax = pylab.axes([lmargin / figwidth,
+                                 (((nlines - iline - 1) *
+                                  (logoheight + len(overlay) *
+                                   (barspacing + barheight)) +
+                                  (1 - int(underlay)) *
+                                  logoheight +
+                                  int(underlay) *
+                                  barspacing + iprop *
+                                  (barspacing + barheight)) /
+                                  figheight),
+                                 xlength / figwidth, barheight / figheight],
+                                 frameon=(proptype != 'wildtype'))
             prop_ax.xaxis.set_ticks_position('none')
             pylab.xticks([])
             pylab.xlim((0, len(isites)))
@@ -1019,21 +1133,29 @@ def LogoOverlay(sites, overlayfile, overlay, nperline, sitewidth, rmargin, logoh
                 prop_ax.yaxis.set_ticks_position('none')
                 for (isite, site) in enumerate(isites):
                     pylab.text(isite + 0.5, -0.5, prop_d[site], size=9,
-                            horizontalalignment='center', family='monospace')
+                               horizontalalignment='center',
+                               family='monospace')
                 continue
             pylab.yticks([0], [shortname], size=8)
             prop_ax.yaxis.set_ticks_position('left')
             propdata = pylab.zeros(shape=(1, len(isites)))
-            propdata[ : ] = pylab.nan # set to nan for all entries
+            propdata[:] = pylab.nan  # set to nan for all entries
             for (isite, site) in enumerate(isites):
                 if site in prop_d:
                     if proptype == 'continuous':
                         propdata[(0, isite)] = prop_d[site]
                     elif proptype == 'discrete':
-                        propdata[(0, isite)] = propcategories.index(prop_d[site])
+                        propdata[(0, isite)] = (propcategories
+                                                .index(prop_d[site]))
                     else:
                         raise ValueError('neither continuous nor discrete')
-            prop_image[shortname] = pylab.imshow(propdata, interpolation='nearest', aspect='auto', extent=[0, len(isites), 0.5, -0.5], cmap=cmap, vmin=vmin, vmax=vmax)
+            prop_image[shortname] = pylab.imshow(propdata,
+                                                 interpolation='nearest',
+                                                 aspect='auto',
+                                                 extent=[0, len(isites),
+                                                         0.5, -0.5],
+                                                 cmap=cmap,
+                                                 vmin=vmin, vmax=vmax)
             pylab.yticks([0], [shortname], size=8)
 
     # set up colorbar axes, then color bars
@@ -1044,12 +1166,14 @@ def LogoOverlay(sites, overlayfile, overlay, nperline, sitewidth, rmargin, logoh
         colorbarwidth = 0.4
         colorbarspacingwidth = 1.0 - colorbarwidth
     elif ncolorbars:
-        colorbarspacingfrac = 0.5 # space between color bars is this fraction of bar width
-        colorbarwidth = 1.0 / (ncolorbars * (1.0 + colorbarspacingfrac)) # width of color bars in fraction of figure width
-        colorbarspacingwidth = colorbarwidth * colorbarspacingfrac # width of color bar spacing in fraction of figure width
+        # space between color bars is this fraction of bar width
+        colorbarspacingfrac = 0.5
+        # width of color bars in fraction of figure width
+        colorbarwidth = 1.0 / (ncolorbars * (1.0 + colorbarspacingfrac))
+        # width of color bar spacing in fraction of figure width
+        colorbarspacingwidth = colorbarwidth * colorbarspacingfrac
     # bottom of color bars
     ybottom = 1.0 - (colorbar_tmargin + barheight) / figheight
-    propnames = {}
     icolorbar = -1
     icolorbarshift = 0
     while icolorbar < len(overlay):
@@ -1059,17 +1183,17 @@ def LogoOverlay(sites, overlayfile, overlay, nperline, sitewidth, rmargin, logoh
             if scalebar:
                 (scalebarheight, scalebarlabel) = scalebar
                 xleft = (colorbarspacingwidth * 0.5 + icolorbar *
-                        (colorbarwidth + colorbarspacingwidth))
+                         (colorbarwidth + colorbarspacingwidth))
                 ytop = 1 - colorbar_tmargin / figheight
                 scalebarheightfrac = scalebarheight / figheight
                 # follow here for fig axes: https://stackoverflow.com/a/5022412
                 fullfigax = pylab.axes([0, 0, 1, 1], facecolor=(1, 1, 1, 0))
                 fullfigax.axvline(x=xleft, ymin=ytop - scalebarheightfrac,
-                        ymax=ytop, color='black', linewidth=1.5)
+                                  ymax=ytop, color='black', linewidth=1.5)
                 pylab.text(xleft + 0.005, ytop - scalebarheightfrac / 2.0,
-                        scalebarlabel, verticalalignment='center',
-                        horizontalalignment='left',
-                        transform=fullfigax.transAxes)
+                           scalebarlabel, verticalalignment='center',
+                           horizontalalignment='left',
+                           transform=fullfigax.transAxes)
             continue
 
         (prop_d, shortname, longname) = overlay[icolorbar]
@@ -1084,25 +1208,41 @@ def LogoOverlay(sites, overlayfile, overlay, nperline, sitewidth, rmargin, logoh
             propname = longname
         else:
             propname = "%s (%s)" % (longname, shortname)
-        colorbar_ax = pylab.axes([colorbarspacingwidth * 0.5 + (icolorbar - icolorbarshift - int(not bool(scalebar))) * (colorbarwidth + colorbarspacingwidth), ybottom, colorbarwidth, barheight / figheight], frameon=True)
+        colorbar_ax = pylab.axes([colorbarspacingwidth * 0.5 +
+                                  (icolorbar - icolorbarshift -
+                                   int(not bool(scalebar))) *
+                                  (colorbarwidth + colorbarspacingwidth),
+                                  ybottom,
+                                  colorbarwidth,
+                                  barheight / figheight],
+                                 frameon=True)
         colorbar_ax.xaxis.set_ticks_position('bottom')
         colorbar_ax.yaxis.set_ticks_position('none')
         pylab.xticks([])
         pylab.yticks([])
         pylab.title(propname, size=9)
         if proptype == 'continuous':
-            cb = pylab.colorbar(prop_image[shortname], cax=colorbar_ax, orientation='horizontal')
-            # if range is close to zero to one, manually set tics to 0, 0.5, 1. This helps for RSA
+            cb = pylab.colorbar(prop_image[shortname],
+                                cax=colorbar_ax,
+                                orientation='horizontal')
+            # if range is close to zero to one, manually set tics to 0, 0.5, 1.
+            # This helps for RSA
             if -0.1 <= vmin <= 0 and 1.0 <= vmax <= 1.15:
                 cb.set_ticks([0, 0.5, 1])
                 cb.set_ticklabels(['0', '0.5', '1'])
             # if it seems plausible, set integer ticks
             if 4 < (vmax - vmin) <= 11:
-                fixedticks = [itick for itick in range(int(vmin), int(vmax) + 1)]
+                fixedticks = [itick for itick in
+                              range(int(vmin), int(vmax) + 1)]
                 cb.set_ticks(fixedticks)
                 cb.set_ticklabels([str(itick) for itick in fixedticks])
         elif proptype == 'discrete':
-            cb = pylab.colorbar(prop_image[shortname], cax=colorbar_ax, orientation='horizontal', boundaries=[i for i in range(len(propcategories) + 1)], values=[i for i in range(len(propcategories))])
+            cb = pylab.colorbar(prop_image[shortname],
+                                cax=colorbar_ax,
+                                orientation='horizontal',
+                                boundaries=[i for i in
+                                            range(len(propcategories) + 1)],
+                                values=[i for i in range(len(propcategories))])
             cb.set_ticks([i + 0.5 for i in range(len(propcategories))])
             cb.set_ticklabels(propcategories)
         else:

--- a/phydmslib/weblogo.py
+++ b/phydmslib/weblogo.py
@@ -475,10 +475,10 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
         # create web logo
         charstring = ''.join(chars_for_string)
         assert len(charstring) == len(chars_for_string),\
-               ("Length of charstring doesn't match length of "
-                "chars_for_string. Do you have unallowable multi-letter "
-                "characters?\n%s"
-                % (str(chars_for_string)))
+            ("Length of charstring doesn't match length of "
+             "chars_for_string. Do you have unallowable multi-letter "
+             "characters?\n%s"
+             % (str(chars_for_string)))
         logoprior = weblogolib.parse_prior('equiprobable', charstring, 0)
         motif = _my_Motif.read_transfac(open(transfacfile), charstring)
         logodata = weblogolib.LogoData.from_counts(motif.alphabet,

--- a/phydmslib/weblogo.py
+++ b/phydmslib/weblogo.py
@@ -29,7 +29,6 @@ import weblogolib.colorscheme  # weblogo library
 import corebio.matrix  # weblogo library
 import corebio.utils  # weblogo library
 from phydmslib.constants import AA_TO_INDEX, NT_TO_INDEX
-matplotlib.use('pdf', warn=False)
 
 
 def KyteDoolittleColorMapping(maptype='jet', reverse=True):

--- a/phydmslib/weblogo.py
+++ b/phydmslib/weblogo.py
@@ -111,8 +111,8 @@ def ChargeColorMapping(maptype='jet', reverse=False):
     """Maps amino-acid charge at neutral pH to colors.
     Currently does not use the keyword arguments for *maptype*
     or *reverse* but accepts these arguments to be consistent
-    with KyteDoolittleColorMapping and MWColorMapping for now."""
-
+    with KyteDoolittleColorMapping and MWColorMapping for now.
+    """
     pos_color = '#FF0000'
     neg_color = '#0000FF'
     neut_color = '#000000'
@@ -133,8 +133,8 @@ def FunctionalGroupColorMapping(maptype='jet', reverse=False):
     Currently does not use the keyword arguments for *maptype*
     or *reverse* but accepts these arguments to be consistent
     with the other mapping functions, which all get called with
-    these arguments."""
-
+    these arguments.
+    """
     small_color = '#f76ab4'
     nucleophilic_color = '#ff7f00'
     hydrophobic_color = '#12ab0d'
@@ -331,7 +331,7 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
         os.remove(plotfile)  # remove existing plot
 
     if not allowunsorted:
-        sorted_sites = natsort.natsorted([r for r in sites])
+        sorted_sites = natsort.natsorted(sites)
         if sorted_sites != sites:
             raise ValueError("sites is not properly sorted")
 
@@ -634,14 +634,14 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
 #  POSSIBILITY OF SUCH DAMAGE.
 
 # Replicates README.txt
-def _my_pdf_formatter(data, format, ordered_alphabets):
+def _my_pdf_formatter(data, pdfformat, ordered_alphabets):
     """ Generate a logo in PDF format.
 
     Modified from weblogo version 3.4 source code.
     """
-    eps = _my_eps_formatter(data, format, ordered_alphabets).decode()
+    eps = _my_eps_formatter(data, pdfformat, ordered_alphabets).decode()
     gs = weblogolib.GhostscriptAPI()
-    return gs.convert('pdf', eps, format.logo_width, format.logo_height)
+    return gs.convert('pdf', eps, pdfformat.logo_width, pdfformat.logo_height)
 
 
 def _my_eps_formatter(logodata, format, ordered_alphabets):
@@ -1107,7 +1107,7 @@ def LogoOverlay(sites, overlayfile, overlay, nperline, sitewidth, rmargin,
         pylab.yticks([])
         pylab.xlim(0.5, len(isites) + 0.5)
         pylab.xticks([])
-        for (iprop, (prop_d, shortname, longname)) in enumerate(overlay):
+        for (iprop, (prop_d, shortname, _longname)) in enumerate(overlay):
             (proptype, vmin, vmax, propcategories) = prop_types[shortname]
             prop_ax = pylab.axes([lmargin / figwidth,
                                  (((nlines - iline - 1) *
@@ -1229,16 +1229,15 @@ def LogoOverlay(sites, overlayfile, overlay, nperline, sitewidth, rmargin,
                 cb.set_ticklabels(['0', '0.5', '1'])
             # if it seems plausible, set integer ticks
             if 4 < (vmax - vmin) <= 11:
-                fixedticks = [itick for itick in
-                              range(int(vmin), int(vmax) + 1)]
+                fixedticks = list(range(int(vmin), int(vmax) + 1))
                 cb.set_ticks(fixedticks)
                 cb.set_ticklabels([str(itick) for itick in fixedticks])
         elif proptype == 'discrete':
             cb = pylab.colorbar(prop_image[shortname],
                                 cax=colorbar_ax,
                                 orientation='horizontal',
-                                boundaries=[i for i in
-                                            range(len(propcategories) + 1)],
+                                boundaries=list(range(len(propcategories) + 1)
+                                                ),
                                 values=[i for i in range(len(propcategories))])
             cb.set_ticks([i + 0.5 for i in range(len(propcategories))])
             cb.set_ticklabels(propcategories)

--- a/phydmslib/weblogo.py
+++ b/phydmslib/weblogo.py
@@ -1048,8 +1048,8 @@ def LogoOverlay(sites, overlayfile, overlay, nperline, sitewidth, rmargin,
                  (barheight + colorbar_bmargin + colorbar_tmargin) +
                  (int(underlay) * len(overlay) * (barheight + barspacing)))
     # set up the figure and axes
-    fig = pylab.figure(figsize=(figwidth / pts_per_inch,
-                                figheight / pts_per_inch))
+    pylab.figure(figsize=(figwidth / pts_per_inch,
+                          figheight / pts_per_inch))
     # determine property types
     prop_types = {}
     for (prop_d, shortname, longname) in overlay:

--- a/phydmslib/weblogo.py
+++ b/phydmslib/weblogo.py
@@ -644,7 +644,7 @@ def _my_pdf_formatter(data, pdfformat, ordered_alphabets):
     return gs.convert('pdf', eps, pdfformat.logo_width, pdfformat.logo_height)
 
 
-def _my_eps_formatter(logodata, format, ordered_alphabets):
+def _my_eps_formatter(logodata, format, ordered_alphabets):  # noqa: F401
     """Generate a logo in Encapsulated Postscript (EPS)
 
     Modified from weblogo version 3.4 source code.

--- a/phydmslib/weblogo.py
+++ b/phydmslib/weblogo.py
@@ -674,8 +674,7 @@ def _my_eps_formatter(logodata, format, ordered_alphabets):
         "show_xaxis_label", "show_yaxis",           "show_yaxis_label",
         "show_boxes",       "show_errorbars",       "show_fineprint",
         "rotate_numbers",   "show_ends",            "stack_height",
-        "stack_width"
-        ]
+        "stack_width"]
 
     for s in from_format:
         substitutions[s] = getattr(format, s)

--- a/phydmslib/weblogo.py
+++ b/phydmslib/weblogo.py
@@ -1,7 +1,4 @@
-"""
-============================
-``weblogo`` module
-============================
+"""``weblogo`` module
 
 Module for making sequence logos with the *weblogolib* package distributed with
 ``weblogo``  This module interfaces with the *weblogolib* API,
@@ -9,7 +6,6 @@ and so is only known to work with *weblogolib* version 3.4 and 3.5.
 
 Written by Jesse Bloom and Mike Doud
 """
-
 
 import collections
 import os
@@ -20,7 +16,6 @@ import shutil
 import natsort
 import numpy
 import matplotlib
-matplotlib.use('pdf')
 import pylab
 import PyPDF2
 # the following are part of the weblogo library
@@ -29,6 +24,7 @@ import weblogolib.colorscheme  # weblogo library
 import corebio.matrix  # weblogo library
 import corebio.utils  # weblogo library
 from phydmslib.constants import AA_TO_INDEX, NT_TO_INDEX
+matplotlib.use('pdf')
 
 
 def KyteDoolittleColorMapping(maptype='jet', reverse=True):
@@ -538,7 +534,7 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
         # close if still open
         try:
             f.close()
-        except:
+        except Exception:
             pass
         # remove temporary file
         if os.path.isfile(transfacfile):
@@ -576,19 +572,19 @@ def LogoPlot(sites, datatype, data, plotfile, nperline,
         finally:
             try:
                 plotfile_f.close()
-            except:
+            except Exception:
                 pass
             try:
                 overlayfile_f.close()
-            except:
+            except Exception:
                 pass
             try:
                 foverlay.close()
-            except:
+            except Exception:
                 pass
             try:
                 fmerged.close()
-            except:
+            except Exception:
                 pass
             for fname in [overlayfile, mergedfile]:
                 if os.path.isfile(fname):
@@ -730,8 +726,9 @@ def _my_eps_formatter(logodata, format, ordered_alphabets):
         data.append("(%s) StartStack" % format.annotate[seq_index])
 
         if conv_factor:
-            stack_height = (logodata.entropy[seq_index] *
-                            std_units[format.unit_name])
+            raise ValueError("Can only scale stack heights by probability.")
+            # stack_height = (logodata.entropy[seq_index] *
+            #                 std_units[format.unit_name])
         else:
             stack_height = 1.0  # Probability
 
@@ -930,13 +927,14 @@ class _my_Motif(corebio.matrix.AlphabeticArray):
                 r.pop(0)
                 defacto_alphabet = ''.join(header)
         else:
-            a = []
-            for i, r in enumerate(items):
-                if not ischar(r[0]) and r[0][0] != 'P':
-                    raise ValueError(
-                        "Expected position as first item on line %d" % i)
-                a.append(r.pop(0))
-            defacto_alphabet = ''.join(a)
+            raise ValueError("Can only use alphabet header.")
+            # a = []
+            # for i, r in enumerate(items):
+            #     if not ischar(r[0]) and r[0][0] != 'P':
+            #         raise ValueError(
+            #             "Expected position as first item on line %d" % i)
+            #     a.append(r.pop(0))
+            # defacto_alphabet = ''.join(a)
 
         # Check defacto_alphabet
         defacto_alphabet = corebio.seq.Alphabet(defacto_alphabet)
@@ -946,16 +944,17 @@ class _my_Motif(corebio.matrix.AlphabeticArray):
                 raise ValueError("Incompatible alphabets: %s , %s (defacto)"
                                  % (alphabet, defacto_alphabet))
         else:
-            alphabets = (unambiguous_rna_alphabet,
-                         unambiguous_dna_alphabet,
-                         unambiguous_protein_alphabet,
-                         )
-            for a in alphabets:
-                if defacto_alphabet.alphabetic(a):
-                    alphabet = a
-                    break
-            if not alphabet:
-                alphabet = defacto_alphabet
+            raise ValueError('Incompatible alphabet')
+            # alphabets = (unambiguous_rna_alphabet,
+            #              unambiguous_dna_alphabet,
+            #              unambiguous_protein_alphabet,
+            #              )
+            # for a in alphabets:
+            #     if defacto_alphabet.alphabetic(a):
+            #         alphabet = a
+            #         break
+            # if not alphabet:
+            #     alphabet = defacto_alphabet
 
         # The last item of each row may be extra cruft. Remove
         if len(items[0]) == len(header) + 1:

--- a/scripts/phydms
+++ b/scripts/phydms
@@ -322,8 +322,7 @@ def main():
                                     .format(nt, g[w]) for (w, nt) in
                                     phydmslib.constants.INDEX_TO_NT.items()])))
                 if not args['divpressure']:
-                    model = (phydmslib
-                             .models
+                    model = (phydmslib.models
                              .ExpCM_empirical_phi(prefslist, g,
                                                   freeparams=freeparams))
                 else:
@@ -383,13 +382,11 @@ def main():
         tree = Bio.Phylo.read(args['tree'], 'newick')
         tipnames = set([clade.name for clade in tree.get_terminals()])
         assert len(tipnames) == tree.count_terminals(), "non-unique tip names?"
-        assert tipnames == seqnames, ("Names in alignment do not match those "
-                                      "in tree.\nSequences in alignment but "
-                                      "NOT in tree:\n\t{0}\n Sequences in "
-                                      "tree but NOT in alignment:\n\t{1}"
-                                      .format('\n\t'.join(seqnames - tipnames),
-                                              '\n\t'.join(tipnames - seqnames))
-                                      )
+        assert tipnames == seqnames, (
+            "Names in alignment do not match those in tree.\nSequences in "
+            "alignment but NOT in tree:\n\t{0}\n Sequences in tree but NOT in "
+            "alignment:\n\t{1}".format('\n\t'.join(seqnames - tipnames),
+                                       '\n\t'.join(tipnames - seqnames)))
         logger.info('Tree has {0} tips.'.format(len(tipnames)))
         tree.root_at_midpoint()
         assert tree.is_bifurcating(), "Tree is not bifurcating: cannot handle"
@@ -563,16 +560,14 @@ def main():
                     mapfunc = pool.imap
                 else:
                     mapfunc = map
-                # placeholder to avoid long line
-                treelks = [treelikForDiffPrefsBySite(site,
-                                                     tl,
-                                                     prefslist,
-                                                     args['diffprefsprior'],
-                                                     modeltype,
-                                                     othermodeltype,
-                                                     args['nograd'])
-                           for site in currentsites]
-                diffprefresults += mapfunc(fitDiffPrefsBySite, treelks)
+                diffprefresults += mapfunc(
+                    fitDiffPrefsBySite, [
+                        treelikForDiffPrefsBySite(site, tl, prefslist,
+                                                  args['diffprefsprior'],
+                                                  modeltype,
+                                                  othermodeltype,
+                                                  args['nograd'])
+                        for site in currentsites])
                 if ncpus > 1:
                     pool.close()
                     pool.join()

--- a/scripts/phydms
+++ b/scripts/phydms
@@ -499,13 +499,13 @@ def main():
                     mapfunc = pool.imap
                 else:
                     mapfunc = map
-                omegaresults += mapfunc(fitOmegaBySite,
-                                        [treeliksForOmegaBySite(site,
-                                                                tl,
-                                                                prefslist,
-                                                                args['omegabysite_fixsyn'],
-                                                                args['nograd'])
-                                         for site in currentsites])
+                treelks = [treeliksForOmegaBySite(site,
+                                                  tl,
+                                                  prefslist,
+                                                  args['omegabysite_fixsyn'],
+                                                  args['nograd'])
+                           for site in currentsites]
+                omegaresults += mapfunc(fitOmegaBySite, treelks)
                 if ncpus > 1:
                     pool.close()
                     pool.join()
@@ -563,15 +563,16 @@ def main():
                     mapfunc = pool.imap
                 else:
                     mapfunc = map
-                diffprefresults += mapfunc(fitDiffPrefsBySite,
-                                           [treelikForDiffPrefsBySite(site,
-                                                                      tl,
-                                                                      prefslist,
-                                                                      args['diffprefsprior'],
-                                                                      modeltype,
-                                                                      othermodeltype,
-                                                                      args['nograd'])
-                                            for site in currentsites])
+                # placeholder to avoid long line
+                treelks = [treelikForDiffPrefsBySite(site,
+                                                     tl,
+                                                     prefslist,
+                                                     args['diffprefsprior'],
+                                                     modeltype,
+                                                     othermodeltype,
+                                                     args['nograd'])
+                           for site in currentsites]
+                diffprefresults += mapfunc(fitDiffPrefsBySite, treelks)
                 if ncpus > 1:
                     pool.close()
                     pool.join()

--- a/scripts/phydms
+++ b/scripts/phydms
@@ -5,57 +5,58 @@
 Written by Jesse Bloom."""
 
 
-import sys
 import os
 import re
 import logging
 import random
 import time
-import math
 import operator
 import multiprocessing
 import warnings
-warnings.simplefilter('always')
-warnings.simplefilter('ignore', ImportWarning)
 import numpy
 import scipy.stats
 import statsmodels.sandbox.stats.multicomp
 import Bio.Phylo
 import phydmslib
-from phydmslib.constants import *
+from phydmslib.constants import INDEX_TO_AA, N_AA
 import phydmslib.file_io
 import phydmslib.parsearguments
 import phydmslib.models
 import phydmslib.treelikelihood
+warnings.simplefilter('always')
+warnings.simplefilter('ignore', ImportWarning)
 
 
 def treelikForDiffPrefsBySite(site, tl, prefslist, prior, modeltype,
-        othermodeltype, nograd):
+                              othermodeltype, nograd):
     """Returns `TreeLikelihood` for fitting diffprefs for a site.
 
     The returned value can be passed to `fitDiffPrefsBySite`."""
-    sitealignment = [(head, seq[3 * (site - 1) : 3 * site]) for
-            (head, seq) in tl.alignment]
-    gammaomegamodel = False
+    sitealignment = [(head, seq[3 * (site - 1): 3 * site]) for
+                     (head, seq) in tl.alignment]
     treeliks = {}
     for (mtype, mname) in [(modeltype, 'primary'),
-            (othermodeltype, 'secondary')]:
+                           (othermodeltype, 'secondary')]:
         if isinstance(tl.model, phydmslib.models.GammaDistributedOmegaModel):
             basemodel = tl.model.basemodel
             assert type(basemodel) in [phydmslib.models.ExpCM,
-                    phydmslib.models.ExpCM_empirical_phi]
-            sitemodel = mtype([prefslist[site - 1]],
-                    prior, basemodel.kappa, basemodel.omega, basemodel.phi,
-                    origbeta=basemodel.beta, freeparams=['zeta', 'omega'])
-            sitemodel = phydmslib.models.GammaDistributedOmegaModel(sitemodel,
-                    tl.model.ncats, tl.model.alpha_omega, tl.model.beta_omega,
-                    freeparams=[])
+                                       phydmslib.models.ExpCM_empirical_phi]
+            sitemodel = mtype([prefslist[site - 1]], prior, basemodel.kappa,
+                              basemodel.omega, basemodel.phi,
+                              origbeta=basemodel.beta,
+                              freeparams=['zeta', 'omega'])
+            sitemodel = (phydmslib.models
+                         .GammaDistributedOmegaModel(sitemodel, tl.model.ncats,
+                                                     tl.model.alpha_omega,
+                                                     tl.model.beta_omega,
+                                                     freeparams=[]))
         else:
             assert type(tl.model) in [phydmslib.models.ExpCM,
-                    phydmslib.models.ExpCM_empirical_phi]
+                                      phydmslib.models.ExpCM_empirical_phi]
             sitemodel = mtype([prefslist[site - 1]],
-                    prior, tl.model.kappa, tl.model.omega, tl.model.phi,
-                    origbeta=tl.model.beta, freeparams=['zeta'])
+                              prior, tl.model.kappa, tl.model.omega,
+                              tl.model.phi, origbeta=tl.model.beta,
+                              freeparams=['zeta'])
         assert sitemodel.freeparams == ['zeta']
         treeliks[mname] = phydmslib.treelikelihood.TreeLikelihood(
                 tl.tree, sitealignment, sitemodel,
@@ -73,18 +74,16 @@ def fitDiffPrefsBySite(argtup):
     (site, treeliks, nograd) = argtup
     try:
         treelik = treeliks['primary']
-        maxresult = treelik.maximizeLikelihood(optimize_brlen=False,
-                approx_grad=nograd)
+        treelik.maximizeLikelihood(optimize_brlen=False, approx_grad=nograd)
     except RuntimeError as err:
         warnings.warn("Optimization failed with primary model; "
                       "trying secondary model.\n"
                       "Error message:\n{0}".format(str(err)))
         treelik = treeliks['secondary']
-        maxresult = treelik.maximizeLikelihood(optimize_brlen=False,
-                approx_grad=nograd)
+        treelik.maximizeLikelihood(optimize_brlen=False, approx_grad=nograd)
     diffprefs = treelik.model.pi[0] - treelik.model.origpi[0]
-    resultstr = [str(site)] + ['{0:.4f}'.format(diffprefs[a])
-            for a in range(N_AA)]
+    resultstr = ([str(site)] +
+                 ['{0:.4f}'.format(diffprefs[a]) for a in range(N_AA)])
     halfabssum = 0.5 * numpy.absolute(diffprefs).sum()
     resultstr.append('{0:.4f}'.format(halfabssum))
     return (halfabssum, '\t'.join(resultstr))
@@ -95,26 +94,31 @@ def treeliksForOmegaBySite(site, tl, prefslist, fixsyn, nograd):
 
     The returned value can be passed to `fitOmegaBySite`."""
     if isinstance(tl.model, phydmslib.models.DistributionModel):
-        assert isinstance(tl.model, phydmslib.models.GammaDistributedOmegaModel)
+        assert isinstance(tl.model,
+                          phydmslib.models.GammaDistributedOmegaModel)
         modeltotype = tl.model.basemodel
     else:
         modeltotype = tl.model
-    sitealignment = [(head, seq[3 * (site - 1) : 3 * site]) for
-            (head, seq) in tl.alignment]
+    sitealignment = [(head, seq[3 * (site - 1): 3 * site]) for
+                     (head, seq) in tl.alignment]
     freeparams = [] if fixsyn else ['mu']
     treeliks = {}
     for (name, addparam) in [('fix', []), ('fit', ['omega'])]:
         if isinstance(modeltotype, phydmslib.models.ExpCM):
             assert len(prefslist) == tl.nsites
-            sitemodel = phydmslib.models.ExpCM([prefslist[site - 1]],
-                    kappa=tl.model.kappa, omega=1.0, beta=tl.model.beta,
-                    mu=1.0, phi=modeltotype.phi,
-                    freeparams=(freeparams + addparam))
+            sitemodel = (phydmslib.models
+                         .ExpCM([prefslist[site - 1]],
+                                kappa=tl.model.kappa, omega=1.0,
+                                beta=tl.model.beta,
+                                mu=1.0, phi=modeltotype.phi,
+                                freeparams=(freeparams + addparam)))
         elif isinstance(modeltotype, phydmslib.models.YNGKP_M0):
             assert prefslist is None
-            sitemodel = phydmslib.models.YNGKP_M0(modeltotype.e_pw,
-                    1, kappa=tl.model.kappa, omega=1.0, mu=1.0,
-                    freeparams=(freeparams + addparam))
+            sitemodel = (phydmslib.models
+                         .YNGKP_M0(modeltotype.e_pw,
+                                   1, kappa=tl.model.kappa,
+                                   omega=1.0, mu=1.0,
+                                   freeparams=(freeparams + addparam)))
         else:
             raise ValueError("Invalid modeltotype {0}".format(modeltotype))
         treeliks[name] = phydmslib.treelikelihood.TreeLikelihood(
@@ -133,13 +137,13 @@ def fitOmegaBySite(argtup):
     site, omega, P, dLnL.
     """
     (site, treeliks, nograd) = argtup
-    if treeliks['fix'].model.freeparams: # can be no params if using fixsyn
-        result = treeliks['fix'].maximizeLikelihood(optimize_brlen=False,
-                approx_grad=nograd)
+    if treeliks['fix'].model.freeparams:  # can be no params if using fixsyn
+        treeliks['fix'].maximizeLikelihood(optimize_brlen=False,
+                                           approx_grad=nograd)
     # starting fit from mu of fix should ensure things don't get worse
-    treeliks['fit'].updateParams({'mu':treeliks['fix'].model.mu})
-    result = treeliks['fit'].maximizeLikelihood(optimize_brlen=False,
-            approx_grad=nograd)
+    treeliks['fit'].updateParams({'mu': treeliks['fix'].model.mu})
+    treeliks['fit'].maximizeLikelihood(optimize_brlen=False,
+                                       approx_grad=nograd)
     omega = treeliks['fit'].model.omega
     dLnL = treeliks['fit'].loglik - treeliks['fix'].loglik
     if dLnL < -0.01:
@@ -173,13 +177,16 @@ def main():
     # output files, remove if they already exist
     underscore = '' if args['outprefix'][-1] == '/' else '_'
     logfile = '{0}{1}log.log'.format(args['outprefix'], underscore)
-    modelparamsfile = '{0}{1}modelparams.txt'.format(args['outprefix'], underscore)
-    loglikelihoodfile = '{0}{1}loglikelihood.txt'.format(args['outprefix'], underscore)
+    modelparamsfile = '{0}{1}modelparams.txt'.format(args['outprefix'],
+                                                     underscore)
+    loglikelihoodfile = '{0}{1}loglikelihood.txt'.format(args['outprefix'],
+                                                         underscore)
     treefile = '{0}{1}tree.newick'.format(args['outprefix'], underscore)
     omegafile = '{0}{1}omegabysite.txt'.format(args['outprefix'], underscore)
-    diffprefsfile = '{0}{1}diffprefsbysite.txt'.format(args['outprefix'], underscore)
+    diffprefsfile = '{0}{1}diffprefsbysite.txt'.format(args['outprefix'],
+                                                       underscore)
     to_remove = [modelparamsfile, loglikelihoodfile, treefile, omegafile,
-            logfile, diffprefsfile]
+                 logfile, diffprefsfile]
     for f in to_remove:
         if os.path.isfile(f):
             os.remove(f)
@@ -189,7 +196,7 @@ def main():
     logging.captureWarnings(True)
     versionstring = phydmslib.file_io.Versions()
     logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s',
-            level=logging.INFO)
+                        level=logging.INFO)
     logger = logging.getLogger(prog)
     warning_logger = logging.getLogger("py.warnings")
     logfile_handler = logging.FileHandler(logfile)
@@ -206,48 +213,57 @@ def main():
         logger.info('Progress is being logged to {0}\n'.format(logfile))
         logger.info("{0}\n".format(versionstring))
         logger.info('Parsed the following arguments:\n{0}\n'.format(
-                '\n'.join(['\t{0} = {1}'.format(*tup) for tup in args.items()])))
+                    '\n'.join(['\t{0} = {1}'
+                              .format(*tup) for tup in args.items()])))
         logger.info('Random number seed: {0}\n'.format(args['seed']))
         random.seed(args['seed'])
 
         # read alignment
         logger.info('Reading alignment from {0}'.format(args['alignment']))
         alignment = phydmslib.file_io.ReadCodonAlignment(args['alignment'],
-                checknewickvalid=True)
+                                                         checknewickvalid=True)
         logger.info(('Read {0} aligned sequences from {1}, each consisting '
-                'of {2} codons.\n').format(len(alignment), args['alignment'],
-                len(alignment[0][1]) // 3))
+                     'of {2} codons.\n')
+                    .format(len(alignment), args['alignment'],
+                            len(alignment[0][1]) // 3))
         seqnames = set([head for (head, seq) in alignment])
 
         # process the substitution model
         yngkp_match = re.compile('^YNGKP_(?P<modelvariant>M\d+)$')
-        if isinstance(args['model'], str) and yngkp_match.search(args['model']):
-            for argname in ['randprefs', 'avgprefs', 'divpressure', 'diffprefsbysite']:
-                assert not args[argname], "'--{0}' incompatible with YNKGP".format(
-                            argname)
-            assert not args['gammaomega'], ("Can't use --gammaomega with YNGKP "
-                    "model; use 'model' of YNGKP_M5 to achieve the same result.")
+        if (isinstance(args['model'],
+                       str) and yngkp_match.search(args['model'])):
+            for argname in ['randprefs', 'avgprefs',
+                            'divpressure', 'diffprefsbysite']:
+                assert not args[argname], ("'--{0}' incompatible with YNKGP"
+                                           .format(argname))
+            assert not args['gammaomega'], ("Can't use --gammaomega with "
+                                            "YNGKP model; use 'model' of "
+                                            "YNGKP_M5 to achieve the same "
+                                            "result.")
             assert not args['gammabeta'], ("Can't use --gammabeta with YNGKP "
-                    "model.")
-            modelvariant = yngkp_match.search(args['model']).group('modelvariant')
-            logger.info(('Codon substitution model with be {0} version '
-                    'of YNGKP (Yang, Nielsen, Goldman, & Pederson. Genetics. '
-                    '155:431-449).').format(modelvariant))
-            e_pw = numpy.ones((3,phydmslib.constants.N_NT), dtype='float')
+                                           "model.")
+            modelvariant = (yngkp_match
+                            .search(args['model'])
+                            .group('modelvariant'))
+            logger.info('Codon substitution model with be {0} version '
+                        '(Yang, Nielsen, Goldman, & Pederson. '
+                        'Genetics. 155:431-449).'.format(modelvariant))
+            e_pw = numpy.ones((3, phydmslib.constants.N_NT), dtype='float')
             for p in range(3):
                 for (w, nt) in phydmslib.constants.INDEX_TO_NT.items():
                     e_pw[p][w] = sum([list(seq)[p::3].count(nt) for (head, seq)
-                            in alignment])
+                                      in alignment])
             e_pw = e_pw / e_pw.sum(axis=1)[0]
             nsites = int(len(alignment[0][1]) / 3)
-            model = phydmslib.models.YNGKP_M0(e_pw, nsites, freeparams=
-                    ['mu', 'omega', 'kappa'])
+            model = phydmslib.models.YNGKP_M0(e_pw, nsites,
+                                              freeparams=['mu', 'omega',
+                                                          'kappa'])
             if modelvariant == 'M0':
                 pass
             elif modelvariant == 'M5':
-                logger.info(('For this {0} model, omega will be drawn from '
-                        '{1} gamma-distributed categories.').format(
-                        args['model'], args['ncats']))
+                logger.info('For this {0} model, omega will be drawn from '
+                            '{1} gamma-distributed categories.'
+                            .format(args['model'], args['ncats']))
                 model = phydmslib.models.GammaDistributedOmegaModel(
                         model, args['ncats'])
             else:
@@ -257,75 +273,88 @@ def main():
         elif (isinstance(args['model'], tuple) and len(args['model']) == 2 and
                 args['model'][0] == 'ExpCM'):
             prefsfile = args['model'][1]
-            logger.info(('The model will be an ExpCM informed by site-specific '
-                    'amino-acid preferences in {0}').format(prefsfile))
+            logger.info(('The model will be an ExpCM informed by site-specific'
+                         ' amino-acid preferences in {0}').format(prefsfile))
             for (argname, desc) in [('avgprefs', 'averaged'),
-                    ('randprefs', 'randomized')]:
+                                    ('randprefs', 'randomized')]:
                 if args[argname]:
-                    logger.info('Preferences will be {0} across sites.'.format(desc))
-            prefs = phydmslib.file_io.readPrefs(prefsfile, minpref=args['minpref'],
-                    avgprefs=args['avgprefs'], randprefs=args['randprefs'],
-                    seed=args['seed'])
+                    logger.info('Preferences will be {0} across sites.'
+                                .format(desc))
+            prefs = phydmslib.file_io.readPrefs(prefsfile,
+                                                minpref=args['minpref'],
+                                                avgprefs=args['avgprefs'],
+                                                randprefs=args['randprefs'],
+                                                seed=args['seed'])
             sites = sorted(prefs.keys())
-            prefslist = [prefs[r] for r in sites] # convert from dict to list
-            assert len(prefs) == len(alignment[0][1]) // 3, ("The number of "
-                    "preferences in {0} does not match the number of codon "
-                    "sites in the alignment").format(prefsfile)
-            logger.info(('Successfully read site-specific amino-acid preferences '
-                    'for all {0} sites.\n').format(len(prefs)))
+            prefslist = [prefs[r] for r in sites]  # convert from dict to list
+            assert (len(prefs) ==
+                    len(alignment[0][1]) // 3), ("The number of preferences "
+                                                 "in {0} does not match the "
+                                                 "number of codon sites in "
+                                                 "the alignment"
+                                                 .format(prefsfile))
+            logger.info('Successfully read site-specific amino-acid '
+                        'preferences for all {0} sites.\n'.format(len(prefs)))
             freeparams = ['mu', 'kappa', 'omega', 'beta']
             if args['fitphi']:
                 assert not args['divpressure'], (
                         "Can't use --divpressure and --fitphi")
                 freeparams.append('eta')
                 logger.info('Nucleotide frequency parameters phi will '
-                        'be optimized by maximum likelihood.\n')
-                model = phydmslib.models.ExpCM(prefslist, freeparams=freeparams)
+                            'be optimized by maximum likelihood.\n')
+                model = phydmslib.models.ExpCM(prefslist,
+                                               freeparams=freeparams)
             else:
                 g = numpy.ndarray(phydmslib.constants.N_NT, dtype='float')
                 for (w, nt) in phydmslib.constants.INDEX_TO_NT.items():
                     g[w] = sum([seq.count(nt) for (head, seq) in alignment])
-                assert len(alignment) * len(prefs) * 3 == (g.sum() +
-                        sum([seq.count('-') for (head, seq) in alignment])), (
-                        "Alignment contains invalid nucleotide characters")
+                assert ((len(alignment) * len(prefs) * 3)
+                        == (g.sum() + sum([seq.count('-') for (head, seq) in
+                                           alignment]))), ("Alignment contains"
+                                                           " invalid "
+                                                           "nucleotide "
+                                                           "characters")
                 g /= g.sum()
-                logger.info('Nucleotide frequency parameters phi will be '
-                        'set so stationary state matches alignment '
-                        'nucleotide frequencies of {0}\n'.format(
-                        ', '.join(['{0} = {1:.3f}'.format(nt, g[w]) for
-                        (w, nt) in phydmslib.constants.INDEX_TO_NT.items()])))
+                logger.info('Nucleotide frequency parameters phi will be set '
+                            'so stationary state matches alignment nucleotide '
+                            'frequencies of {0}\n'
+                            .format(', '.join(['{0} = {1:.3f}'
+                                    .format(nt, g[w]) for (w, nt) in
+                                    phydmslib.constants.INDEX_TO_NT.items()])))
                 if not args['divpressure']:
-                    model = phydmslib.models.ExpCM_empirical_phi(prefslist, g,
-                        freeparams=freeparams)
+                    model = (phydmslib
+                             .models
+                             .ExpCM_empirical_phi(prefslist, g,
+                                                  freeparams=freeparams))
                 else:
                     for otherarg in ['omegabysite', 'diffprefsbysite',
-                            'gammomega', 'gammabeta']:
+                                     'gammomega', 'gammabeta']:
                         if otherarg in args and args[otherarg]:
                             raise ValueError("Can't use --divpressure and "
-                                    "--{0}".format(otherarg))
+                                             "--{0}".format(otherarg))
                     freeparams.append('omega2')
                     divpressure = phydmslib.file_io.readDivPressure(
                             args['divpressure'])
                     assert set(prefs.keys()) == set(divpressure.keys()), (
-                            "The sites in {0} are different from {1}.".format(
-                            args['divpressure'], prefsfile))
+                            "The sites in {0} are different from {1}."
+                            .format(args['divpressure'], prefsfile))
                     logger.info(('Read diversifying pressure from {0} '
-                            'for all sites.').format(args['divpressure']))
+                                 'for all sites.').format(args['divpressure']))
                     divPressureSites = list(divpressure.keys())
-                    divpressure = numpy.array([divpressure[x] for x in
-                            sorted(divPressureSites)])
+                    divpressure = numpy.array([divpressure[x] for
+                                               x in sorted(divPressureSites)])
                     model = phydmslib.models.ExpCM_empirical_phi_divpressure(
                             prefslist, g, divpressure, freeparams=freeparams)
             if args['gammaomega']:
                 assert not args['gammabeta'], ("Can't use --gammabeta with"
-                        "--gammomega")
+                                               "--gammomega")
                 logger.info(('Omega will be drawn from {0} gamma-distributed '
                             'categories.\n').format(args['ncats']))
                 model = phydmslib.models.GammaDistributedOmegaModel(
                         model, args['ncats'])
             if args['gammabeta']:
                 assert not args['gammaomega'], ("Can't use --gammabeta with"
-                        "--gammomega")
+                                                "--gammomega")
                 logger.info(('Beta will be drawn from {0} gamma-distributed '
                             'categories.\n').format(args['ncats']))
                 model = phydmslib.models.GammaDistributedBetaModel(
@@ -343,9 +372,10 @@ def main():
                     if param in model.freeparams:
                         paramvalues[param.strip()] = float(value)
             assert paramvalues, "No values to initialize."
-            print("Initializing the following values:\n\t{0}\n".format(
-                    '\n\t'.join(['{0} = {1:.5f}'.format(param, value) for
-                    (param, value) in sorted(paramvalues.items())])))
+            print("Initializing the following values:\n\t{0}\n"
+                  .format('\n\t'.join(['{0} = {1:.5f}'.format(param, value)
+                                       for (param, value) in
+                                       sorted(paramvalues.items())])))
             model.updateParams(paramvalues)
 
         # read tree
@@ -353,16 +383,19 @@ def main():
         tree = Bio.Phylo.read(args['tree'], 'newick')
         tipnames = set([clade.name for clade in tree.get_terminals()])
         assert len(tipnames) == tree.count_terminals(), "non-unique tip names?"
-        assert tipnames == seqnames, ("Names in alignment do not match those in "
-                "tree.\nSequences in alignment but NOT in tree:\n\t{0}\n"
-                "Sequences in tree but NOT in alignment:\n\t{1}".format(
-                '\n\t'.join(seqnames - tipnames), '\n\t'.join(tipnames - seqnames)))
+        assert tipnames == seqnames, ("Names in alignment do not match those "
+                                      "in tree.\nSequences in alignment but "
+                                      "NOT in tree:\n\t{0}\n Sequences in "
+                                      "tree but NOT in alignment:\n\t{1}"
+                                      .format('\n\t'.join(seqnames - tipnames),
+                                              '\n\t'.join(tipnames - seqnames))
+                                      )
         logger.info('Tree has {0} tips.'.format(len(tipnames)))
         tree.root_at_midpoint()
         assert tree.is_bifurcating(), "Tree is not bifurcating: cannot handle"
         nadjusted = 0
         for node in tree.get_terminals() + tree.get_nonterminals():
-            if (node.branch_length == None) and (node == tree.root):
+            if (node.branch_length is None) and (node == tree.root):
                 node.branch_length = args['minbrlen']
             elif node.branch_length < args['minbrlen']:
                 nadjusted += 1
@@ -384,7 +417,7 @@ def main():
         if args['brlen'] == 'scale':
             optimize_brlen = False
             logger.info("Branch lengths will be scaled but not optimized "
-                    "individually.")
+                        "individually.")
         elif args['brlen'] == 'optimize':
             logger.info("Branch lengths will be optimized individually.")
             optimize_brlen = True
@@ -397,17 +430,19 @@ def main():
             logger.info('Maximizing with cProfile (probably slower).')
             logger.info('Profile stats will be in to {0}'.format(pstatsfile))
             maxresult = []
-            def wrapper(maxresult): # wrapper to get return value from cProfile
+
+            def wrapper(maxresult):  # wrapper to get return value frm cProfile
                 maxresult.append(tl.maximizeLikelihood(
                         optimize_brlen=optimize_brlen,
                         approx_grad=args['nograd'],
                         printfunc=printfunc))
-            cProfile.runctx('wrapper(maxresult)', globals(), locals(), pstatsfile)
+            cProfile.runctx('wrapper(maxresult)', globals(), locals(),
+                            pstatsfile)
             maxresult = maxresult[0]
             for psort in ['cumulative', 'tottime']:
                 fname = '{0}_{1}.txt'.format(pstatsfile, psort)
-                logger.info('Writing profile stats sorted by {0} to {1}'.format(
-                        psort, fname))
+                logger.info('Writing profile stats sorted by {0} to {1}'
+                            .format(psort, fname))
                 f = open(fname, 'w')
                 s = pstats.Stats(pstatsfile, stream=f)
                 s.strip_dirs()
@@ -416,16 +451,19 @@ def main():
                 f.close()
         else:
             maxresult = tl.maximizeLikelihood(optimize_brlen=optimize_brlen,
-                    approx_grad=args['nograd'], printfunc=printfunc)
+                                              approx_grad=args['nograd'],
+                                              printfunc=printfunc)
         logger.info('Maximization complete:\n\t{0}'.format(
                 maxresult.replace('\n', '\n\t')))
         logger.info('Optimized log likelihood is {0:.2f}.'.format(tl.loglik))
         logger.info('Writing log likelihood to {0}'.format(loglikelihoodfile))
         with open(loglikelihoodfile, 'w') as f:
             f.write('log likelihood = {0:.2f}'.format(tl.loglik))
-        params = '\n\t'.join(['{0} = {1:6g}'.format(p, pvalue) for (p, pvalue)
-                in sorted(tl.model.paramsReport.items())])
-        logger.info('Model parameters after optimization:\n\t{0}'.format(params))
+        params = ('\n\t'.join(['{0} = {1:6g}'
+                  .format(p, pvalue) for (p, pvalue) in
+                          sorted(tl.model.paramsReport.items())]))
+        logger.info('Model parameters after optimization:\n\t{0}'
+                    .format(params))
         logger.info('Writing model parameters to {0}'.format(modelparamsfile))
         with open(modelparamsfile, 'w') as f:
             f.write(params.replace('\t', ''))
@@ -442,7 +480,7 @@ def main():
         # optimize a different omega for each site
         if args['omegabysite']:
             logger.info("\nFitting a different omega to each site to "
-                    "detect diversifying selection.")
+                        "detect diversifying selection.")
             if args['omegabysite_fixsyn']:
                 fixsynstr = 'Synonymous rate will be fixed across sites.'
             else:
@@ -453,16 +491,21 @@ def main():
             # To save memory, use pool sizes equal to number of CPUs
             omegaresults = []
             for firstsite in range(1, tl.nsites + 1, ncpus):
-                currentsites = range(firstsite, min(tl.nsites + 1,
-                        firstsite + ncpus))
+                currentsites = range(firstsite,
+                                     min(tl.nsites + 1,
+                                         firstsite + ncpus))
                 if ncpus > 1:
                     pool = multiprocessing.Pool(ncpus)
                     mapfunc = pool.imap
                 else:
                     mapfunc = map
-                omegaresults += mapfunc(fitOmegaBySite, [treeliksForOmegaBySite(
-                        site, tl, prefslist, args['omegabysite_fixsyn'],
-                        args['nograd']) for site in currentsites])
+                omegaresults += mapfunc(fitOmegaBySite,
+                                        [treeliksForOmegaBySite(site,
+                                                                tl,
+                                                                prefslist,
+                                                                args['omegabysite_fixsyn'],
+                                                                args['nograd'])
+                                         for site in currentsites])
                 if ncpus > 1:
                     pool.close()
                     pool.join()
@@ -472,16 +515,16 @@ def main():
             # compute Q-values separately for each sign of omega
             qvalues = numpy.ones(pvalues.shape)
             for op in [operator.ge, operator.le]:
-                pvalues_sign = numpy.where(op(omegas, 1),
-                        pvalues, 1)
+                pvalues_sign = numpy.where(op(omegas, 1), pvalues, 1)
                 qvalues_sign = (statsmodels.sandbox.stats.multicomp
-                        .multipletests(pvalues_sign, method='fdr_bh')[1])
+                                .multipletests(pvalues_sign, method='fdr_bh')
+                                [1])
                 qvalues = numpy.minimum(qvalues, qvalues_sign)
             sortindex = numpy.argsort(qvalues)
             qvalues = numpy.take(qvalues, sortindex)
             omega_strs = numpy.take(omega_strs, sortindex)
             omegaresults = ['{0}\t{1:.3g}'.format(omega_str, q) for
-                    (omega_str, q) in zip(omega_strs, qvalues)]
+                            (omega_str, q) in zip(omega_strs, qvalues)]
             logger.info("Completed fitting the site-specific omega values.")
             logger.info("Writing results to {0}\n".format(omegafile))
             with open(omegafile, 'w') as f:
@@ -490,13 +533,13 @@ def main():
                         'of omega = 1.\n# P-values NOT corrected for multiple '
                         'testing, so consider Q-values too.\n# Q-values '
                         'computed separately for omega > and < 1 # {0}\n#\n'
-                        'site\tomega\tP\tdLnL\tQ\n{1}'.format(fixsynstr,
-                        '\n'.join(omegaresults)))
+                        'site\tomega\tP\tdLnL\tQ\n{1}'
+                        .format(fixsynstr, '\n'.join(omegaresults)))
 
         # optimize differential preferences for each site
         if args['diffprefsbysite']:
             logger.info("\nFitting differential preferences for each site to "
-                    "detect differential selection.")
+                        "detect differential selection.")
             if args['fitprefsmethod'] == 1:
                 modeltype = phydmslib.models.ExpCM_fitprefs
                 othermodeltype = phydmslib.models.ExpCM_fitprefs2
@@ -506,39 +549,49 @@ def main():
             else:
                 raise ValueError("Invalid fitprefsmethod")
             logger.info("For the fitting, using {0} implementation "
-                    "as specified by fitprefsmethod = {1}".format(
-                    modeltype.__name__, args['fitprefsmethod']))
+                        "as specified by fitprefsmethod = {1}"
+                        .format(modeltype.__name__, args['fitprefsmethod']))
             logger.info("Fitting with {0} CPUs...".format(ncpus))
-            # We use a multiprocessing pool if more than 1 CPU.
-            # To save memory, use pool sizes equal to number of CPUs
+            #  We use a multiprocessing pool if more than 1 CPU.
+            #  To save memory, use pool sizes equal to number of CPUs
             diffprefresults = []
             for firstsite in range(1, tl.nsites + 1, ncpus):
                 currentsites = range(firstsite, min(tl.nsites + 1,
-                        firstsite + ncpus))
+                                     firstsite + ncpus))
                 if ncpus > 1:
                     pool = multiprocessing.Pool(ncpus)
                     mapfunc = pool.imap
                 else:
                     mapfunc = map
                 diffprefresults += mapfunc(fitDiffPrefsBySite,
-                        [treelikForDiffPrefsBySite(site, tl, prefslist,
-                        args['diffprefsprior'], modeltype, othermodeltype,
-                        args['nograd']) for site in currentsites])
+                                           [treelikForDiffPrefsBySite(site,
+                                                                      tl,
+                                                                      prefslist,
+                                                                      args['diffprefsprior'],
+                                                                      modeltype,
+                                                                      othermodeltype,
+                                                                      args['nograd'])
+                                            for site in currentsites])
                 if ncpus > 1:
                     pool.close()
                     pool.join()
-            logger.info("Completed fitting site-specific differential preferences.")
+            logger.info("Completed fitting site-specific "
+                        "differential preferences.")
             logger.info("Writing results to {0}\n".format(diffprefsfile))
             with open(diffprefsfile, 'w') as f:
-                f.write('# Differential preferences fit to each site.\n' +
-                        '# Regularizing prior: {0}\n#\n'.format(args['diffprefsprior'])
-                        + 'site\t' + '\t'.join(['dpi_{0}'.format(INDEX_TO_AA[a])
-                        for a in range(N_AA)]) + '\thalf_sum_abs_dpi\n')
+                f.write(('# Differential preferences fit to each site.\n'
+                         '# Regularizing prior: {0}\n#\n'
+                         .format(args['diffprefsprior']))
+                        + 'site\t'
+                        + ('\t'.join(['dpi_{0}'
+                           .format(INDEX_TO_AA[a]) for a in range(N_AA)]))
+                        + '\thalf_sum_abs_dpi\n')
                 f.write('\n'.join([tup[1] for tup in sorted(diffprefresults,
                         reverse=True)]))
 
-    except:
-        logger.exception('Terminating {0} at {1} with ERROR'.format(prog, time.asctime()))
+    except Exception:
+        logger.exception('Terminating {0} at {1} with '
+                         'ERROR'.format(prog, time.asctime()))
         raise
     else:
         logger.info('Successful completion of {0}'.format(prog))
@@ -546,6 +599,5 @@ def main():
         logging.shutdown()
 
 
-
 if __name__ == '__main__':
-    main() # run the script
+    main()  # run the script

--- a/scripts/phydms_comprehensive
+++ b/scripts/phydms_comprehensive
@@ -5,7 +5,6 @@
 Written by Jesse Bloom and Sarah Hilton."""
 
 
-import sys
 import os
 import re
 import time
@@ -18,17 +17,18 @@ import glob
 import phydmslib
 import phydmslib.file_io
 import phydmslib.parsearguments
-import pandas as pd
+
 
 def RunCmds(cmds):
     """Runs the command line arguments in *cmds* using *subprocess*."""
     try:
         p = subprocess.Popen(cmds, stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT)
+                             stderr=subprocess.STDOUT)
         pid = p.pid
         (stdout, stderr) = p.communicate()
-    except:
+    except Exception:
         os.kill(pid, signal.SIGTERM)
+
 
 def createModelComparisonFile(models, outprefix, modelcomparisonfile):
     """Creates `modelcomparisonfile` in Markdown format.
@@ -54,21 +54,24 @@ def createModelComparisonFile(models, outprefix, modelcomparisonfile):
         with open(outprefix + modelName + '_modelparams.txt') as f:
             params = [(line.split('=')) for line in f]
         stats['nParams'].append(len(params))
-        paramvalues = ['{0}={1:.2f}'.format(name.strip(), float(value)) for
-                (name, value) in sorted(params) if 'phi' not in name]
+        paramvalues = ['{0}={1:.2f}'.format(name.strip(), float(value))
+                       for (name, value) in sorted(params) if 'phi' not in
+                       name]
         stats['ParamValues'].append(', '.join(paramvalues))
         stats['deltaAIC'].append(2 * (stats['nParams'][-1] -
-                stats['LogLikelihood'][-1]))
+                                      stats['LogLikelihood'][-1]))
     minAIC = min(stats['deltaAIC'])
     stats['deltaAIC'] = [x - minAIC for x in stats['deltaAIC']]
     nrows = len(stats['Model'])
-    indexorder = [tup[1] for tup in sorted(zip(stats['deltaAIC'], range(nrows)))]
+    indexorder = [tup[1] for tup in sorted(zip(stats['deltaAIC'],
+                                           range(nrows)))]
     for col in ['deltaAIC', 'LogLikelihood']:
         stats[col] = ['{0:.2f}'.format(x) for x in stats[col]]
     stats['nParams'] = [str(x) for x in stats['nParams']]
     colwidths = [max(map(len, stats[col] + [col])) for col in columns]
     formatline = ('| ' + ' | '.join(['{' + str(i) + ':' + str(w) + '}'
-            for (i, w) in enumerate(colwidths)]) + ' |')
+                                     for (i, w) in enumerate(colwidths)])
+                  + ' |')
     sepline = '|-' + '-|-'.join(['-' * w for w in colwidths]) + '-|'
     text = [formatline.format(*columns), sepline]
     for i in indexorder:
@@ -86,7 +89,7 @@ def main():
     args = vars(parser.parse_args())
     prog = parser.prog
 
-    #create output directory if needed
+    # create output directory if needed
     outdir = os.path.dirname(args['outprefix'])
     if outdir:
         if not os.path.isdir(outdir):
@@ -94,7 +97,7 @@ def main():
                 os.remove(outdir)
             os.mkdir(outdir)
 
-    #setup files
+    # setup files
     # file names slightly different depending on
     # whether outprefix is directory or file
     if args['outprefix'][-1] == '/':
@@ -105,50 +108,52 @@ def main():
     modelcomparisonfile = '{0}modelcomparison.md'.format(args['outprefix'])
     raxmlStandardOutputFile = '{0}raxml_output.txt'.format(args['outprefix'])
 
-    #Set up to log everything to logfile.
+    # Set up to log everything to logfile.
     if os.path.isfile(logfile):
         os.remove(logfile)
     logging.shutdown()
     logging.captureWarnings(True)
     versionstring = phydmslib.file_io.Versions()
     logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s',
-        level=logging.INFO)
+                        level=logging.INFO)
     logger = logging.getLogger(prog)
     logfile_handler = logging.FileHandler(logfile)
     logger.addHandler(logfile_handler)
     formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
     logfile_handler.setFormatter(formatter)
 
-    #print some basic information
+    # print some basic information
     logger.info('Beginning execution of {0} in directory {1}\n'
-            .format(prog, os.getcwd()))
+                .format(prog, os.getcwd()))
     logger.info('Progress is being logged to {0}\n'.format(logfile))
     logger.info('{0}\n'.format(versionstring))
     logger.info('Parsed the following command-line arguments:\n{0}\n'
-            .format('\n'.join(['\t{0} = {1}'.format(key, args[key])
-            for key in args.keys()])))
+                .format('\n'.join(['\t{0} = {1}'.format(key, args[key])
+                                   for key in args.keys()])))
 
-    #setup models
+    # setup models
     filesuffixlist = ['_log.log', '_tree.newick', '_loglikelihood.txt',
-            '_modelparams.txt']
-    filesuffixes = {} # keyed by model, values are list of suffixes
+                      '_modelparams.txt']
+    filesuffixes = {}  # keyed by model, values are list of suffixes
     models = {}
     additionalcmds = ["--brlen", args["brlen"]]
     if args['omegabysite']:
         additionalcmds.append('--omegabysite')
         filesuffixlist = copy.deepcopy(filesuffixlist) + ['_omegabysite.txt']
 
-    #set up the YNGKP models
-    models = {'YNGKP_M0':('YNGKP_M0', additionalcmds)}
+    # set up the YNGKP models
+    models = {'YNGKP_M0': ('YNGKP_M0', additionalcmds)}
     filesuffixes['YNGKP_M0'] = filesuffixlist
     models['YNGKP_M5'] = ('YNGKP_M5', additionalcmds)
     filesuffixes['YNGKP_M5'] = filesuffixlist
 
-    #set up the ExpCM
+    # set up the ExpCM
     additionalcmds = copy.deepcopy(additionalcmds)
     if args['diffprefsbysite']:
-        additionalcmds = copy.deepcopy(additionalcmds) + ['--diffprefsbysite']
-        filesuffixlist = copy.deepcopy(filesuffixlist) + ['_diffprefsbysite.txt']
+        additionalcmds = (copy.deepcopy(additionalcmds)
+                          + ['--diffprefsbysite'])
+        filesuffixlist = (copy.deepcopy(filesuffixlist)
+                          + ['_diffprefsbysite.txt'])
     for prefsfile in args['prefsfiles']:
         if re.search('\s', prefsfile):
             raise ValueError("There is a space in the preferences file name:\
@@ -156,75 +161,73 @@ def main():
         prefsfilebase = os.path.splitext(os.path.basename(prefsfile))[0]
         modelname = 'ExpCM_{0}'.format(prefsfilebase)
         assert modelname not in filesuffixes, "Duplicate preferences file"\
-                " base name {0} for {1}; make names unique even after "\
-                "removing directory and extension".format(modelname, prefsfile)
+            " base name {0} for {1}; make names unique even after "\
+            "removing directory and extension".format(modelname, prefsfile)
         filesuffixes[modelname] = filesuffixlist
         models[modelname] = ('ExpCM_{0}'.format(prefsfile), additionalcmds)
         if args["gammaomega"]:
             gammaomegamodelname = '{0}_gammaomega'.format(modelname)
             models[gammaomegamodelname] = ('ExpCM_{0}'.format(prefsfile),
-                    additionalcmds + ['--gammaomega'])
+                                           additionalcmds + ['--gammaomega'])
             filesuffixes[gammaomegamodelname] = filesuffixlist
         if args["gammabeta"]:
             gammabetamodelname = '{0}_gammabeta'.format(modelname)
             models[gammabetamodelname] = ('ExpCM_{0}'.format(prefsfile),
-                    additionalcmds + ['--gammabeta'])
+                                          additionalcmds + ['--gammabeta'])
             filesuffixes[gammabetamodelname] = filesuffixlist
         if not args['noavgprefs']:
             avgmodelname = 'averaged_{0}'.format(modelname)
             models[avgmodelname] = ('ExpCM_{0}'.format(prefsfile),
-                    additionalcmds + ['--avgprefs'], 0)
+                                    additionalcmds + ['--avgprefs'], 0)
             filesuffixes[avgmodelname] = filesuffixlist
             if args["gammaomega"]:
                 avgmodelname = 'averaged_{0}_gammaomega'.format(modelname)
                 models[avgmodelname] = ('ExpCM_{0}'.format(prefsfile),
-                        additionalcmds + ['--gammaomega'] \
-                        + ['--avgprefs'], 0)
+                                        additionalcmds + ['--gammaomega']
+                                        + ['--avgprefs'], 0)
                 filesuffixes[avgmodelname] = filesuffixlist
             if args["gammabeta"]:
                 avgmodelname = 'averaged_{0}_gammabeta'.format(modelname)
                 models[avgmodelname] = ('ExpCM_{0}'.format(prefsfile),
-                        additionalcmds + ['--gammabeta'] \
-                        + ['--avgprefs'], 0)
+                                        additionalcmds + ['--gammabeta']
+                                        + ['--avgprefs'], 0)
                 filesuffixes[avgmodelname] = filesuffixlist
         if args['randprefs']:
             randmodelname = 'randomized_{0}'.format(modelname)
             models[randmodelname] = ('ExpCM_{0}'.format(prefsfile),
-                    additionalcmds + ['--randprefs'], 0)
+                                     additionalcmds + ['--randprefs'], 0)
             filesuffixes[randmodelname] = filesuffixlist
             if args["gammaomega"]:
                 randmodelname = 'randomized_{0}_gammaomega'.format(modelname)
                 models[randmodelname] = ('ExpCM_{0}'.format(prefsfile),
-                        additionalcmds + ['--gammaomega'] \
-                        + ['--randprefs'], 0)
+                                         additionalcmds + ['--gammaomega']
+                                         + ['--randprefs'], 0)
                 filesuffixes[randmodelname] = filesuffixlist
             if args["gammabeta"]:
                 randmodelname = 'randomized_{0}_gammabeta'.format(modelname)
                 models[randmodelname] = ('ExpCM_{0}'.format(prefsfile),
-                        additionalcmds + ['--gammabeta'] \
-                        + ['--randprefs'], 0)
+                                         additionalcmds + ['--gammabeta']
+                                         + ['--randprefs'], 0)
                 filesuffixes[randmodelname] = filesuffixlist
 
     # check alignment
     logger.info('Checking that the alignment {0} is valid...'
-            .format(args['alignment']))
+                .format(args['alignment']))
     alignment = phydmslib.file_io.ReadCodonAlignment(args['alignment'],
-            checknewickvalid=True) #checks that the identifiers are unique
+                                                     checknewickvalid=True)
     logger.info('Valid alignment specifying {0} sequences of length {1}.\n'
-            .format(len(alignment), len(alignment[0][1])))
+                .format(len(alignment), len(alignment[0][1])))
 
-    #read or build a tree
+    # read or build a tree
     if args["tree"]:
-      logger.info("Reading tree from {0}".format(args['tree']))
+        logger.info("Reading tree from {0}".format(args['tree']))
     else:
         logger.info("Tree not specified.")
         try:
-            raxmlversion = subprocess.check_output([args['raxml'], '-v'],
-                    stderr=subprocess.STDOUT).strip()
             logger.info("Inferring tree with RAxML using command {0}"
-                    .format(args['raxml']))
+                        .format(args['raxml']))
 
-            #remove pre-existing RAxML files
+            # remove pre-existing RAxML files
             raxmlOutputName = os.path.splitext(os.path.basename(
                     args["alignment"]))[0]
             raxmlOutputFiles = []
@@ -234,14 +237,14 @@ def main():
                     os.remove(raxmlFile)
             if len(raxmlOutputFiles) > 0:
                 logger.info('Removed the following RAxML files:\n{0}\n'
-                    .format('\n'.join(['\t{0}'.format(fname) for
-                    fname in raxmlOutputFiles])))
+                            .format('\n'.join(['\t{0}'.format(fname) for
+                                               fname in raxmlOutputFiles])))
 
             # run RAxmL
             raxmlCMD = [args['raxml'], '-s', args['alignment'], '-n',
-                    raxmlOutputName, '-m', 'GTRCAT', '-p1', '-T', '2']
+                        raxmlOutputName, '-m', 'GTRCAT', '-p1', '-T', '2']
             with open(raxmlStandardOutputFile, 'w') as f:
-                subprocess.check_call(raxmlCMD, stdout = f)
+                subprocess.check_call(raxmlCMD, stdout=f)
 
             # move RAxML tree to output directory and remove all other files
             for raxmlFile in glob.glob("RAxML_*{0}".format(raxmlOutputName)):
@@ -253,43 +256,44 @@ def main():
                 else:
                     os.remove(raxmlFile)
         except OSError:
-            raise ValueError("The raxml command of {0} is not valid."
-                    " Is raxml installed at this path?".format(args['raxml']))
+            raise ValueError("The raxml command of {0} is not valid. Is raxml "
+                             "installed at this path?".format(args['raxml']))
 
     # get number of available CPUs and assign to each model
     if args['ncpus'] == -1:
         try:
             args['ncpus'] = multiprocessing.cpu_count()
-        except:
+        except Exception:
             raise RuntimeError("Encountered a problem trying to dynamically"
-                    " determine the number of available CPUs. "
-                    "Please manually specify the number of desired CPUs with"
-                    " '--ncpus' and try again.")
+                               " determine the number of available CPUs. "
+                               "Please manually specify the number of "
+                               "desired CPUs with '--ncpus' and try again.")
             logger.info('Will use all %d available CPUs.\n' % args['ncpus'])
     assert args['ncpus'] >= 1, "Failed to specify valid number of CPUs"
 
     # YNGKP models get one CPU
     # ExpCM get more than one if excess over number of models
-    expcm_modelnames = [modelname for modelname in models.keys() \
-            if 'ExpCM' in modelname]
-    yngkp_modelnames = [modelname for modelname in models.keys() \
-            if 'YNGKP' in modelname]
-    assert len(models.keys()) == len(expcm_modelnames) + len(yngkp_modelnames)\
-            , "not ExpCM or YNGKP:\n{0}".format(str(models.keys()))
+    expcm_modelnames = [modelname for modelname in models.keys()
+                        if 'ExpCM' in modelname]
+    yngkp_modelnames = [modelname for modelname in models.keys()
+                        if 'YNGKP' in modelname]
+    assert len(models.keys())\
+           == (len(expcm_modelnames) + len(yngkp_modelnames)),\
+           ("not ExpCM or YNGKP:\n{0}".format(str(models.keys())))
     ncpus_per_model = dict([(modelname, 1) for modelname in yngkp_modelnames])
     nperexpcm = max(1, (args['ncpus'] - 2) // len(expcm_modelnames))
     for modelname in expcm_modelnames:
         ncpus_per_model[modelname] = nperexpcm
     for modelname in models.keys():
         mtup = models[modelname]
-        models[modelname] = (mtup[0], mtup[1] + ['--ncpus',
-                str(ncpus_per_model[modelname])])
+        models[modelname] = (mtup[0],
+                             mtup[1] + ['--ncpus',
+                                        str(ncpus_per_model[modelname])])
 
-
-    pool = {} # holds process for model name
-    started = {} # holds whether process started for model name
-    completed = {} # holds whether process completed for model name
-    outprefixes = {} # holds outprefix for model name
+    pool = {}  # holds process for model name
+    started = {}  # holds whether process started for model name
+    completed = {}  # holds whether process completed for model name
+    outprefixes = {}  # holds outprefix for model name
 
     # rest of execution in try / finally
     try:
@@ -299,7 +303,8 @@ def main():
         removed = []
         for modelname in models.keys():
             for suffix in filesuffixes[modelname]:
-                fname = "{0}{1}{2}".format(args['outprefix'], modelname, suffix)
+                fname = "{0}{1}{2}".format(args['outprefix'], modelname,
+                                           suffix)
                 outfiles.append(fname)
         for fname in outfiles:
             if os.path.isfile(fname):
@@ -307,20 +312,20 @@ def main():
                 removed.append(fname)
         if removed:
             logger.info('Removed the following existing files that have names'
-                    " that match the names of output files that will be "
-                    'created: {0}\n'.format(', '.join(removed)))
+                        " that match the names of output files that will be "
+                        'created: {0}\n'.format(', '.join(removed)))
 
-        #now run the models
+        # now run the models
         for modelname in list(models.keys()):
             (model, additionalcmds) = models[modelname]
             outprefix = "{0}{1}".format(args['outprefix'], modelname)
             cmds = ['phydms', args['alignment'], args["tree"], model,
                     outprefix] + additionalcmds
-            logger.info('Starting analysis to optimize tree in {0} using model '
-                    '{1}. The command is: {2}\n'.format( args["tree"],
-                    modelname, ' '.join(cmds)))
-            pool[modelname] = multiprocessing.Process(target=RunCmds\
-                    , args=(cmds,))
+            logger.info('Starting analysis to optimize tree in {0} using '
+                        'model {1}. The command is: {2}\n'
+                        .format(args["tree"], modelname, ' '.join(cmds)))
+            pool[modelname] = multiprocessing.Process(target=RunCmds,
+                                                      args=(cmds,))
             outprefixes[modelname] = outprefix
             completed[modelname] = False
             started[modelname] = False
@@ -335,32 +340,33 @@ def main():
                         break
             for (modelname, p) in pool.items():
                 if started[modelname] and (not completed[modelname]) and \
-                        (not p.is_alive()): # process just completed
+                        (not p.is_alive()):  # process just completed
                     completed[modelname] = True
                     logger.info('Analysis completed for {0}'.format(modelname))
                     for fname in [outprefixes[modelname] + suffix for suffix
-                            in filesuffixes[modelname]]:
+                                  in filesuffixes[modelname]]:
                         if not os.path.isfile(fname):
                             raise RuntimeError("phydms failed to created"
-                                    " expected output file {0}.".format(fname))
-                        logger.info("Found expected output file {0}"\
-                                .format(fname))
-                    logger.info('Analysis successful for {0}\n'\
-                            .format(modelname))
+                                               " expected output file {0}."
+                                               .format(fname))
+                        logger.info("Found expected output file {0}"
+                                    .format(fname))
+                    logger.info('Analysis successful for {0}\n'
+                                .format(modelname))
             time.sleep(1)
 
         createModelComparisonFile(models.keys(), args["outprefix"],
-                modelcomparisonfile)
+                                  modelcomparisonfile)
 
         # make sure all expected output files are there
         for fname in outfiles:
             if not os.path.isfile(fname):
                 raise RuntimeError("Cannot find expected output file {0}"
-                        .format(fname))
+                                   .format(fname))
 
-    except:
+    except Exception:
         logger.exception('Terminating {0} at {1} with ERROR'
-                .format(prog, time.asctime()))
+                         .format(prog, time.asctime()))
     else:
         logger.info('Successful completion of {0}'.format(prog))
     finally:
@@ -371,4 +377,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main() # run the script
+    main()  # run the script

--- a/scripts/phydms_comprehensive
+++ b/scripts/phydms_comprehensive
@@ -346,9 +346,9 @@ def main():
                     for fname in [outprefixes[modelname] + suffix for suffix
                                   in filesuffixes[modelname]]:
                         if not os.path.isfile(fname):
-                            raise RuntimeError("phydms failed to created"
-                                               " expected output file {0}."
-                                               .format(fname))
+                            raise RuntimeError(
+                                "phydms failed to created expected output "
+                                "file {0}.".format(fname))
                         logger.info("Found expected output file {0}"
                                     .format(fname))
                     logger.info('Analysis successful for {0}\n'

--- a/scripts/phydms_divpressure
+++ b/scripts/phydms_divpressure
@@ -6,7 +6,6 @@ Written by Jesse Boom and Sarah Hilton.
 """
 
 
-import sys
 import os
 import re
 import time
@@ -20,14 +19,16 @@ import phydmslib.parsearguments
 import pandas as pd
 import random
 
-def randomizeDivpressure(divpressureFile,numberRandomizations,outprefix):
+
+def randomizeDivpressure(divpressureFile, numberRandomizations, outprefix):
     """
     This function randomizes a diversfiying pressure list the number of
     times specfied by the user. Each randomization is written to a new
     diversifying pressures files in the directory 'randomizedFiles'.
     The function returns a dictionary of file names keyed by the random seed.
     """
-    divpressurefilebase = os.path.splitext(os.path.basename(divpressureFile))[0]
+    divpressurefilebase = (os.path
+                           .splitext(os.path.basename(divpressureFile))[0])
     outdir = os.path.dirname(outprefix+"randomizedFiles/")
     if outdir:
         if not os.path.isdir(outdir):
@@ -41,14 +42,15 @@ def randomizeDivpressure(divpressureFile,numberRandomizations,outprefix):
     for seed in range(int(numberRandomizations)):
         random.seed(seed)
         random.shuffle(divpressures)
-        randomDivpressureFile = outdir+'/{0}_random_{1}.csv'\
-                .format(divpressurefilebase, seed)
+        randomDivpressureFile = '{0}/{1}_random_{2}.csv'\
+                                .format(outdir, divpressurefilebase, seed)
         with open(randomDivpressureFile, 'w') as f:
             f.write("#SITE,VALUE\n")
-            f.write('\n'.join('{0},{1}'.format(site, dp) for (site, dp) \
-                    in zip(sites, divpressures)))
+            f.write('\n'.join('{0},{1}'.format(site, dp) for (site, dp)
+                              in zip(sites, divpressures)))
         randomFiles[seed] = randomDivpressureFile
     return randomFiles
+
 
 def createModelComparisonFile(models, outprefix):
     """
@@ -76,60 +78,65 @@ def createModelComparisonFile(models, outprefix):
         Only the non-randomized `phydms` runs are included.
     """
 
-    #modelcomparison.csv
-    final = pd.DataFrame({"Preferences":[],"DiversifyingPressureSet":[],
-            "DiversifyingPressureType":[],"DiversifyingPressureID":[],
-            "variable":[], "value":[]})
+    # modelcomparison.csv
+    final = pd.DataFrame({"Preferences": [], "DiversifyingPressureSet": [],
+                          "DiversifyingPressureType": [],
+                          "DiversifyingPressureID": [],
+                          "variable": [], "value": []})
     for modelID in models.keys():
-        outFilePrefix = "ExpCM_" + '_'.join(str(item) for item in modelID\
-                if item != "None")
+        outFilePrefix = "ExpCM_" + '_'.join(str(item) for item in
+                                            modelID if item != "None")
         df = pd.read_csv(outprefix + outFilePrefix + "_modelparams.txt",
-                sep = " = ", header = None, engine = 'python')
-        df.columns = ['variable', 'value'] #rename the columns
+                         sep=" = ", header=None, engine='python')
+        df.columns = ['variable', 'value']  # rename the columns
         df["Preferences"] = [modelID[0] for x in range(len(df))]
         df["DiversifyingPressureSet"] = [modelID[1] for x in range(len(df))]
         df["DiversifyingPressureType"] = [modelID[2] for x in range(len(df))]
-        df["DiversifyingPressureID"] = [modelID[1] + "_" + str(modelID[3]) \
-                for x in range(len(df))]
+        df["DiversifyingPressureID"] = [modelID[1] + "_" + str(modelID[3])
+                                        for x in range(len(df))]
         final = pd.concat([final, df], sort=True)
         with open(outprefix + outFilePrefix + "_loglikelihood.txt") as f:
-            temp = {"Preferences":[],"DiversifyingPressureSet":[],
-                    "DiversifyingPressureType":[],"DiversifyingPressureID":[],
-                    "variable":[], "value":[]}
+            temp = {"Preferences": [], "DiversifyingPressureSet": [],
+                    "DiversifyingPressureType": [],
+                    "DiversifyingPressureID": [],
+                    "variable": [], "value": []}
             lines = f.readlines()
             temp["Preferences"] = [modelID[0]]
             temp["DiversifyingPressureSet"] = [modelID[1]]
             temp["DiversifyingPressureType"] = [modelID[2]]
-            temp["DiversifyingPressureID"] = [modelID[1] + "_" + str(modelID[3])]
+            temp["DiversifyingPressureID"] = ["{0}_{1}".format(modelID[1],
+                                                               modelID[3])]
             temp["variable"].append("LogLikelihood")
             temp["value"].append(lines[0].split(" = ")[-1])
         final = pd.concat([final, pd.DataFrame(temp)])
-    final.to_csv(outprefix + "modelcomparison.csv", index = False)
-    final.reset_index(drop=True, inplace = True)
+    final.to_csv(outprefix + "modelcomparison.csv", index=False)
+    final.reset_index(drop=True, inplace=True)
 
-
-    #modelcomparison.md
-    #pivot the dataframe so the parameters are columns
-    mdDF = final[final["DiversifyingPressureType"] != "Random"]\
-            .pivot(index = "DiversifyingPressureSet", columns='variable',
-             values='value')
+    # modelcomparison.md
+    # spivot the dataframe so the parameters are columns
+    mdDF = (final[final["DiversifyingPressureType"] != "Random"]
+            .pivot(index="DiversifyingPressureSet",
+                   columns='variable', values='value'))
     mdDF = mdDF[[x for x in mdDF.columns.values]]
     with open(outprefix + "modelcomparison.md", "w") as f:
-        f.write("|".join(["DiversifyingPressureSet"] \
-                + list(mdDF.columns.values)) + "\n")
+        f.write("|".join(["DiversifyingPressureSet"] +
+                         list(mdDF.columns.values)) + "\n")
         f.write("".join(["---|" for x in range(len(mdDF.columns.values))]
                 + ["---"]) + "\n")
         for index, row in mdDF.iterrows():
-            f.write("|".join([str(x) for x in [index]+ list(row)]) + "\n")
+            f.write("|".join([str(x) for x in [index] + list(row)]) + "\n")
+
 
 def RunCmds(cmds):
     """Runs the command line arguments in *cmds* using *subprocess*."""
     try:
-        p = subprocess.Popen(cmds, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        p = subprocess.Popen(cmds, stdout=subprocess.PIPE,
+                             stderr=subprocess.STDOUT)
         pid = p.pid
         (stdout, stderr) = p.communicate()
-    except:
-        os.kill(pid, signal.SIGTERM)
+    except Exception:
+        os.kill(pid)
+
 
 def main():
     """
@@ -148,11 +155,11 @@ def main():
             (pref file, list of `phydms` commands,
             number of empirical parameters, modelprefix)
 
-    The branch lengths are optimized using `ExpCM` without diversifying pressure
-    on either the tree specfied by the user or the tree inferred under the
-    *GTRCAT* with `RAxML`. The `ExpCM` with diversifying pressures are run with
-    this optimized tree and the branch lengths are scaled but not individually
-    optimized.
+    The branch lengths are optimized using `ExpCM` without diversifying
+    pressure on either the tree specfied by the user or the tree inferred
+    under the *GTRCAT* with `RAxML`. The `ExpCM` with diversifying pressures
+    are run with this optimized tree and the branch lengths are scaled but not
+    individually optimized.
     """
 
     # Parse command line arguments
@@ -160,7 +167,7 @@ def main():
     args = vars(parser.parse_args())
     prog = parser.prog
 
-    #create output directory if needed
+    # create output directory if needed
     outdir = os.path.dirname(args['outprefix'])
     if outdir:
         if not os.path.isdir(outdir):
@@ -168,69 +175,68 @@ def main():
                 os.remove(outdir)
             os.mkdir(outdir)
 
-    #setup files
-    #file names depend on whether outprefix is directory or file
+    # setup files
+    # file names depend on whether outprefix is directory or file
     if args['outprefix'][-1] == '/':
         logfile = "{0}log.log".format(args['outprefix'])
     else:
         logfile = "{0}.log".format(args['outprefix'])
         args['outprefix'] = '{0}_'.format(args['outprefix'])
-    modelcomparisonfile = '{0}modelcomparison.txt'.format(args['outprefix'])
     raxmlStandardOutputFile = '{0}ramxl_output.txt'.format(args['outprefix'])
 
-    #Set up to log everything to logfile.
-        # Set up to log everything to logfile.
+    # Set up to log everything to logfile.
+    # Set up to log everything to logfile.
     if os.path.isfile(logfile):
         os.remove(logfile)
     logging.shutdown()
     logging.captureWarnings(True)
     versionstring = phydmslib.file_io.Versions()
     logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s',
-        level=logging.INFO)
+                        level=logging.INFO)
     logger = logging.getLogger(prog)
     logfile_handler = logging.FileHandler(logfile)
     logger.addHandler(logfile_handler)
     formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
     logfile_handler.setFormatter(formatter)
 
-    #print some basic information
+    # print some basic information
     logger.info('Beginning execution of {0} in directory {1}\n'
-            .format(prog, os.getcwd()))
+                .format(prog, os.getcwd()))
     logger.info('Progress is being logged to {0}\n'.format(logfile))
     logger.info('{0}\n'.format(versionstring))
     logger.info('Parsed the following command-line arguments:\n{0}\n'
-            .format('\n'.join(['\t{0} = {1}'.format(key, args[key])
-            for key in args.keys()])))
+                .format('\n'.join(['\t{0} = {1}'
+                        .format(key, args[key]) for key in args.keys()])))
 
-    #Set up to log everything to logfile.
+    # Set up to log everything to logfile.
     if os.path.isfile(logfile):
         os.remove(logfile)
     logging.shutdown()
     versionstring = phydmslib.file_io.Versions()
     logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s',
-            level=logging.INFO)
+                        level=logging.INFO)
     logger = logging.getLogger(prog)
     logfile_handler = logging.FileHandler(logfile)
     logger.addHandler(logfile_handler)
     formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
     logfile_handler.setFormatter(formatter)
 
-    #print some basic information
+    # print some basic information
     logger.info('Beginning execution of {0} in directory {1}\n'
-            .format(prog, os.getcwd()))
+                .format(prog, os.getcwd()))
     logger.info('Progress is being logged to {0}\n'.format(logfile))
     logger.info('{0}\n'.format(versionstring))
     logger.info('Parsed the following command-line arguments:\n{0}\n'
-            .format('\n'.join(['\t{0} = {1}'.format(key, args[key])
-            for key in args.keys()])))
+                .format('\n'.join(['\t{0} = {1}'
+                        .format(key, args[key]) for key in args.keys()])))
 
-    #setup models
+    # setup models
     filesuffixlist = ['_log.log', '_tree.newick', '_loglikelihood.txt',
-            '_modelparams.txt']
-    filesuffixes = {} # keyed by model, values are list of suffixes
+                      '_modelparams.txt']
+    filesuffixes = {}  # keyed by model, values are list of suffixes
     models = {}
 
-    #set up the ExpCM without diversifying pressure
+    # set up the ExpCM without diversifying pressure
     expcmadditionalcmds = []
     nempiricalExpCM = 3
     if re.search('\s', args['prefsfile']):
@@ -241,60 +247,69 @@ def main():
     assert modelID not in filesuffixes, "Duplicate model ID"
     filesuffixes[modelID] = filesuffixlist
     models[modelID] = ('ExpCM_{0}'.format(args['prefsfile']),
-            expcmadditionalcmds, nempiricalExpCM, "ExpCM_" + '_'.join(str(item)\
-                    for item in modelID if item != "None"))
+                       expcmadditionalcmds,
+                       nempiricalExpCM,
+                       "ExpCM_" + '_'.join(str(item) for item in
+                                           modelID if item != "None"))
 
-    #set up ExpCM with diversifying pressure
+    # set up ExpCM with diversifying pressure
     for divpressure in args["divpressure"]:
-        divpressurefilebase = os.path.splitext(os.path.basename(divpressure))[0]
+        divpressurefilebase = (os.path
+                               .splitext(os.path.basename(divpressure))[0])
         modelID = (prefsfilebase, divpressurefilebase, "True", "None")
         assert modelID not in filesuffixes, "Duplicate model ID (divpressure)"
         filesuffixes[modelID] = filesuffixlist
         models[modelID] = ('ExpCM_{0}'.format(args['prefsfile']),
-                expcmadditionalcmds + ["--divpressure", divpressure],
-                nempiricalExpCM, "ExpCM_" + '_'.join(str(item) for item\
-                in modelID if item != "None"))
-        #set up ExpCM with diversifying pressure randomizations
+                           expcmadditionalcmds + ["--divpressure",
+                                                  divpressure],
+                           nempiricalExpCM,
+                           "ExpCM_" + '_'.join(str(item) for item
+                                               in modelID if item != "None"))
+        # set up ExpCM with diversifying pressure randomizations
         if args["randomizations"]:
             randomFiles = randomizeDivpressure(divpressure,
-                    args["randomizations"], args["outprefix"])
-            for random in randomFiles.keys():
-                modelID = (prefsfilebase, divpressurefilebase, "Random", random)
-                assert modelID not in filesuffixes, "Duplicate model ID (divpressure)"
+                                               args["randomizations"],
+                                               args["outprefix"])
+            for r in randomFiles.keys():
+                modelID = (prefsfilebase, divpressurefilebase,
+                           "Random", r)
+                assert modelID not in filesuffixes, ("Duplicate model ID "
+                                                     "(divpressure)")
                 filesuffixes[modelID] = filesuffixlist
                 models[modelID] = ('ExpCM_{0}'.format(args['prefsfile']),
-                        expcmadditionalcmds + ["--divpressure", randomFiles[random]],
-                        nempiricalExpCM, "ExpCM_" + '_'.join(str(item) for item\
-                        in modelID if item != "None"))
+                                   expcmadditionalcmds + ["--divpressure",
+                                                          randomFiles[r]],
+                                   nempiricalExpCM,
+                                   "ExpCM_" + '_'.join(str(item) for item in
+                                                       modelID if item !=
+                                                       "None"))
 
     # check alignment
     logger.info('Checking that the alignment {0} is valid...'
-            .format(args['alignment']))
+                .format(args['alignment']))
     alignment = phydmslib.file_io.ReadCodonAlignment(args['alignment'],
-            checknewickvalid=True) #checks that the identifiers are unique
-    assert len(set([align[1] for align in alignment])) == len([align[1]
-            for align in alignment]), "Remove duplicate sequences from {0}."\
-                    .format(args["alignment"])
+                                                     checknewickvalid=True)
+    assert len(set([align[1] for align in alignment])) \
+           == len([align[1] for align in alignment]),\
+           ("Remove duplicate sequences from {0}.".format(args["alignment"]))
     logger.info('Valid alignment specifying {0} sequences of length {1}.\n'
-            .format(len(alignment), len(alignment[0][1])))
+                .format(len(alignment), len(alignment[0][1])))
 
-
-    #read or build a tree
+    # read or build a tree
     if args["tree"]:
-      logger.info("Reading tree from {0}".format(args['tree']))
+        logger.info("Reading tree from {0}".format(args['tree']))
     else:
         logger.info("Tree not specified.")
         try:
-            raxmlversion = subprocess.check_output([args['raxml'], '-v'],
-                    stderr=subprocess.STDOUT).strip()
             logger.info("Inferring tree with RAxML using command {0}"
-                    .format(args['raxml']))
+                        .format(args['raxml']))
 
-            #remove pre-existing RAxML files
+            # remove pre-existing RAxML files
             raxmlOutputName = os.path.splitext(os.path.basename(
                     args["alignment"]))[0]
-            raxmlOutputFiles = [n for n in glob.glob("RAxML_*{0}"
-                    .format(raxmlOutputName)) if os.path.isfile(n)]
+            raxmlOutputFiles = [n for n in
+                                glob.glob("RAxML_*{0}".format(raxmlOutputName))
+                                if os.path.isfile(n)]
             raxmlOutputFiles = []
             for raxmlFile in glob.glob("RAxML_*{0}".format(raxmlOutputName)):
                 if os.path.isfile(raxmlFile):
@@ -302,14 +317,14 @@ def main():
                     os.remove(raxmlFile)
             if len(raxmlOutputFiles) > 0:
                 logger.info('Removed the following RAxML files:\n{0}\n'
-                    .format('\n'.join(['\t{0}'.format(fname) for
-                    fname in raxmlOutputFiles])))
+                            .format('\n'.join(['\t{0}'.format(fname) for
+                                               fname in raxmlOutputFiles])))
 
             # run RAxmL
             raxmlCMD = [args['raxml'], '-s', args['alignment'], '-n',
-                    raxmlOutputName, '-m', 'GTRCAT', '-p1', '-T', '2']
+                        raxmlOutputName, '-m', 'GTRCAT', '-p1', '-T', '2']
             with open(raxmlStandardOutputFile, 'w') as f:
-                subprocess.check_call(raxmlCMD, stdout = f)
+                subprocess.check_call(raxmlCMD, stdout=f)
 
             # move RAxML tree to output directory and remove all other files
             for raxmlFile in glob.glob("RAxML_*{0}".format(raxmlOutputName)):
@@ -322,34 +337,37 @@ def main():
                     os.remove(raxmlFile)
         except OSError:
             raise ValueError("The raxml command of {0} is not valid."
-                    " Is raxml installed at this path?".format(args['raxml']))
+                             " Is raxml installed at this path?"
+                             .format(args['raxml']))
 
-    #setting up cpus
+    # setting up cpus
     if args['ncpus'] == -1:
         try:
             args['ncpus'] = multiprocessing.cpu_count()
-        except:
+        except Exception:
             raise RuntimeError("Encountered a problem trying to dynamically"
-                    "determine the number of available CPUs. Please manually"
-                    " specify the number of desired CPUs with '--ncpus' and"
-                    " try again.")
+                               "determine the number of available CPUs. "
+                               "Please manually specify the number of "
+                               "desired CPUs with '--ncpus' and try again.")
         logger.info('Will use all %d available CPUs.\n' % args['ncpus'])
     assert args['ncpus'] >= 1, "Failed to specify valid number of CPUs"
 
-    #Each model gets at least 1 CPU
+    # Each model gets at least 1 CPU
     ncpus_per_model = {}
     nperexpcm = max(1, (args['ncpus'] - 2) // len(models))
     for modelID in models.keys():
         ncpus_per_model[modelID] = nperexpcm
         mtup = models[modelID]
-        assert len(mtup) == 4 # should be 3-tuple
-        models[modelID] = (mtup[0], mtup[1] + ['--ncpus',
-                str(ncpus_per_model[modelID])], mtup[2], mtup[3])
+        assert len(mtup) == 4  # should be 3-tuple
+        models[modelID] = (mtup[0],
+                           mtup[1] + ['--ncpus',
+                                      str(ncpus_per_model[modelID])],
+                           mtup[2], mtup[3])
 
-    pool = {} # holds process for model name
-    started = {} # holds whether process started for model name
-    completed = {} # holds whether process completed for model name
-    outprefixes = {} # holds outprefix for model name
+    pool = {}  # holds process for model name
+    started = {}  # holds whether process started for model name
+    completed = {}  # holds whether process completed for model name
+    outprefixes = {}  # holds outprefix for model name
 
     # rest of execution in try / finally
     try:
@@ -359,7 +377,8 @@ def main():
         removed = []
         for modelID in models.keys():
             for suffix in filesuffixes[modelID]:
-                fname = "{0}{1}{2}".format(args['outprefix'], models[modelID][3], suffix)
+                fname = "{0}{1}{2}".format(args['outprefix'],
+                                           models[modelID][3], suffix)
                 outfiles.append(fname)
         for fname in outfiles:
             if os.path.isfile(fname):
@@ -367,11 +386,11 @@ def main():
                 removed.append(fname)
         if removed:
             logger.info('Removed the following existing files that have names'
-                    " that match the names of output files that will be "
-                    'created: {0}\n'.format(', '.join(removed)))
+                        " that match the names of output files that will be "
+                        'created: {0}\n'.format(', '.join(removed)))
 
     # first run the `ExpCM` model without diversiying pressure to optimize
-    #the branch lengths
+    # the branch lengths
         noDivPressure = [x for x in list(models.keys()) if x[1] == "None"]
         assert len(noDivPressure) == 1, "More than one ExpCM without\
                 diversifying pressure was specified"
@@ -380,32 +399,33 @@ def main():
         outprefix = "{0}{1}".format(args['outprefix'], modelname)
         cmds = ['phydms', args['alignment'], args["tree"], model,
                 outprefix] + additionalcmds + ["--brlen", "optimize"]
-        logger.info('Starting analysis. Optimizing the branch lengths. The command is: %s\n' % (' '.join(cmds)))
+        logger.info('Starting analysis. Optimizing the branch lengths. The '
+                    'command is: %s\n' % (' '.join(cmds)))
         outprefixes[noDivPressure] = outprefix
         subprocessOutput = '{0}subprocess_output.txt'.format(args['outprefix'])
         with open(subprocessOutput, 'w') as f:
-            subprocess.check_call(cmds, stdout = f)
+            subprocess.check_call(cmds, stdout=f)
         if os.path.isfile(subprocessOutput):
             os.remove(subprocessOutput)
-        for fname in [outprefixes[noDivPressure] + suffix for suffix
-                in filesuffixes[noDivPressure]]:
+        for fname in [outprefixes[noDivPressure] + suffix
+                      for suffix in filesuffixes[noDivPressure]]:
             if not os.path.isfile(fname):
                 raise RuntimeError("phydms failed to created"
-                        " expected output file {0}.".format(fname))
-        logger.info('Analysis successful for {0} without diversifying pressure.\n'\
-                .format(modelID[0]))
+                                   " expected output file {0}.".format(fname))
+        logger.info('Analysis successful for {0} without diversifying '
+                    'pressure.\n'.format(modelID[0]))
         treeFile = '{0}_tree.newick'.format(outprefix)
         assert os.path.isfile(treeFile)
 
-    #now run the other models
+    # now run the other models
         divPressureModels = [x for x in list(models.keys()) if x[1] != "None"]
         for modelID in divPressureModels:
             (model, additionalcmds, nempirical, modelname) = models[modelID]
             outprefix = "{0}{1}".format(args['outprefix'], modelname)
             cmds = ['phydms', args['alignment'], treeFile, model,
                     outprefix] + additionalcmds + ["--brlen", "scale"]
-            pool[modelID] = multiprocessing.Process(target=RunCmds\
-                    , args=(cmds,))
+            pool[modelID] = multiprocessing.Process(target=RunCmds,
+                                                    args=(cmds,))
             outprefixes[modelID] = outprefix
             completed[modelID] = False
             started[modelID] = False
@@ -420,30 +440,36 @@ def main():
                         break
             for (modelID, p) in pool.items():
                 if started[modelID] and (not completed[modelID]) and \
-                        (not p.is_alive()): # process just completed
+                        (not p.is_alive()):  # process just completed
                     completed[modelID] = True
                     for fname in [outprefixes[modelID] + suffix for suffix
-                            in filesuffixes[modelID]]:
+                                  in filesuffixes[modelID]]:
                         if not os.path.isfile(fname):
                             raise RuntimeError("phydms failed to created"
-                                    " expected output file {0}.".format(fname))
+                                               " expected output file {0}."
+                                               .format(fname))
                     if modelID[1] != "None":
                         if modelID[2] != "True":
-                            logger.info('Analysis successful for {0} with diversifying pressure {1} and random seed {2}\n'\
-                                .format(modelID[0], modelID[1], modelID[3]))
+                            logger.info('Analysis successful for {0} with '
+                                        'diversifying pressure {1} and random '
+                                        'seed {2}\n'
+                                        .format(modelID[0], modelID[1],
+                                                modelID[3]))
                         else:
-                            logger.info('Analysis successful for {0} with diversifying pressure {1}\n'\
-                                .format(modelID[0], modelID[1]))
+                            logger.info('Analysis successful for {0} with '
+                                        'diversifying pressure {1}\n'
+                                        .format(modelID[0], modelID[1]))
                     else:
-                        logger.info('Analysis successful for {0} without diversifying pressure.\n'\
-                            .format(modelID[0]))
+                        logger.info('Analysis successful for {0} without '
+                                    'diversifying pressure.\n'
+                                    .format(modelID[0]))
             time.sleep(1)
 
-    #make sure all expected output files are there
+    # make sure all expected output files are there
         for fname in outfiles:
             if not os.path.isfile(fname):
                 raise RuntimeError("Cannot find expected output file {0}"
-                        .format(fname))
+                                   .format(fname))
         createModelComparisonFile(models, args["outprefix"])
         for fname in outfiles:
             if os.path.isfile(fname):
@@ -453,9 +479,9 @@ def main():
                 os.remove(f)
             os.rmdir(args["outprefix"] + "randomizedFiles/")
 
-    except:
+    except Exception:
         logger.exception('Terminating {0} at {1} with ERROR'
-                .format(prog, time.asctime()))
+                         .format(prog, time.asctime()))
     else:
         logger.info('Successful completion of {0}'.format(prog))
     finally:
@@ -466,7 +492,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main() # run the script
-
-#make the test script
-#figure out why the logging prints twice
+    main()  # run the script

--- a/scripts/phydms_logoplot
+++ b/scripts/phydms_logoplot
@@ -5,9 +5,7 @@
 Written by Jesse Bloom."""
 
 
-import sys
 import os
-import re
 import time
 import math
 import natsort
@@ -15,8 +13,7 @@ import pandas
 import phydmslib.weblogo
 import phydmslib.file_io
 import phydmslib.parsearguments
-from phydmslib.constants import *
-
+from phydmslib.constants import AA_TO_INDEX
 
 
 def main():
@@ -37,9 +34,10 @@ def main():
     # check on outfile we will create
     assert os.path.splitext(args['outfile'])[1].lower() == '.pdf', (
             "outfile {0} does not end in '.pdf'".format(args['outfile']))
-    assert (not os.path.dirname(args['outfile'])) or (os.path.isdir(
-            os.path.dirname(args['outfile']))), ("outfile {0} includes "
-            "non-existent directory".format(args['outfile']))
+    assert (not os.path.dirname(args['outfile'])) or\
+           (os.path.isdir(os.path.dirname(args['outfile']))),\
+           ("outfile {0} includes ""non-existent directory"
+            .format(args['outfile']))
     if os.path.isfile(args['outfile']):
         print("Removing existing outfile of {0}\n".format(args['outfile']))
         os.remove(args['outfile'])
@@ -49,8 +47,8 @@ def main():
     if args['prefs']:
         datatype = 'prefs'
         print("Reading preferences from {0}".format(args['prefs']))
-        prefs = phydmslib.file_io.readPrefs(args['prefs'], 
-                sites_as_strings=True)
+        prefs = phydmslib.file_io.readPrefs(args['prefs'],
+                                            sites_as_strings=True)
         sites = natsort.realsorted(prefs.keys())
         print("Read preferences for {0} sites.".format(len(sites)))
         beta = args['stringency']
@@ -61,16 +59,16 @@ def main():
                 prefsum = sum([prefs[r][a] for a in aas])
                 prefs[r] = dict([(a, prefs[r][a] / prefsum) for a in aas])
         data = prefs
-        ydatamax = None 
+        ydatamax = None
 
     elif args['diffprefs']:
         datatype = 'diffprefs'
         print("Reading differential preferences from {0}".format(
                 args['diffprefs']))
-        diffprefs = pandas.read_csv(args['diffprefs'], sep='\t', 
-                comment='#')
+        diffprefs = pandas.read_csv(args['diffprefs'], sep='\t', comment='#')
         sites = natsort.realsorted(map(str, diffprefs['site'].values))
-        print("Read differential preferences for {0} sites.".format(len(sites)))
+        print("Read differential preferences for {0} sites."
+              .format(len(sites)))
         data = {}
         ydatamax = args['diffprefheight'] * 1.01
         for r in sites:
@@ -82,8 +80,8 @@ def main():
             sumneg = sum([-dpi for dpi in data[r].values() if dpi < 0])
             if max(sumpos, sumneg) >= ydatamax:
                 raise ValueError("diffprefs extend beyond --diffprefheight "
-                        "{0}. Increase --diffprefheight.".format(
-                        args['diffprefheight']))
+                                 "{0}. Increase --diffprefheight."
+                                 .format(args['diffprefheight']))
 
     else:
         raise ValueError("Didn't specify either --prefs or --diffprefs")
@@ -94,15 +92,14 @@ def main():
     fix_limits = {}
     if args['omegabysite']:
         print("\nWe will make an overlay with the site-specific omega "
-                "values in {0}.".format(args['omegabysite']))
-        omegas = pandas.read_csv(args['omegabysite'], comment='#',
-                sep='\t')
-        assert set(sites) == set(map(str, omegas['site'].values)), ("sites "
-                "in {0} don't match those in prefs or diffprefs".format(
-                args['omegabysite']))
+              "values in {0}.".format(args['omegabysite']))
+        omegas = pandas.read_csv(args['omegabysite'], comment='#', sep='\t')
+        assert set(sites) == set(map(str, omegas['site'].values)),\
+               ("sites in {0} don't match those in prefs or diffprefs"
+               .format(args['omegabysite']))
         shortname = '$\omega_r$'
         longname = ('{0} $<1 \; \longleftarrow$ $\log_{{10}} P$ '
-                '$\longrightarrow \;$ {0} $>1$'.format(shortname))
+                    '$\longrightarrow \;$ {0} $>1$'.format(shortname))
         prop_d = {}
         for r in sites:
             omegar = float(omegas[omegas['site'].astype(str) == r]['omega'])
@@ -112,8 +109,8 @@ def main():
             else:
                 prop_d[r] = -max(math.log10(args['minP']), math.log10(p))
         overlay = [(prop_d, shortname, longname)]
-        ticklocs = [itick for itick in range(int(math.log10(args['minP'])), 
-                1 - int(math.log10(args['minP'])))]
+        ticklocs = [itick for itick in range(int(math.log10(args['minP'])),
+                    1 - int(math.log10(args['minP'])))]
         ticknames = [-abs(itick) for itick in ticklocs]
         fix_limits[shortname] = (ticklocs, ticknames)
     else:
@@ -137,11 +134,11 @@ def main():
                 custom_cmap=args['colormap'],
                 map_metric=args['mapmetric'],
             )
-    assert os.path.isfile(args['outfile']), "Failed to create plot" 
+    assert os.path.isfile(args['outfile']), "Failed to create plot"
     print("Created plot {0}".format(args['outfile']))
 
     print('\nSuccessful completion of %s' % prog)
 
 
 if __name__ == '__main__':
-    main() # run the script
+    main()  # run the script

--- a/scripts/phydms_prepalignment
+++ b/scripts/phydms_prepalignment
@@ -10,18 +10,19 @@ import re
 import time
 import subprocess
 import matplotlib
-matplotlib.use('pdf')
 import matplotlib.pyplot as plt
-plt.style.use('ggplot')
 import Bio.SeqIO
 import Bio.Data.CodonTable
 import phydmslib.parsearguments
 import phydmslib.file_io
-
+matplotlib.use('pdf')
+plt.style.use('ggplot')
 
 _cleanheader = re.compile('[\s\:\;\(\)\[\]\,\'\"]')
+
+
 def CleanHeader(head):
-    """Returns copy of header with problem characters replaced by underscore."""
+    """Returns copy of header with problem chars replaced by underscore."""
     return _cleanheader.sub('_', head)
 
 
@@ -40,14 +41,17 @@ def MAFFT_CDSandProtAlignments(headseqprots, mafftcmd, tempfileprefix):
     The sequence order is preserved in this list.
     """
     # mafft shortens sequence names to the first 253 characters
-    headseqprots = [(head[:254], seq, prot) for (head, seq, prot) in headseqprots]
+    headseqprots = [(head[:254], seq, prot) for
+                    (head, seq, prot) in headseqprots]
     headseqprotsnames = [head for head, seq, prot in headseqprots]
-    assert len(headseqprotsnames) == len(set(headseqprotsnames)), "The first 253 characters of each sequence name must be unique."
+    assert len(headseqprotsnames) == len(set(headseqprotsnames)),\
+           "The first 253 characters of each sequence name must be unique."
 
     seq_d = dict([(head, seq) for (head, seq, prot) in headseqprots])
     prot_d = dict([(head, prot) for (head, seq, prot) in headseqprots])
 
-    (tempfiledir, tempfilebase) = (os.path.dirname(tempfileprefix), os.path.basename(tempfileprefix))
+    (tempfiledir, tempfilebase) = (os.path.dirname(tempfileprefix),
+                                   os.path.basename(tempfileprefix))
     if tempfiledir:
         tempfileprefix = tempfiledir + '/_' + tempfilebase
     else:
@@ -56,9 +60,11 @@ def MAFFT_CDSandProtAlignments(headseqprots, mafftcmd, tempfileprefix):
     alignedprotsfile = tempfileprefix + '_aligned_mafft_prots.fasta'
     outputfile = tempfileprefix + '_mafft_output.txt'
     with open(unalignedprotsfile, 'w') as f:
-        f.write('\n'.join(['>{0}\n{1}'.format(head, prot) for (head, seq, prot) in headseqprots]))
+        f.write('\n'.join(['>{0}\n{1}'.format(head, prot)
+                           for (head, seq, prot) in headseqprots]))
 
-    with open(alignedprotsfile,'w') as stdout, open(outputfile, 'w') as stderr:
+    with open(alignedprotsfile, 'w') as stdout,\
+         open(outputfile, 'w') as stderr:
         subprocess.check_call(
                 [mafftcmd, '--auto', '--thread', '-1', unalignedprotsfile],
                 stdout=stdout,
@@ -71,18 +77,19 @@ def MAFFT_CDSandProtAlignments(headseqprots, mafftcmd, tempfileprefix):
         alignedprot = str(alignedprotrecord.seq)
         prot = prot_d[head]
         seq = seq_d[head]
-        assert ('-' not in prot) and ('-' not in seq), "Already gaps in seq or prot"
+        assert ('-' not in prot) and ('-' not in seq),\
+               "Already gaps in seq or prot"
         assert len(alignedprot) >= len(prot)
         assert len(alignedprot.replace('-', '')) == len(prot)
         assert len(seq) == len(prot) * 3
         alignedseq = []
-        i = 0 # keeps track of position in unaligned prot
+        i = 0  # keeps track of position in unaligned prot
         for aa in alignedprot:
             if aa == '-':
                 alignedseq.append('---')
             else:
                 assert aa == prot[i]
-                alignedseq.append(seq[3 * i : 3 * i + 3])
+                alignedseq.append(seq[3 * i: 3 * i + 3])
                 i += 1
         alignedseqprots_by_head[head] = (''.join(alignedseq), alignedprot)
 
@@ -107,9 +114,11 @@ def main():
     prog = parser.prog
 
     # print some basic information
-    print('\nBeginning execution of %s in directory %s at time %s\n' % (prog, os.getcwd(), time.asctime()))
+    print('\nBeginning execution of %s in directory %s at time %s\n'
+          % (prog, os.getcwd(), time.asctime()))
     print("%s\n" % phydmslib.file_io.Versions())
-    print('Parsed the following command-line arguments:\n%s\n' % '\n'.join(['\t%s = %s' % tup for tup in args.items()]))
+    print('Parsed the following command-line arguments:\n%s\n' % '\n'
+          .join(['\t%s = %s' % tup for tup in args.items()]))
 
     plot = os.path.splitext(args['alignment'])[0] + '.pdf'
     for f in [plot, args['alignment']]:
@@ -121,13 +130,17 @@ def main():
     for argname in ['keepseqs', 'purgeseqs']:
         argvalue = args[argname]
         if argvalue:
-            if len(argvalue) == 1 and argvalue[0] and os.path.isfile(argvalue[0]):
+            if len(argvalue) == 1 and \
+               argvalue[0] and os.path.isfile(argvalue[0]):
                 with open(argvalue[0]) as f:
-                    args[argname] = set([line.strip() for line in f.readlines() if line and not line.isspace()])
-                print("Read {0} sequences from the --{1} file {2}".format(len(args[argname]), argname, argvalue[0]))
+                    args[argname] = set([line.strip() for line in f.readlines()
+                                         if line and not line.isspace()])
+                print("Read {0} sequences from the --{1} file {2}"
+                      .format(len(args[argname]), argname, argvalue[0]))
             else:
                 args[argname] = set([x for x in argvalue if x])
-                print("There are {0} sequences specified by --{1}".format(len(args[argname]), argname))
+                print("There are {0} sequences specified by --{1}"
+                      .format(len(args[argname]), argname))
         else:
             args[argname] = set([])
 
@@ -147,12 +160,15 @@ def main():
             if (purgename in head) or (purgename in cleanhead):
                 for keepname in args['keepseqs']:
                     if (keepname in head) or (keepname in cleanhead):
-                        raise ValueError("--purgseqs and --keepseqs conflict about what to do with {0}".format(head))
+                        raise ValueError("--purgseqs and --keepseqs conflict "
+                                         "about what to do with {0}"
+                                         .format(head))
                 break
         else:
             cleanseqs.append(seq)
     seqs = cleanseqs
-    print("Retained {0} after removing those specified for purging by '--purgeseqs.'".format(len(seqs)))
+    print("Retained {0} after removing those specified for purging by "
+          "'--purgeseqs.'".format(len(seqs)))
 
     # remove gaps if sequences not pre-aligned
     if not args['prealigned']:
@@ -161,12 +177,14 @@ def main():
 
     # check length divisible by 3
     seqs = [seq for seq in seqs if len(seq) % 3 == 0]
-    print("Retained {0} sequences after removing any with length not multiple of 3.".format(len(seqs)))
+    print("Retained {0} sequences after removing any with length not multiple "
+          "of 3.".format(len(seqs)))
 
     # purge ambiguous nucleotide sequences
     seqmatch = re.compile('^[ACTG-]+$')
     seqs = [seq for seq in seqs if seqmatch.search(str(seq.seq))]
-    print("Retained {0} sequences after purging any with ambiguous nucleotides.".format(len(seqs)))
+    print("Retained {0} sequences after purging any with ambiguous "
+          "nucleotides.".format(len(seqs)))
 
     # make sure all sequences translate without premature stops
     prots = []
@@ -175,7 +193,7 @@ def main():
         try:
             prots.append(str(seqs[i].seq.translate(gap='-', stop_symbol='*')))
         except Bio.Data.CodonTable.TranslationError:
-            remove_indices.append(i) # doesn't translate
+            remove_indices.append(i)  # doesn't translate
     for i in sorted(remove_indices, reverse=True):
         del seqs[i]
     assert len(prots) == len(seqs)
@@ -184,14 +202,15 @@ def main():
         for i in range(len(seqs)):
             prot = prots[i]
             if (prot.count('*') == 1) and prot.replace('-', '')[-1] == '*':
-                # convert terminal stop to gap, trimmed later if all sites gapped
+                # convert terminal stop to gap
+                # trimmed later if all sites gapped
                 istop = prot.index('*')
                 prot = list(prots[i])
                 prot[istop] = '-'
                 prots[i] = ''.join(prot)
                 # introduce gap requires making seq mutable
                 iseq = seqs[i].seq.tomutable()
-                iseq[3 * istop : 3 * istop + 3] = '---'
+                iseq[3 * istop: 3 * istop + 3] = '---'
                 seqs[i].seq = iseq.toseq()
             elif prot.count('*') >= 1:
                 # premature stop
@@ -201,31 +220,39 @@ def main():
             prot = prots[i]
             if prot.count('*') == 1 and prot[-1] == '*':
                 # trim terminal stop
-                prots[i] = prots[i][ : -1]
-                seqs[i].seq = seqs[i].seq[ : -3]
+                prots[i] = prots[i][: -1]
+                seqs[i].seq = seqs[i].seq[: -3]
             elif prot.count('*') >= 1:
                 # premature stop
                 remove_indices.append(i)
     for i in sorted(remove_indices, reverse=True):
         del prots[i]
         del seqs[i]
-    print("Retained {0} sequences after purging any with premature stops or that are otherwise un-translateable.".format(len(seqs)))
+    print("Retained {0} sequences after purging any with premature stops or "
+          "that are otherwise un-translateable.".format(len(seqs)))
 
     # get reference sequence
-    refseq = [seq for seq in seqs if (args['refseq'] in seq.description) or (CleanHeader(args['refseq']) in seq.description)]
+    refseq = [seq for seq in seqs if (args['refseq'] in seq.description) or
+              (CleanHeader(args['refseq']) in seq.description)]
     if len(refseq) == 1:
         refseq = refseq[0]
-        print("Using the following as reference sequence: {0}".format(refseq.description))
+        print("Using the following as reference sequence: {0}"
+              .format(refseq.description))
     elif len(refseq) < 1:
-        raise ValueError("Failed to find any sequence with a header that contained refseq identifier of {0}\nWas reference sequence purged due to not being translate-able?".format(args['refseq']))
+        raise ValueError("Failed to find any sequence with a header that "
+                         "contained refseq identifier of {0}\nWas reference "
+                         "sequence purged due to not being translate-able?"
+                         .format(args['refseq']))
     else:
-        raise ValueError("Found multiple sequences with headers that contained refseq identifier of {0}".format(args['refseqs']))
+        raise ValueError("Found multiple sequences with headers that "
+                         "contained refseq identifier of {0}"
+                         .format(args['refseqs']))
 
     # For removing sequences, we make two lists: sequences to always keeps,
     # then other sequences ordered by frequency that protein occurs.
     # This allows us to preferentially retain common sequences.
-    seqs_alwayskeep = [] # entries are (head, seq, prot) as strings
-    protcounts = {} # keyed by protein, values are lists of (head, seq, prot)
+    seqs_alwayskeep = []  # entries are (head, seq, prot) as strings
+    protcounts = {}  # keyed by protein, values are lists of (head, seq, prot)
     foundrefseq = False
     assert len(seqs) == len(prots)
     for (seqrecord, prot) in zip(seqs, prots):
@@ -246,59 +273,91 @@ def main():
                     protcounts[prot].append((cleanhead, seq, prot))
                 else:
                     protcounts[prot] = [(cleanhead, seq, prot)]
-    assert len(seqs) == len(seqs_alwayskeep) + sum([len(x) for x in protcounts.values()]), "Somehow lost sequences when looking for unique seqs."
+    assert len(seqs) ==\
+           len(seqs_alwayskeep) + sum([len(x) for x in protcounts.values()]),\
+           "Somehow lost sequences when looking for unique seqs."
     assert foundrefseq, "Never found refseq to add to seqs_alwayskeep"
     # get one unique copy of each protein sorted by number of copies
-    seqs_unique = sorted([(len(x), x[0]) for x in protcounts.values()], reverse=True)
+    seqs_unique = sorted([(len(x), x[0]) for x in protcounts.values()],
+                         reverse=True)
     seqs_unique = [seqtup for (count, seqtup) in seqs_unique]
-    print("Purged sequences encoding redundant proteins, being sure to retain reference sequence and any specified by '--keepseqs'. Overall, {0} sequences remain.".format(len(seqs_unique) + len(seqs_alwayskeep)))
-    heads = [tup[0] for tup in seqs_unique] + [tup[0] for tup in seqs_alwayskeep]
-    assert len(heads) == len(set(heads)), "Found sequences with non-unique cleaned headers:\n%s".format('\n'.join([head for head in heads if heads.count(head) > 1]))
+    print("Purged sequences encoding redundant proteins, being sure to retain "
+          "reference sequence and any specified by '--keepseqs'. Overall, {0} "
+          "sequences remain.".format(len(seqs_unique) + len(seqs_alwayskeep)))
+    heads = [tup[0] for tup in seqs_unique] +\
+            [tup[0] for tup in seqs_alwayskeep]
+    assert len(heads) == len(set(heads)),\
+           ("Found sequences with non-unique cleaned headers:\n%{0}"
+           .format('\n'.join([head for head in heads if heads.count(head) > 1]
+                             )))
 
     if args['prealigned']:
-        print("You specified '--prealigned', so the sequences are NOT being aligned.")
+        print("You specified '--prealigned', "
+              "so the sequences are NOT being aligned.")
         # make sure sequences all the same length
         seqlengths = [len(tup[1]) for tup in seqs_unique + seqs_alwayskeep]
-        assert all([seqlengths[0] == n for n in seqlengths]), "You indicated sequences are pre-aligned with the '--prealigned option, but they are not all of the same length."
+        assert all([seqlengths[0] == n for n in seqlengths]),\
+               ("You indicated sequences are pre-aligned with the "
+                "'--prealigned option, but they are not all of the same "
+                "length.")
     else:
         # align all sequences
         try:
-            mafftversion = subprocess.check_output([args['mafft'], '--version'], stderr=subprocess.STDOUT).strip()
-            print("Aligning sequences with MAFFT using {0} {1}".format(args['mafft'], mafftversion))
+            mafftversion = (subprocess.check_output([args['mafft'],
+                                                    '--version'],
+                                                    stderr=subprocess.STDOUT)
+                            .strip())
+            print("Aligning sequences with MAFFT using {0} {1}"
+                  .format(args['mafft'], mafftversion))
         except OSError:
-            raise ValueError("The mafft command of {0} is not valid. Is mafft installed at this path?".format(args['mafft']))
-        alignment = MAFFT_CDSandProtAlignments(seqs_unique + seqs_alwayskeep, args['mafft'], args['alignment'])
-        seqs_unique = alignment[ : len(seqs_unique)]
-        seqs_alwayskeep = alignment[len(seqs_unique) : ]
+            raise ValueError("The mafft command of {0} is not valid. "
+                             "Is mafft installed at this path?"
+                             .format(args['mafft']))
+        alignment = MAFFT_CDSandProtAlignments(seqs_unique + seqs_alwayskeep,
+                                               args['mafft'], args['alignment']
+                                               )
+        seqs_unique = alignment[: len(seqs_unique)]
+        seqs_alwayskeep = alignment[len(seqs_unique):]
         seqlengths = [len(tup[1]) for tup in seqs_unique + seqs_alwayskeep]
-        assert all([seqlengths[0] == n for n in seqlengths]), "MAFFT alignment failed to yield sequences all of the same length."
+        assert all([seqlengths[0] == n for n in seqlengths]),\
+               "MAFFT alignment failed to yield sequences all of the\
+               same length."
 
     # strip gaps relative refseq
-    assert seqs_alwayskeep[0][0] == CleanHeader(refseq.description), "Expected refseq to have this header:\t{0}\nFound this:\t{1}".format(refseq.description, seqs_alwayskeep[0][0])
+    assert seqs_alwayskeep[0][0] == CleanHeader(refseq.description),\
+           ("Expected refseq to have this header:\t{0}\nFound this:\t{1}"
+           .format(refseq.description, seqs_alwayskeep[0][0]))
     refseqprot = seqs_alwayskeep[0][2]
     gapped = set([i for i in range(len(refseqprot)) if refseqprot[i] == '-'])
     for xlist in [seqs_alwayskeep, seqs_unique]:
         for (i, (head, seq, prot)) in enumerate(xlist):
-            strippedprot = ''.join([aa for (j, aa) in enumerate(prot) if j not in gapped])
-            strippedseq = ''.join([seq[3 * j : 3 * j + 3] for j in range(len(prot)) if j not in gapped])
+            strippedprot = ''.join([aa for (j, aa) in enumerate(prot)
+                                    if j not in gapped])
+            strippedseq = ''.join([seq[3 * j: 3 * j + 3] for j in
+                                   range(len(prot)) if j not in gapped])
             xlist[i] = (head, strippedseq, strippedprot)
-    refseqprot = seqs_alwayskeep[0][2] # with gaps removed
-    assert '-' not in refseqprot, "Gap stripping from reference sequence failed."
-    refseq = seqs_alwayskeep[0][1] # with gaps removed
+    refseqprot = seqs_alwayskeep[0][2]  # with gaps removed
+    assert '-' not in refseqprot, "Gap stripping from reference sequence \
+                                   failed."
+    refseq = seqs_alwayskeep[0][1]  # with gaps removed
     assert '-' not in refseq, "Gap stripping from reference sequence failed."
-    print("After stripping gaps relative to reference sequence, all proteins are of length {0}".format(len(refseqprot)))
+    print("After stripping gaps relative to reference sequence, all proteins "
+          "are of length {0}".format(len(refseqprot)))
 
-    # make seqs_unique, seq_alwayskeep be *(head, seq, prot, ntident, protident)*
+    # make seqs_unique,
+    # seq_alwayskeep be *(head, seq, prot, ntident, protident)*
     refseqprotlength = float(len(refseqprot))
     refseqlength = float(len(refseq))
     for xlist in [seqs_alwayskeep, seqs_unique]:
         for (i, (head, seq, prot)) in enumerate(xlist):
-            protident = sum([x == y for (x, y) in zip(prot, refseqprot)]) / refseqprotlength
-            ntident = sum([x == y for (x, y) in zip(seq, refseq)]) / refseqlength
+            protident = (sum([x == y for (x, y) in zip(prot, refseqprot)]) /
+                         refseqprotlength)
+            ntident = (sum([x == y for (x, y) in zip(seq, refseq)]) /
+                       refseqlength)
             xlist[i] = (head, seq, prot, ntident, protident)
 
     # purge sequences that don't meet identity threshold
-    purged_idents = [] # list of *(ntident, protident)* for purged sequences
+    purged_idents = []  # list of *(ntident, protident)* for purged sequences
     for xlist in [seqs_unique]:
         remove_indices = []
         for (i, (head, seq, prot, ntident, protident)) in enumerate(xlist):
@@ -307,7 +366,9 @@ def main():
                 remove_indices.append(i)
         for i in sorted(remove_indices, reverse=True):
             del xlist[i]
-    print("Retained {0} sequences after purging those with < {1} protein identity to reference sequence.".format(len(seqs_alwayskeep + seqs_unique), args['minidentity']))
+    print("Retained {0} sequences after purging those with < {1} protein "
+          "identity to reference sequence."
+          .format(len(seqs_alwayskeep + seqs_unique), args['minidentity']))
 
     # purge sequences that don't meet uniqueness threshold
     alignment = seqs_alwayskeep
@@ -319,18 +380,22 @@ def main():
                 break
         else:
             alignment.append((head, seq, prot, ntident, protident))
-    print("Retained {0} sequences after purging those without at least {1} amino-acid differences with other retained sequences.".format(len(alignment), args['minuniqueness']))
+    print("Retained {0} sequences after purging those without at least {1} "
+          "amino-acid differences with other retained sequences."
+          .format(len(alignment), args['minuniqueness']))
 
     # write final alignment of coding sequences
-    print("Writing the final alignment of {0} coding sequences to {1}".format(len(alignment), args['alignment']))
+    print("Writing the final alignment of {0} coding sequences to {1}"
+          .format(len(alignment), args['alignment']))
     with open(args['alignment'], 'w') as f:
         for (head, seq, prot, ntident, protident) in alignment:
             f.write('>{0}\n{1}\n'.format(head, seq))
 
     # make plot
-    retained_idents = [(ntident, protident) for (head, seq, prot, ntident, protident) in alignment]
+    retained_idents = [(ntident, protident) for
+                       (head, seq, prot, ntident, protident) in alignment]
     print("Plotting retained and purged sequences to {0}".format(plot))
-    fig = plt.figure()
+    plt.figure()
     points = []
     labels = []
     for (label, idents, color, marker, alpha) in [
@@ -356,4 +421,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main() # run the script
+    main()  # run the script

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,9 @@
+pytest
+flake8
+flake8-docstrings
+flake8-rst-docstrings
+flake8-builtins
+flake8-import-order
+flake8-comprehensions
+flake8-bugbear
+flake8-print

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,5 +5,6 @@ flake8-rst-docstrings
 flake8-builtins
 flake8-import-order
 flake8-comprehensions
+flake8-per-file-ignores
 flake8-bugbear
 flake8-print

--- a/tests/profile_phydms.py
+++ b/tests/profile_phydms.py
@@ -15,7 +15,6 @@ import multiprocessing
 
 def main():
     """Main body of script."""
-
     profiledir = './NP_profile/'
     if not os.path.isdir(profiledir):
         os.mkdir(profiledir)
@@ -50,15 +49,17 @@ def main():
             for f in glob.glob('{0}*'.format(outprefix)):
                 os.remove(f)
             cmd = ['phydms', alignment, tree, model, outprefix, '--profile'] + args
-            pool[name] = multiprocessing.Process(target=subprocess.check_call, 
-                    args=(cmd,), kwargs={'stdout':subprocess.PIPE, 
-                    'stderr':subprocess.PIPE})
-    started = dict([(name, False) for name in pool])
-    completed = dict([(name, False) for name in pool])
+            pool[name] = (multiprocessing
+                          .Process(target=subprocess.check_call,
+                                   args=(cmd,),
+                                   kwargs={'stdout': subprocess.PIPE,
+                                           'stderr': subprocess.PIPE}))
+    started = {name: False for name in pool}
+    completed = {name: False for name in pool}
 
     while not all(completed.values()):
-        nrunning = (list(started.values()).count(True) - 
-                list(completed.values()).count(True))
+        nrunning = (list(started.values()).count(True) -
+                    list(completed.values()).count(True))
         if nrunning < ncpus:
             for (name, p) in pool.items():
                 if (not started[name]) and (not completed[name]):
@@ -77,4 +78,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main() # run the script
+    main()  # run the script

--- a/tests/profile_phydms.py
+++ b/tests/profile_phydms.py
@@ -18,13 +18,13 @@ def main():
     profiledir = './NP_profile/'
     if not os.path.isdir(profiledir):
         os.mkdir(profiledir)
-    print("Profiling results will be written to {0}".format(profiledir))  # noqa: F401
+    print("Profiling results will be written to {0}".format(profiledir))
 
     alignment = './NP_data/NP_alignment.fasta'
     tree = './NP_data/NP_tree.newick'
     prefs = './NP_data/NP_prefs.tsv'
     print("Using alignment, tree, and prefs in:\n\t{0}".format('\n\t'.join(
-            [alignment, tree, prefs])))  # noqa: F401
+            [alignment, tree, prefs])))
 
     ncpus = max(1, multiprocessing.cpu_count() - 1)
     print("Will run programs using {0} CPUs.".format(ncpus))
@@ -67,16 +67,16 @@ def main():
                 if (not started[name]) and (not completed[name]):
                     p.start()
                     started[name] = True
-                    print("Started profiling run for {0}".format(name))  # noqa: F401
+                    print("Started profiling run for {0}".format(name))
                     break
         for (name, p) in pool.items():
             if started[name] and (not completed[name]) and (
                     not p.is_alive()):
                 completed[name] = True
-                print("Completed profiling run for {0}".format(name))  # noqa: F401
+                print("Completed profiling run for {0}".format(name))
         time.sleep(5)
 
-    print("Program complete.")  # noqa: F401
+    print("Program complete.")
 
 
 if __name__ == '__main__':

--- a/tests/profile_phydms.py
+++ b/tests/profile_phydms.py
@@ -18,13 +18,13 @@ def main():
     profiledir = './NP_profile/'
     if not os.path.isdir(profiledir):
         os.mkdir(profiledir)
-    print("Profiling results will be written to {0}".format(profiledir))
+    print("Profiling results will be written to {0}".format(profiledir))  # noqa: F401
 
     alignment = './NP_data/NP_alignment.fasta'
     tree = './NP_data/NP_tree.newick'
     prefs = './NP_data/NP_prefs.tsv'
     print("Using alignment, tree, and prefs in:\n\t{0}".format('\n\t'.join(
-            [alignment, tree, prefs])))
+            [alignment, tree, prefs])))  # noqa: F401
 
     ncpus = max(1, multiprocessing.cpu_count() - 1)
     print("Will run programs using {0} CPUs.".format(ncpus))
@@ -67,16 +67,16 @@ def main():
                 if (not started[name]) and (not completed[name]):
                     p.start()
                     started[name] = True
-                    print("Started profiling run for {0}".format(name))
+                    print("Started profiling run for {0}".format(name))  # noqa: F401
                     break
         for (name, p) in pool.items():
             if started[name] and (not completed[name]) and (
                     not p.is_alive()):
                 completed[name] = True
-                print("Completed profiling run for {0}".format(name))
+                print("Completed profiling run for {0}".format(name))  # noqa: F401
         time.sleep(5)
 
-    print("Program complete.")
+    print("Program complete.")  # noqa: F401
 
 
 if __name__ == '__main__':

--- a/tests/profile_phydms.py
+++ b/tests/profile_phydms.py
@@ -48,7 +48,9 @@ def main():
             outprefix = '{0}/{1}'.format(profiledir, name)
             for f in glob.glob('{0}*'.format(outprefix)):
                 os.remove(f)
-            cmd = ['phydms', alignment, tree, model, outprefix, '--profile'] + args
+            cmd = ['phydms', alignment, tree, model, outprefix,
+                   '--profile']
+            cmd = cmd + args
             pool[name] = (multiprocessing
                           .Process(target=subprocess.check_call,
                                    args=(cmd,),

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -9,7 +9,6 @@ import unittest
 
 def main():
     """Runs the tests."""
-
     failurestrings = []
     for test in glob.glob('test_*.py'):
         sys.stderr.write('\nRunning tests in {0}...\n'.format(test))
@@ -21,7 +20,7 @@ def main():
             sys.stderr.write('All tests were successful.\n')
         else:
             sys.stderr.write('Test(s) FAILED!\n')
-            for (testcase, failstring) in result.failures + result.errors:
+            for (_testcase, failstring) in result.failures + result.errors:
                 failurestrings.append(failstring)
 
     if not failurestrings:

--- a/tests/run_time_test.py
+++ b/tests/run_time_test.py
@@ -8,9 +8,10 @@ import unittest
 import pandas as pd
 import time
 
+
 def main():
     """Runs the tests."""
-    r = {"test":[], "time":[]}
+    r = {"test": [], "time": []}
     failurestrings = []
     for test in glob.glob('test_*.py'):
         s = time.time()
@@ -26,7 +27,7 @@ def main():
             r["time"].append(float(e-s)/60)
         else:
             sys.stderr.write('Test(s) FAILED!\n')
-            for (testcase, failstring) in result.failures + result.errors:
+            for (_testcase, failstring) in result.failures + result.errors:
                 failurestrings.append(failstring)
 
     if not failurestrings:
@@ -36,8 +37,9 @@ def main():
         for fstring in failurestrings:
             sys.stderr.write('\n*********\n{0}\n********\n'.format(fstring))
     r = pd.DataFrame(r)
-    r["Greater_10min"] = ["y" if x>10 else "n" for x in r["time"]]
+    r["Greater_10min"] = ["y" if x > 10 else "n" for x in r["time"]]
     r.to_csv("time_test_results.csv", index=False)
+
 
 if __name__ == '__main__':
     main()

--- a/tests/test_YNGKPM0.py
+++ b/tests/test_YNGKPM0.py
@@ -33,8 +33,7 @@ class testYNGKP_M0(unittest.TestCase):
         omega = 0.4
         kappa = 2.5
         self.YNGKP_M0 = phydmslib.models.YNGKP_M0(
-            self.e_pa, self.nsites, omega=omega, kappa=kappa
-        )
+            self.e_pa, self.nsites, omega=omega, kappa=kappa)
         self.assertTrue(numpy.allclose(omega, self.YNGKP_M0.omega))
         self.assertTrue(numpy.allclose(kappa, self.YNGKP_M0.kappa))
 
@@ -48,8 +47,7 @@ class testYNGKP_M0(unittest.TestCase):
             self.params = {
                 "omega": random.uniform(0.1, 2),
                 "kappa": random.uniform(0.5, 10),
-                "mu": random.uniform(0.05, 5.0),
-            }
+                "mu": random.uniform(0.05, 5.0)}
             self.YNGKP_M0.updateParams(self.params)
             self.check_YNGKP_M0_attributes()
             self.check_YNGKP_M0_derivatives()
@@ -118,7 +116,7 @@ class testYNGKP_M0(unittest.TestCase):
                     self.assertTrue(
                         diff < 1e-3,
                         ("diff {0} for {1}: x = {2}, y = {3} mu = {4}, "
-                         + "omega = {5}, Pxy = {6}, kappa = {7}"
+                         "omega = {5}, Pxy = {6}, kappa = {7}"
                          ).format(diff, pname, x, y, self.YNGKP_M0.mu,
                                   self.YNGKP_M0.omega,
                                   self.YNGKP_M0.Pxy[0][x][y],
@@ -135,8 +133,7 @@ class testYNGKP_M0(unittest.TestCase):
                           self.YNGKP_M0.Ainv[r]))
             self.assertTrue(
                 numpy.allclose(self.YNGKP_M0.Pxy[r], fromdiag, atol=1e-5),
-                "Max diff {0}".format((self.YNGKP_M0.Pxy[r] - fromdiag).max()),
-            )
+                "Max diff {0}".format((self.YNGKP_M0.Pxy[r] - fromdiag).max()))
 
             for t in [0.02, 0.2, 0.5]:
                 direct = scipy.linalg.expm(self.YNGKP_M0.Pxy[r] *
@@ -144,8 +141,7 @@ class testYNGKP_M0(unittest.TestCase):
                 self.assertTrue(
                     numpy.allclose(self.YNGKP_M0.M(t)[r], direct, atol=1e-6),
                     "Max diff {0}"
-                    .format((self.YNGKP_M0.M(t)[r] - direct).max()),
-                )
+                    .format((self.YNGKP_M0.M(t)[r] - direct).max()))
 
         # check derivatives of M calculated by dM
         # implementation looks a bit complex because `check_grad` function

--- a/tests/test_YNGKPM0.py
+++ b/tests/test_YNGKPM0.py
@@ -4,7 +4,8 @@ Written by Jesse Bloom.
 Edited by Sarah Hilton
 
 Uses `sympy` to make sure attributes and derivatives of attributes
-are correct for `YNGKP_M0` implemented in `phydmslib.models`."""
+are correct for `YNGKP_M0` implemented in `phydmslib.models`.
+"""
 
 
 import random
@@ -17,9 +18,10 @@ import phydmslib.models
 
 
 class testYNGKP_M0(unittest.TestCase):
+    """Test YNGKP M0."""
+
     def test_YNGKP_M0(self):
         """Initialize `YNGKP_M0`, test values, update, test again."""
-
         # create alignment
         numpy.random.seed(1)
         random.seed(1)
@@ -44,7 +46,7 @@ class testYNGKP_M0(unittest.TestCase):
         )
 
         # now check YNGKP_M0 attributes / derivates, updating several times
-        for update in range(2):
+        for _update in range(2):
             self.params = {
                 "omega": random.uniform(0.1, 2),
                 "kappa": random.uniform(0.5, 10),
@@ -75,7 +77,7 @@ class testYNGKP_M0(unittest.TestCase):
         assert self.YNGKP_M0.Ainv.shape == (1, N_CODON, N_CODON)
         assert self.YNGKP_M0.A.shape == (1, N_CODON, N_CODON)
         assert self.YNGKP_M0.M(0.2).shape == (self.nsites, N_CODON, N_CODON)
-        for (pname, value) in self.params.items():
+        for (pname, _value) in self.params.items():
             assert self.YNGKP_M0.dM(0.2, pname, self.YNGKP_M0.M(0.2)).shape ==\
                   (self.nsites, N_CODON, N_CODON)
 

--- a/tests/test_YNGKPM0.py
+++ b/tests/test_YNGKPM0.py
@@ -41,9 +41,7 @@ class testYNGKP_M0(unittest.TestCase):
         self.assertTrue(
             numpy.allclose(
                 numpy.repeat(1.0, self.nsites),
-                self.YNGKP_M0.stationarystate.sum(axis=1),
-            )
-        )
+                self.YNGKP_M0.stationarystate.sum(axis=1)))
 
         # now check YNGKP_M0 attributes / derivates, updating several times
         for _update in range(2):
@@ -109,35 +107,22 @@ class testYNGKP_M0(unittest.TestCase):
                 pvalue = [pvalue]
             for x in random.sample(range(N_CODON), 3):  # check a few codons
                 for y in range(N_CODON):
-                    diff = scipy.optimize.check_grad(
-                        funcPxy,
-                        funcdPxy,
-                        pvalue,
-                        pname,
-                        self.YNGKP_M0,
-                        x,
-                        y,
-                        epsilon=1e-4,
-                    )
+                    diff = scipy.optimize.check_grad(funcPxy,
+                                                     funcdPxy,
+                                                     pvalue,
+                                                     pname,
+                                                     self.YNGKP_M0,
+                                                     x,
+                                                     y,
+                                                     epsilon=1e-4)
                     self.assertTrue(
                         diff < 1e-3,
-                        (
-                            "diff {0} for {1}:"
-                            + "x = {2}, y = {3} "
-                            + "mu = {4}, "
-                            + "omega = {5}, Pxy = {6}, "
-                            + "kappa = {7}"
-                        ).format(
-                            diff,
-                            pname,
-                            x,
-                            y,
-                            self.YNGKP_M0.mu,
-                            self.YNGKP_M0.omega,
-                            self.YNGKP_M0.Pxy[0][x][y],
-                            self.YNGKP_M0.kappa,
-                        ),
-                    )
+                        ("diff {0} for {1}: x = {2}, y = {3} mu = {4}, "
+                         + "omega = {5}, Pxy = {6}, kappa = {7}"
+                         ).format(diff, pname, x, y, self.YNGKP_M0.mu,
+                                  self.YNGKP_M0.omega,
+                                  self.YNGKP_M0.Pxy[0][x][y],
+                                  self.YNGKP_M0.kappa))
             self.YNGKP_M0.updateParams(self.params)  # back to original value
 
     def check_YNGKP_M0_matrix_exponentials(self):
@@ -202,18 +187,11 @@ class testYNGKP_M0(unittest.TestCase):
                 for r in range(1):
                     for x in range(N_CODON):
                         for y in range(N_CODON):
-                            diff = scipy.optimize.check_grad(
-                                funcM,
-                                funcdM,
-                                pvalue,
-                                pname,
-                                t,
-                                self.YNGKP_M0,
-                                r,
-                                x,
-                                y,
-                                storedvalues,
-                            )
+                            diff = scipy.optimize.check_grad(funcM, funcdM,
+                                                             pvalue, pname,
+                                                             t, self.YNGKP_M0,
+                                                             r, x, y,
+                                                             storedvalues)
                             self.assertTrue(diff < 1e-3,
                                             "diff {0} for {1}: r = {2}, "
                                             "x = {3}, y = {4}"

--- a/tests/test_YNGKPM0.py
+++ b/tests/test_YNGKPM0.py
@@ -12,41 +12,44 @@ import unittest
 import numpy
 import scipy.linalg
 import scipy.optimize
-import sympy
-from phydmslib.constants import *
+from phydmslib.constants import N_NT, N_CODON
 import phydmslib.models
 
 
 class testYNGKP_M0(unittest.TestCase):
-
     def test_YNGKP_M0(self):
         """Initialize `YNGKP_M0`, test values, update, test again."""
 
         # create alignment
-        sequences = [""]
-        #self.e_pa = numpy.array([[4.0, 0.0, 0.0, 0.0], [0.0, 1.0, 2.0, 1.0], [0.0, 2.0, 0.0, 2.0]])
         numpy.random.seed(1)
         random.seed(1)
-        self.e_pa = numpy.random.uniform(0.12, 1.0, size = (3, N_NT))
-        self.e_pa = self.e_pa/self.e_pa.sum(axis=1, keepdims=True)
+        self.e_pa = numpy.random.uniform(0.12, 1.0, size=(3, N_NT))
+        self.e_pa = self.e_pa / self.e_pa.sum(axis=1, keepdims=True)
         self.nsites = 10
 
         # create initial YNGKP_M0
-        phi = numpy.random.dirichlet([2] * N_NT)
         omega = 0.4
         kappa = 2.5
-        self.YNGKP_M0 = phydmslib.models.YNGKP_M0(self.e_pa, self.nsites, omega=omega, kappa=kappa)
+        self.YNGKP_M0 = phydmslib.models.YNGKP_M0(
+            self.e_pa, self.nsites, omega=omega, kappa=kappa
+        )
         self.assertTrue(numpy.allclose(omega, self.YNGKP_M0.omega))
         self.assertTrue(numpy.allclose(kappa, self.YNGKP_M0.kappa))
 
-        self.assertTrue(numpy.allclose(numpy.repeat(1.0, self.nsites), self.YNGKP_M0.stationarystate.sum(axis=1)))
+        self.assertTrue(
+            numpy.allclose(
+                numpy.repeat(1.0, self.nsites),
+                self.YNGKP_M0.stationarystate.sum(axis=1),
+            )
+        )
 
         # now check YNGKP_M0 attributes / derivates, updating several times
         for update in range(2):
-            self.params = {'omega':random.uniform(0.1, 2),
-                      'kappa':random.uniform(0.5, 10),
-                      'mu':random.uniform(0.05, 5.0),
-                     }
+            self.params = {
+                "omega": random.uniform(0.1, 2),
+                "kappa": random.uniform(0.5, 10),
+                "mu": random.uniform(0.05, 5.0),
+            }
             self.YNGKP_M0.updateParams(self.params)
             self.check_YNGKP_M0_attributes()
             self.check_YNGKP_M0_derivatives()
@@ -59,9 +62,9 @@ class testYNGKP_M0(unittest.TestCase):
         # make sure Prxy has rows summing to zero
         self.assertFalse(numpy.isnan(self.YNGKP_M0.Pxy).any())
         self.assertFalse(numpy.isinf(self.YNGKP_M0.Pxy).any())
-        diag = numpy.eye(N_CODON, dtype='bool')
+        diag = numpy.eye(N_CODON, dtype="bool")
         self.assertTrue(numpy.allclose(0, numpy.sum(self.YNGKP_M0.Pxy[0],
-                axis=1)))
+                                       axis=1)))
         self.assertTrue(numpy.allclose(0, self.YNGKP_M0.Pxy[0].sum()))
         self.assertTrue((self.YNGKP_M0.Pxy[0][diag] <= 0).all())
         self.assertTrue((self.YNGKP_M0.Pxy[0][~diag] >= 0).all())
@@ -73,8 +76,8 @@ class testYNGKP_M0(unittest.TestCase):
         assert self.YNGKP_M0.A.shape == (1, N_CODON, N_CODON)
         assert self.YNGKP_M0.M(0.2).shape == (self.nsites, N_CODON, N_CODON)
         for (pname, value) in self.params.items():
-            assert self.YNGKP_M0.dM(0.2, pname, self.YNGKP_M0.M(0.2)).shape == (self.nsites, N_CODON, N_CODON)
-
+            assert self.YNGKP_M0.dM(0.2, pname, self.YNGKP_M0.M(0.2)).shape ==\
+                  (self.nsites, N_CODON, N_CODON)
 
     def check_YNGKP_M0_derivatives(self):
         """Makes sure derivatives are as expected."""
@@ -85,98 +88,138 @@ class testYNGKP_M0(unittest.TestCase):
 
         def funcPxy(paramvalue, paramname, YNGKP_M0, x, y):
             if len(paramvalue) == 1:
-                YNGKP_M0.updateParams({paramname:paramvalue[0]})
+                YNGKP_M0.updateParams({paramname: paramvalue[0]})
             else:
-                YNGKP_M0.updateParams({paramname:paramvalue})
+                YNGKP_M0.updateParams({paramname: paramvalue})
             return YNGKP_M0.Pxy[0][x][y]
 
         def funcdPxy(paramvalue, paramname, YNGKP_M0, x, y):
             if len(paramvalue) == 1:
-                YNGKP_M0.updateParams({paramname:paramvalue[0]})
+                YNGKP_M0.updateParams({paramname: paramvalue[0]})
             else:
-                YNGKP_M0.updateParams({paramname:paramvalue})
+                YNGKP_M0.updateParams({paramname: paramvalue})
             return YNGKP_M0.dPxy[paramname][0][x][y]
 
         for (pname, pvalue) in sorted(self.params.items())[::-1]:
-            if pname == 'mu':
+            if pname == "mu":
                 continue
             if isinstance(pvalue, float):
                 pvalue = [pvalue]
-            for x in random.sample(range(N_CODON), 3): # check a few codons
+            for x in random.sample(range(N_CODON), 3):  # check a few codons
                 for y in range(N_CODON):
-                    diff = scipy.optimize.check_grad(funcPxy, funcdPxy,
-                            pvalue, pname, self.YNGKP_M0, x, y, epsilon=1e-4)
-                    self.assertTrue(diff < 1e-3, ("diff {0} for {1}:" +
-                            "x = {2}, y = {3} " +
-                            "mu = {4}, " +
-                            "omega = {5}, Pxy = {6}, " +
-                            "kappa = {7}"
-                            ).format(diff, pname, x, y,
-                            self.YNGKP_M0.mu, self.YNGKP_M0.omega,
+                    diff = scipy.optimize.check_grad(
+                        funcPxy,
+                        funcdPxy,
+                        pvalue,
+                        pname,
+                        self.YNGKP_M0,
+                        x,
+                        y,
+                        epsilon=1e-4,
+                    )
+                    self.assertTrue(
+                        diff < 1e-3,
+                        (
+                            "diff {0} for {1}:"
+                            + "x = {2}, y = {3} "
+                            + "mu = {4}, "
+                            + "omega = {5}, Pxy = {6}, "
+                            + "kappa = {7}"
+                        ).format(
+                            diff,
+                            pname,
+                            x,
+                            y,
+                            self.YNGKP_M0.mu,
+                            self.YNGKP_M0.omega,
                             self.YNGKP_M0.Pxy[0][x][y],
-                            self.YNGKP_M0.kappa))
-            self.YNGKP_M0.updateParams(self.params) # back to original value
+                            self.YNGKP_M0.kappa,
+                        ),
+                    )
+            self.YNGKP_M0.updateParams(self.params)  # back to original value
 
     def check_YNGKP_M0_matrix_exponentials(self):
         """Makes sure matrix exponentials of YNGKP_M0 are as expected."""
         for r in range(1):
             # fromdiag is recomputed Prxy after diagonalization
-            fromdiag = numpy.dot(self.YNGKP_M0.A[0], numpy.dot(numpy.diag(
-                    self.YNGKP_M0.D[r]), self.YNGKP_M0.Ainv[r]))
-            self.assertTrue(numpy.allclose(self.YNGKP_M0.Pxy[r], fromdiag,
-                    atol=1e-5), "Max diff {0}".format((self.YNGKP_M0.Pxy[r] - fromdiag).max()))
+            fromdiag = numpy.dot(
+                self.YNGKP_M0.A[0],
+                numpy.dot(numpy.diag(self.YNGKP_M0.D[r]),
+                          self.YNGKP_M0.Ainv[r]))
+            self.assertTrue(
+                numpy.allclose(self.YNGKP_M0.Pxy[r], fromdiag, atol=1e-5),
+                "Max diff {0}".format((self.YNGKP_M0.Pxy[r] - fromdiag).max()),
+            )
 
             for t in [0.02, 0.2, 0.5]:
-                direct = scipy.linalg.expm(self.YNGKP_M0.Pxy[r] * self.YNGKP_M0.mu * t)
-                self.assertTrue(numpy.allclose(self.YNGKP_M0.M(t)[r], direct, atol=1e-6),
-                        "Max diff {0}".format((self.YNGKP_M0.M(t)[r] - direct).max()))
+                direct = scipy.linalg.expm(self.YNGKP_M0.Pxy[r] *
+                                           self.YNGKP_M0.mu * t)
+                self.assertTrue(
+                    numpy.allclose(self.YNGKP_M0.M(t)[r], direct, atol=1e-6),
+                    "Max diff {0}"
+                    .format((self.YNGKP_M0.M(t)[r] - direct).max()),
+                )
+
         # check derivatives of M calculated by dM
         # implementation looks a bit complex because `check_grad` function
         # can only be used for single values at a time, so have to loop
         # over r, x, y and so hash values to make faster
         def funcM(paramvalue, paramname, t, YNGKP_M0, r, x, y, storedvalues):
             """Gets `M(t)[r][x][y]`."""
-            key = ('M', tuple(paramvalue), paramname, t)
+            key = ("M", tuple(paramvalue), paramname, t)
             if key not in storedvalues:
                 if len(paramvalue) == 1:
-                    YNGKP_M0.updateParams({paramname:paramvalue[0]})
+                    YNGKP_M0.updateParams({paramname: paramvalue[0]})
                 else:
-                    YNGKP_M0.updateParams({paramname:paramvalue})
+                    YNGKP_M0.updateParams({paramname: paramvalue})
                 storedvalues[key] = YNGKP_M0.M(t)
             if len(storedvalues[key].shape) == 3:
                 return storedvalues[key][r][x][y]
             else:
-                return storedvalues[key][:,r,x,y]
+                return storedvalues[key][:, r, x, y]
+
         def funcdM(paramvalue, paramname, t, YNGKP_M0, r, x, y, storedvalues):
             """Gets `dM`."""
-            key = ('dM', tuple(paramvalue), paramname, t)
+            key = ("dM", tuple(paramvalue), paramname, t)
             if key not in storedvalues:
                 if len(paramvalue) == 1:
-                    YNGKP_M0.updateParams({paramname:paramvalue[0]})
+                    YNGKP_M0.updateParams({paramname: paramvalue[0]})
                 else:
-                    YNGKP_M0.updateParams({paramname:paramvalue})
+                    YNGKP_M0.updateParams({paramname: paramvalue})
                 storedvalues[key] = YNGKP_M0.dM(t, paramname, YNGKP_M0.M(t))
             if len(storedvalues[key].shape) == 3:
                 return storedvalues[key][r][x][y]
             else:
-                return storedvalues[key][:,r,x,y]
+                return storedvalues[key][:, r, x, y]
+
         for (pname, pvalue) in sorted(self.params.items()):
-            storedvalues = {} # used to hash values
+            storedvalues = {}  # used to hash values
             if isinstance(pvalue, float):
                 pvalue = [pvalue]
             for t in [0.01, 0.2, 0.5]:
                 for r in range(1):
                     for x in range(N_CODON):
                         for y in range(N_CODON):
-                            diff = scipy.optimize.check_grad(funcM, funcdM, pvalue,
-                                    pname, t, self.YNGKP_M0, r, x, y, storedvalues)
-                            self.assertTrue(diff < 1e-3, ("diff {0} for {1}:" +
-                                " r = {2}, x = {3}, y = {4}"
-                                ).format(diff, pname, r, x, y))
-                self.YNGKP_M0.updateParams(self.params) # back to original value
+                            diff = scipy.optimize.check_grad(
+                                funcM,
+                                funcdM,
+                                pvalue,
+                                pname,
+                                t,
+                                self.YNGKP_M0,
+                                r,
+                                x,
+                                y,
+                                storedvalues,
+                            )
+                            self.assertTrue(diff < 1e-3,
+                                            "diff {0} for {1}: r = {2}, "
+                                            "x = {3}, y = {4}"
+                                            .format(diff, pname, r, x, y))
+                # back to original value
+                self.YNGKP_M0.updateParams(self.params)
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     runner = unittest.TextTestRunner()
     unittest.main(testRunner=runner)

--- a/tests/test_alignmentSimulation.py
+++ b/tests/test_alignmentSimulation.py
@@ -99,7 +99,7 @@ class test_simulateAlignment_ExpCM(unittest.TestCase):
         nsubs /= float(nsites)
         tl = phydmslib.treelikelihood.TreeLikelihood(biotree, a, model)
         tl.maximizeLikelihood()
-        treedist += sum([n.branch_length for n in tl.tree.get_terminals()])
+        treedist += sum((n.branch_length for n in tl.tree.get_terminals()))
 
         # We expect nsubs = t, but build in some tolerance
         # with rtol since we simulated finite number of sites.

--- a/tests/test_alignmentSimulation.py
+++ b/tests/test_alignmentSimulation.py
@@ -6,21 +6,15 @@ Written by Sarah Hilton and Jesse Bloom.
 """
 
 import os
-import sys
 import numpy
-import math
 import unittest
 import random
-import io
-import copy
 import phydmslib.models
 import phydmslib.treelikelihood
 import phydmslib.simulate
-from phydmslib.constants import *
+from phydmslib.constants import N_NT, AA_TO_INDEX, N_AA
 import Bio.SeqIO
 import Bio.Phylo
-import pyvolve
-
 
 
 class test_simulateAlignment_ExpCM(unittest.TestCase):
@@ -54,15 +48,17 @@ class test_simulateAlignment_ExpCM(unittest.TestCase):
         if self.MODEL == phydmslib.models.ExpCM:
             phi = numpy.random.dirichlet([7] * N_NT)
             model = phydmslib.models.ExpCM(prefs, kappa=kappa, omega=omega,
-                    beta=beta, mu=mu, phi=phi, freeparams=['mu'])
+                                           beta=beta, mu=mu, phi=phi,
+                                           freeparams=['mu'])
         elif self.MODEL == phydmslib.models.ExpCM_empirical_phi:
             g = numpy.random.dirichlet([7] * N_NT)
-            model = phydmslib.models.ExpCM_empirical_phi(prefs, g,
-                    kappa=kappa, omega=omega, beta=beta, mu=mu,
-                    freeparams=['mu'])
+            model = phydmslib.models.ExpCM_empirical_phi(prefs, g, kappa=kappa,
+                                                         omega=omega,
+                                                         beta=beta, mu=mu,
+                                                         freeparams=['mu'])
         elif self.MODEL == phydmslib.models.YNGKP_M0:
             e_pw = numpy.asarray([numpy.random.dirichlet([7] * N_NT) for i
-                    in range(3)])
+                                  in range(3)])
             model = phydmslib.models.YNGKP_M0(e_pw, nsites)
         else:
             raise ValueError("Invalid MODEL: {0}".format(type(self.MODEL)))
@@ -79,7 +75,7 @@ class test_simulateAlignment_ExpCM(unittest.TestCase):
         # simulate the alignment
         phydmslib.simulate.simulateAlignment(model, temptree, alignmentPrefix)
 
-        # read in the test tree, re-scale the branch lengths, and remove the file
+        # read in the test tree, re-scale the branch lengths, remove the file
         biotree = Bio.Phylo.read(temptree, 'newick')
         os.remove(temptree)
         for node in biotree.get_terminals() + biotree.get_nonterminals():
@@ -89,8 +85,8 @@ class test_simulateAlignment_ExpCM(unittest.TestCase):
         # check and see if the simulated alignment has the expected number of
         # subs exists
         alignment = '{0}_simulatedalignment.fasta'.format(alignmentPrefix)
-        nsubs = 0 # subs in simulated seqs (estimate from Hamming distance)
-        treedist = 0.0 # distance inferred by `TreeLikelihood`
+        nsubs = 0  # subs in simulated seqs (estimate from Hamming distance)
+        treedist = 0.0  # distance inferred by `TreeLikelihood`
         a = [(s.description, str(s.seq)) for s in Bio.SeqIO.parse(
                 alignment, 'fasta')]
         assert len(a[0][1]) == len(a[1][1]) == nsites * 3
@@ -98,8 +94,8 @@ class test_simulateAlignment_ExpCM(unittest.TestCase):
             if os.path.isfile(f):
                 os.remove(f)
         for r in range(nsites):
-            codon1 = a[0][1][3 * r : 3 * r + 3]
-            codon2 = a[1][1][3 * r : 3 * r + 3]
+            codon1 = a[0][1][3 * r: 3 * r + 3]
+            codon2 = a[1][1][3 * r: 3 * r + 3]
             nsubs += len([j for j in range(3) if codon1[j] != codon2[j]])
         nsubs /= float(nsites)
         tl = phydmslib.treelikelihood.TreeLikelihood(biotree, a, model)
@@ -109,9 +105,9 @@ class test_simulateAlignment_ExpCM(unittest.TestCase):
         # We expect nsubs = t, but build in some tolerance
         # with rtol since we simulated finite number of sites.
         self.assertTrue(numpy.allclose(nsubs, t, rtol=0.2),
-                ("Simulated subs per site of {0} is not close "
-                "to expected value of {1} (branchScale = {2}, t = {3})").format(
-                nsubs, t, model.branchScale, t))
+                        ("Simulated subs per site of {0} is not close "
+                        "to expected value of {1} (branchScale = {2}, "
+                         "t = {3})").format(nsubs, t, model.branchScale, t))
         self.assertTrue(numpy.allclose(treedist, nsubs, rtol=0.2), (
                 "Simulated subs per site of {0} is not close to inferred "
                 "branch length of {1}").format(nsubs, treedist))

--- a/tests/test_alignmentSimulation.py
+++ b/tests/test_alignmentSimulation.py
@@ -26,7 +26,6 @@ class test_simulateAlignment_ExpCM(unittest.TestCase):
 
     def test_simulateAlignment(self):
         """Simulate evolution, ensure scaled branches match number of subs."""
-
         numpy.random.seed(1)
         random.seed(1)
 
@@ -36,7 +35,7 @@ class test_simulateAlignment_ExpCM(unittest.TestCase):
         nsites = 1000
         prefs = []
         minpref = 0.01
-        for r in range(nsites):
+        for _r in range(nsites):
             rprefs = numpy.random.dirichlet([1] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
@@ -121,6 +120,7 @@ class test_simulateAlignment_ExpCM(unittest.TestCase):
 
 class test_simulateAlignment_YNGKP_M0(test_simulateAlignment_ExpCM):
     """Tests `simulateAlignment` of `YNGKP_M0` model."""
+
     MODEL = phydmslib.models.YNGKP_M0
 
 

--- a/tests/test_alignmentSimulationRandomSeed.py
+++ b/tests/test_alignmentSimulationRandomSeed.py
@@ -6,26 +6,20 @@ Written by Sarah Hilton and Jesse Bloom.
 """
 
 import os
-import sys
 import numpy
-import math
 import unittest
 import random
-import io
-import copy
 import phydmslib.models
 import phydmslib.treelikelihood
 import phydmslib.simulate
-from phydmslib.constants import *
+from phydmslib.constants import N_NT, N_AA, AA_TO_INDEX
 import Bio.SeqIO
 import Bio.Phylo
-import pyvolve
 import glob
 
 
-
-class test_simulateAlignmentRandomSeed_ExpCM(unittest.TestCase):
-    """Tests `simulateAlignment` of `simulate.py` module with different seed numbers."""
+class test_simulateRandomSeed_ExpCM(unittest.TestCase):
+    """Tests `simulate.simulateAlignment` module with different seeds."""
 
     # use approach here to run multiple tests:
     # http://stackoverflow.com/questions/17260469/instantiate-python-unittest-testcase-with-arguments
@@ -53,15 +47,17 @@ class test_simulateAlignmentRandomSeed_ExpCM(unittest.TestCase):
         if self.MODEL == phydmslib.models.ExpCM:
             phi = numpy.random.dirichlet([7] * N_NT)
             model = phydmslib.models.ExpCM(prefs, kappa=kappa, omega=omega,
-                    beta=beta, mu=mu, phi=phi, freeparams=['mu'])
+                                           beta=beta, mu=mu, phi=phi,
+                                           freeparams=['mu'])
         elif self.MODEL == phydmslib.models.ExpCM_empirical_phi:
             g = numpy.random.dirichlet([7] * N_NT)
-            model = phydmslib.models.ExpCM_empirical_phi(prefs, g,
-                    kappa=kappa, omega=omega, beta=beta, mu=mu,
-                    freeparams=['mu'])
+            model = phydmslib.models.ExpCM_empirical_phi(prefs, g, kappa=kappa,
+                                                         omega=omega,
+                                                         beta=beta, mu=mu,
+                                                         freeparams=['mu'])
         elif self.MODEL == phydmslib.models.YNGKP_M0:
             e_pw = numpy.asarray([numpy.random.dirichlet([7] * N_NT) for i
-                    in range(3)])
+                                  in range(3)])
             model = phydmslib.models.YNGKP_M0(e_pw, nsites)
         else:
             raise ValueError("Invalid MODEL: {0}".format(type(self.MODEL)))
@@ -80,26 +76,32 @@ class test_simulateAlignmentRandomSeed_ExpCM(unittest.TestCase):
         # alignments with the same seed number should be the same
         # make two alignments with the same seed number
         for counter in range(2):
-            alignmentPrefix = "test_counter{0}_seed{1}".format(counter,seed)
-            phydmslib.simulate.simulateAlignment(model, temptree, alignmentPrefix, seed)
-            for s in Bio.SeqIO.parse("test_counter{0}_seed{1}_simulatedalignment.fasta".format(counter,seed), "fasta"):
+            alignmentPrefix = "test_counter{0}_seed{1}".format(counter, seed)
+            phydmslib.simulate.simulateAlignment(model, temptree,
+                                                 alignmentPrefix, seed)
+            for s in Bio.SeqIO.parse("test_counter{0}_seed{1}_simulated"
+                                     "alignment.fasta".format(counter, seed),
+                                     "fasta"):
                 alignments[counter][s.id] = str(s.seq)
         # check they are the same
         for key in alignments[counter].keys():
-            self.assertTrue(alignments[counter][key] == alignments[counter - 1][key])
+            self.assertTrue(alignments[counter][key] ==
+                            alignments[counter - 1][key])
 
         # alignments with different seed numbers should be different
         # make an alignment with a different seed number
         seed += 1
         counter += 1
-        alignmentPrefix = "test_counter{0}_seed{1}".format(counter,seed)
-        phydmslib.simulate.simulateAlignment(model, temptree, alignmentPrefix, seed)
-        for s in Bio.SeqIO.parse("test_counter{0}_seed{1}_simulatedalignment.fasta".format(counter,seed), "fasta"):
+        alignmentPrefix = "test_counter{0}_seed{1}".format(counter, seed)
+        phydmslib.simulate.simulateAlignment(model, temptree,
+                                             alignmentPrefix, seed)
+        for s in Bio.SeqIO.parse("test_counter{0}_seed{1}_simulatedalignment."
+                                 "fasta".format(counter, seed), "fasta"):
             alignments[counter][s.id] = str(s.seq)
         # check they are different
         for key in alignments[counter].keys():
-            self.assertFalse(alignments[counter][key] == alignments[counter - 1][key])
-
+            self.assertFalse(alignments[counter][key] ==
+                             alignments[counter - 1][key])
 
         # general clean-up
         os.remove(temptree)
@@ -108,7 +110,7 @@ class test_simulateAlignmentRandomSeed_ExpCM(unittest.TestCase):
                 os.remove(fasta)
 
 
-class test_simulateAlignmentRandomSeed_YNGKP_M0(test_simulateAlignmentRandomSeed_ExpCM):
+class test_simulateRandomSeed_YNGKP_M0(test_simulateRandomSeed_ExpCM):
     """Tests `simulateAlignment` of `YNGKP_M0` model."""
     MODEL = phydmslib.models.YNGKP_M0
 

--- a/tests/test_alignmentSimulationRandomSeed.py
+++ b/tests/test_alignmentSimulationRandomSeed.py
@@ -27,7 +27,6 @@ class test_simulateRandomSeed_ExpCM(unittest.TestCase):
 
     def test_simulateAlignmentRandomSeed(self):
         """Simulate evolution, ensure scaled branches match number of subs."""
-
         numpy.random.seed(1)
         random.seed(1)
 
@@ -35,7 +34,7 @@ class test_simulateRandomSeed_ExpCM(unittest.TestCase):
         nsites = 200
         prefs = []
         minpref = 0.01
-        for r in range(nsites):
+        for _r in range(nsites):
             rprefs = numpy.random.dirichlet([1] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
@@ -112,6 +111,7 @@ class test_simulateRandomSeed_ExpCM(unittest.TestCase):
 
 class test_simulateRandomSeed_YNGKP_M0(test_simulateRandomSeed_ExpCM):
     """Tests `simulateAlignment` of `YNGKP_M0` model."""
+
     MODEL = phydmslib.models.YNGKP_M0
 
 

--- a/tests/test_alignmentSimulation_divpressure.py
+++ b/tests/test_alignmentSimulation_divpressure.py
@@ -27,7 +27,6 @@ class test_simulateAlignment_ExpCM_divselection(unittest.TestCase):
 
     def test_simulateAlignment(self):
         """Simulate evolution, ensure scaled branches match number of subs."""
-
         numpy.random.seed(1)
         random.seed(1)
 
@@ -37,7 +36,7 @@ class test_simulateAlignment_ExpCM_divselection(unittest.TestCase):
         nsites = 1000
         prefs = []
         minpref = 0.01
-        for r in range(nsites):
+        for _r in range(nsites):
             rprefs = numpy.random.dirichlet([1] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()

--- a/tests/test_alignmentSimulation_divpressure.py
+++ b/tests/test_alignmentSimulation_divpressure.py
@@ -96,7 +96,7 @@ class test_simulateAlignment_ExpCM_divselection(unittest.TestCase):
         nsubs /= float(nsites)
         tl = phydmslib.treelikelihood.TreeLikelihood(biotree, a, model)
         tl.maximizeLikelihood()
-        treedist += sum([n.branch_length for n in tl.tree.get_terminals()])
+        treedist += sum((n.branch_length for n in tl.tree.get_terminals()))
 
         # We expect nsubs = t, but build in some tolerance
         # with rtol since we simulated finite number of sites.

--- a/tests/test_branchScale.py
+++ b/tests/test_branchScale.py
@@ -100,7 +100,7 @@ class test_branchScale_ExpCM(unittest.TestCase):
                 nsubs += len([j for j in range(3) if codon1[j] != codon2[j]])
             tl = phydmslib.treelikelihood.TreeLikelihood(biotree, a, model)
             tl.maximizeLikelihood()
-            treedist += sum([n.branch_length for n in tl.tree.get_terminals()])
+            treedist += sum((n.branch_length for n in tl.tree.get_terminals()))
         nsubs /= float(nsites * nreplicates)
         treedist /= float(nreplicates)
 

--- a/tests/test_branchScale.py
+++ b/tests/test_branchScale.py
@@ -28,7 +28,6 @@ class test_branchScale_ExpCM(unittest.TestCase):
 
     def test_branchScale(self):
         """Simulate evolution, ensure scaled branches match number of subs."""
-
         numpy.random.seed(1)
         random.seed(1)
 
@@ -36,7 +35,7 @@ class test_branchScale_ExpCM(unittest.TestCase):
         nsites = 50
         prefs = []
         minpref = 0.01
-        for r in range(nsites):
+        for _r in range(nsites):
             rprefs = numpy.random.dirichlet([1] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
@@ -87,7 +86,7 @@ class test_branchScale_ExpCM(unittest.TestCase):
         nsubs = 0  # subs in simulated seqs (estimate from Hamming distance)
         treedist = 0.0  # distance inferred by `TreeLikelihood`
         nreplicates = 100
-        for i in range(nreplicates):
+        for _i in range(nreplicates):
             evolver(seqfile=alignment, infofile=info, ratefile=rates)
             a = [(s.description, str(s.seq)) for s in Bio.SeqIO.parse(
                     alignment, 'fasta')]
@@ -125,6 +124,7 @@ class test_branchScale_ExpCM(unittest.TestCase):
 
 class test_branchScale_YNGKP_M0(test_branchScale_ExpCM):
     """Tests `branchScale` of `YNGKP_M0` model."""
+
     MODEL = phydmslib.models.YNGKP_M0
 
 

--- a/tests/test_branchScale.py
+++ b/tests/test_branchScale.py
@@ -7,21 +7,16 @@ Written by Jesse Bloom.
 """
 
 import os
-import sys
 import numpy
-import math
 import unittest
 import random
-import io
-import copy
 import phydmslib.models
 import phydmslib.treelikelihood
 import phydmslib.simulate
-from phydmslib.constants import *
+from phydmslib.constants import N_NT, N_AA, AA_TO_INDEX
 import Bio.SeqIO
 import Bio.Phylo
 import pyvolve
-
 
 
 class test_branchScale_ExpCM(unittest.TestCase):
@@ -53,17 +48,19 @@ class test_branchScale_ExpCM(unittest.TestCase):
         if self.MODEL == phydmslib.models.ExpCM:
             phi = numpy.random.dirichlet([7] * N_NT)
             model = phydmslib.models.ExpCM(prefs, kappa=kappa, omega=omega,
-                    beta=beta, mu=mu, phi=phi, freeparams=['mu'])
+                                           beta=beta, mu=mu, phi=phi,
+                                           freeparams=['mu'])
             partitions = phydmslib.simulate.pyvolvePartitions(model)
         elif self.MODEL == phydmslib.models.ExpCM_empirical_phi:
             g = numpy.random.dirichlet([7] * N_NT)
-            model = phydmslib.models.ExpCM_empirical_phi(prefs, g,
-                    kappa=kappa, omega=omega, beta=beta, mu=mu,
-                    freeparams=['mu'])
+            model = phydmslib.models.ExpCM_empirical_phi(prefs, g, kappa=kappa,
+                                                         omega=omega,
+                                                         beta=beta, mu=mu,
+                                                         freeparams=['mu'])
             partitions = phydmslib.simulate.pyvolvePartitions(model)
         elif self.MODEL == phydmslib.models.YNGKP_M0:
             e_pw = numpy.asarray([numpy.random.dirichlet([7] * N_NT) for i
-                    in range(3)])
+                                  in range(3)])
             model = phydmslib.models.YNGKP_M0(e_pw, nsites)
             partitions = phydmslib.simulate.pyvolvePartitions(model)
         else:
@@ -87,8 +84,8 @@ class test_branchScale_ExpCM(unittest.TestCase):
         info = '_temp_info.txt'
         rates = '_temp_ratefile.txt'
         evolver = pyvolve.Evolver(partitions=partitions, tree=pyvolvetree)
-        nsubs = 0 # subs in simulated seqs (estimate from Hamming distance)
-        treedist = 0.0 # distance inferred by `TreeLikelihood`
+        nsubs = 0  # subs in simulated seqs (estimate from Hamming distance)
+        treedist = 0.0  # distance inferred by `TreeLikelihood`
         nreplicates = 100
         for i in range(nreplicates):
             evolver(seqfile=alignment, infofile=info, ratefile=rates)
@@ -99,8 +96,8 @@ class test_branchScale_ExpCM(unittest.TestCase):
                 if os.path.isfile(f):
                     os.remove(f)
             for r in range(nsites):
-                codon1 = a[0][1][3 * r : 3 * r + 3]
-                codon2 = a[1][1][3 * r : 3 * r + 3]
+                codon1 = a[0][1][3 * r: 3 * r + 3]
+                codon2 = a[1][1][3 * r: 3 * r + 3]
                 nsubs += len([j for j in range(3) if codon1[j] != codon2[j]])
             tl = phydmslib.treelikelihood.TreeLikelihood(biotree, a, model)
             tl.maximizeLikelihood()
@@ -111,9 +108,10 @@ class test_branchScale_ExpCM(unittest.TestCase):
         # We expect nsubs = branchScale * t, but build in some tolerance
         # with rtol since we simulated finite number of sites.
         self.assertTrue(numpy.allclose(nsubs, model.branchScale * t, rtol=0.2),
-                ("Simulated subs per site of {0} is not close "
-                "to expected value of {1} (branchScale = {2}, t = {3})").format(
-                nsubs, t * model.branchScale, model.branchScale, t))
+                        ("Simulated subs per site of {0} is not close to "
+                        "expected value of {1} (branchScale = {2}, t = {3})")
+                        .format(nsubs, t * model.branchScale,
+                                model.branchScale, t))
         self.assertTrue(numpy.allclose(treedist, nsubs, rtol=0.2), (
                 "Simulated subs per site of {0} is not close to inferred "
                 "branch length of {1}").format(nsubs, treedist))

--- a/tests/test_brlenderivatives.py
+++ b/tests/test_brlenderivatives.py
@@ -4,19 +4,15 @@ Written by Jesse Bloom.
 """
 
 import os
-import sys
-import re
-import math
 import unittest
 import random
-import copy
 import numpy
 import scipy.optimize
 import Bio.Phylo
 import phydmslib.models
 import phydmslib.treelikelihood
 import phydmslib.simulate
-from phydmslib.constants import *
+from phydmslib.constants import N_CODON, N_NT, AA_TO_INDEX, N_AA
 import pyvolve
 
 
@@ -99,18 +95,26 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
 
     def test_Initialize(self):
         """Test that `TreeLikelihood` initializes properly."""
-        tl = phydmslib.treelikelihood.TreeLikelihood(self.tree,
-                self.alignment, self.model, underflowfreq=self.underflowfreq,
-                dparamscurrent=False, dtcurrent=True)
+        tl = (phydmslib.treelikelihood
+              .TreeLikelihood(self.tree,
+                              self.alignment,
+                              self.model,
+                              underflowfreq=self.underflowfreq,
+                              dparamscurrent=False,
+                              dtcurrent=True))
         self.assertEqual(tl.dloglik_dt.shape, tl.t.shape)
 
     def test_dM_dt(self):
         """Tests model `dM` with respect to `t`."""
         numpy.random.seed(1)
         random.seed(1)
-        tl = phydmslib.treelikelihood.TreeLikelihood(self.tree,
-                self.alignment, self.model, underflowfreq=self.underflowfreq,
-                dparamscurrent=False, dtcurrent=True)
+        tl = (phydmslib.treelikelihood
+              .TreeLikelihood(self.tree,
+                              self.alignment,
+                              self.model,
+                              underflowfreq=self.underflowfreq,
+                              dparamscurrent=False,
+                              dtcurrent=True))
 
         def func(t, k, r, x, y):
             return tl._M(k, t[0], None)[r][x][y]
@@ -129,9 +133,12 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
     def test_AdjustBrLen(self):
         """Tests adjusting branch lengths."""
         numpy.random.seed(1)
-        tl = phydmslib.treelikelihood.TreeLikelihood(self.tree,
-                self.alignment, self.model, underflowfreq=self.underflowfreq,
-                dparamscurrent=False, dtcurrent=True)
+        tl = (phydmslib.treelikelihood
+              .TreeLikelihood(self.tree,
+                              self.alignment,
+                              self.model,
+                              underflowfreq=self.underflowfreq,
+                              dparamscurrent=False, dtcurrent=True))
         loglik1 = tl.loglik
         tl.t = 2 * tl.t
         self.assertFalse(numpy.allclose(loglik1, tl.loglik))
@@ -151,9 +158,13 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
 
     def test_BrLenDerivatives(self):
         """Tests derivatives of branch lengths."""
-        tl = phydmslib.treelikelihood.TreeLikelihood(self.tree,
-                self.alignment, self.model, underflowfreq=self.underflowfreq,
-                dparamscurrent=False, dtcurrent=True)
+        tl = (phydmslib.treelikelihood
+              .TreeLikelihood(self.tree,
+                              self.alignment,
+                              self.model,
+                              underflowfreq=self.underflowfreq,
+                              dparamscurrent=False,
+                              dtcurrent=True))
 
         def func(t, n):
             tx = tl.t
@@ -169,33 +180,39 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
 
         for n in range(len(tl.t)):
             diff = scipy.optimize.check_grad(func, dfunc,
-                    numpy.array([tl.t[n]]), n)
+                                             numpy.array([tl.t[n]]), n)
             self.assertTrue(diff < 2e-5, diff)
-
 
     def test_dtcurrent(self):
         """Tests use of `dtcurrent` attribute."""
-        tl1 = phydmslib.treelikelihood.TreeLikelihood(self.tree,
-                self.alignment, self.model, underflowfreq=self.underflowfreq,
-                dparamscurrent=False, dtcurrent=True)
+        tl1 = (phydmslib.treelikelihood
+               .TreeLikelihood(self.tree,
+                               self.alignment,
+                               self.model,
+                               underflowfreq=self.underflowfreq,
+                               dparamscurrent=False, dtcurrent=True))
 
-        tl2 = phydmslib.treelikelihood.TreeLikelihood(self.tree,
-                self.alignment, self.model, underflowfreq=self.underflowfreq,
-                dparamscurrent=True, dtcurrent=False)
+        tl2 = (phydmslib.treelikelihood
+               .TreeLikelihood(self.tree,
+                               self.alignment,
+                               self.model,
+                               underflowfreq=self.underflowfreq,
+                               dparamscurrent=True,
+                               dtcurrent=False))
 
         self.assertTrue(numpy.allclose(tl1.loglik, tl2.loglik))
 
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(Exception):
             tl2.dtcurrent = True
 
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(Exception):
             tl1.dparamscurrent = True
 
-        with self.assertRaises(Exception) as context:
-            x = tl2.dloglik_dt
+        with self.assertRaises(Exception):
+            tl2.dloglik_dt
 
-        with self.assertRaises(Exception) as context:
-            x = tl1.dloglik
+        with self.assertRaises(Exception):
+            tl1.dloglik
 
         tl1.t = 1.1 * tl1.t
         tl2.t = 1.1 * tl2.t
@@ -204,8 +221,8 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
         self.assertTrue(numpy.allclose(tl1.dloglik_dt, tl2.dloglik_dt))
         self.assertTrue(numpy.allclose(tl1.loglik, tl2.loglik))
 
-        tl1.updateParams({'kappa':3.15})
-        tl2.updateParams({'kappa':3.15})
+        tl1.updateParams({'kappa': 3.15})
+        tl2.updateParams({'kappa': 3.15})
         tl2.dtcurrent = False
         tl2.dparamscurrent = True
         tl1.dtcurrent = False
@@ -219,7 +236,7 @@ class test_BrLenDerivatives_ExpCM_empirical_phi(test_BrLenDerivatives_ExpCM):
     MODEL = phydmslib.models.ExpCM_empirical_phi
 
 
-class test_BrLenDerivativs_ExpCM_empirical_phi_divpressure(test_BrLenDerivatives_ExpCM):
+class test_BrLenDerivativs_ExpCM_emp_phi_divpress(test_BrLenDerivatives_ExpCM):
     MODEL = phydmslib.models.ExpCM_empirical_phi_divpressure
 
 

--- a/tests/test_brlenderivatives.py
+++ b/tests/test_brlenderivatives.py
@@ -63,7 +63,7 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
         prefs = []
         minpref = 0.02
         g = numpy.random.dirichlet([10] * N_NT)
-        for r in range(self.nsites):
+        for _r in range(self.nsites):
             rprefs = numpy.random.dirichlet([0.5] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
@@ -167,12 +167,14 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
                               dtcurrent=True))
 
         def func(t, n):
+            """Evaluate function."""
             tx = tl.t
             tx[n] = t[0]
             tl.t = tx
             return tl.loglik
 
         def dfunc(t, n):
+            """Take derviative."""
             tx = tl.t
             tx[n] = t[0]
             tl.t = tx
@@ -233,30 +235,42 @@ class test_BrLenDerivatives_ExpCM(unittest.TestCase):
 
 
 class test_BrLenDerivatives_ExpCM_empirical_phi(test_BrLenDerivatives_ExpCM):
+    """Test branch length derv for ExpCM with empirical phi."""
+
     MODEL = phydmslib.models.ExpCM_empirical_phi
 
 
 class test_BrLenDerivativs_ExpCM_emp_phi_divpress(test_BrLenDerivatives_ExpCM):
+    """Test branch length derv for ExpCM with empirical phi & div pressure."""
+
     MODEL = phydmslib.models.ExpCM_empirical_phi_divpressure
 
 
 class test_BrLenDerivatives_YNGKP_M0(test_BrLenDerivatives_ExpCM):
+    """Test branch length derv for YNGKP M0."""
+
     MODEL = phydmslib.models.YNGKP_M0
 
 
 class test_BrLenDerivatives_YNGKP_M5(test_BrLenDerivatives_ExpCM):
+    """Test branch length derv for YNGKP M5."""
+
     MODEL = phydmslib.models.YNGKP_M0
     DISTRIBUTIONMODEL = phydmslib.models.GammaDistributedOmegaModel
 
 
 class test_BrLenDerivatives_ExpCM_gamma_omega(
         test_BrLenDerivatives_ExpCM):
+    """Test branch length derv for ExpCM with gamma omega."""
+
     MODEL = phydmslib.models.ExpCM
     DISTRIBUTIONMODEL = phydmslib.models.GammaDistributedOmegaModel
 
 
 class test_BrLenDerivatives_ExpCM_empirical_phi_gamma_omega(
         test_BrLenDerivatives_ExpCM):
+    """Test branch length derv for ExpCM with empirical phi & Gamma omega."""
+
     MODEL = phydmslib.models.ExpCM_empirical_phi
     DISTRIBUTIONMODEL = phydmslib.models.GammaDistributedOmegaModel
 

--- a/tests/test_brlenoptimize.py
+++ b/tests/test_brlenoptimize.py
@@ -4,18 +4,15 @@ Written by Jesse Bloom.
 """
 
 import os
-import sys
-import re
-import math
 import unittest
 import random
-import copy
 import Bio.Phylo
 import phydmslib.models
 import phydmslib.treelikelihood
 import phydmslib.simulate
-from phydmslib.constants import *
+from phydmslib.constants import AA_TO_INDEX, N_AA
 import pyvolve
+import numpy
 
 
 class test_BrLenOptimize_ExpCM(unittest.TestCase):
@@ -45,7 +42,6 @@ class test_BrLenOptimize_ExpCM(unittest.TestCase):
         self.nsites = 50
         prefs = []
         minpref = 0.02
-        g = numpy.random.dirichlet([5] * N_NT)
         for r in range(self.nsites):
             rprefs = numpy.random.dirichlet([0.5] * N_AA)
             rprefs[rprefs < minpref] = minpref
@@ -85,13 +81,19 @@ class test_BrLenOptimize_ExpCM(unittest.TestCase):
 
     def test_Optimize(self):
         """Tests optimization of branch lengths."""
-        tl = phydmslib.treelikelihood.TreeLikelihood(self.tree,
-                self.alignment, self.model, underflowfreq=self.underflowfreq)
-        maxresult = tl.maximizeLikelihood(optimize_brlen=True)
+        tl = (phydmslib.treelikelihood
+              .TreeLikelihood(self.tree,
+                              self.alignment,
+                              self.model,
+                              underflowfreq=self.underflowfreq))
+        tl.maximizeLikelihood(optimize_brlen=True)
 
-        tl2 = phydmslib.treelikelihood.TreeLikelihood(self.tree,
-                self.alignment, self.model, underflowfreq=self.underflowfreq)
-        maxresult = tl.maximizeLikelihood(optimize_brlen=False)
+        tl2 = (phydmslib.treelikelihood
+               .TreeLikelihood(self.tree,
+                               self.alignment,
+                               self.model,
+                               underflowfreq=self.underflowfreq))
+        tl.maximizeLikelihood(optimize_brlen=False)
 
         self.assertTrue(tl.loglik > tl2.loglik)
 

--- a/tests/test_brlenoptimize.py
+++ b/tests/test_brlenoptimize.py
@@ -42,7 +42,7 @@ class test_BrLenOptimize_ExpCM(unittest.TestCase):
         self.nsites = 50
         prefs = []
         minpref = 0.02
-        for r in range(self.nsites):
+        for _r in range(self.nsites):
             rprefs = numpy.random.dirichlet([0.5] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
@@ -100,6 +100,8 @@ class test_BrLenOptimize_ExpCM(unittest.TestCase):
 
 class test_BrLenOptimize_ExpCM_gamma_omega(
         test_BrLenOptimize_ExpCM):
+    """Test ExpCM with gamma omega."""
+
     MODEL = phydmslib.models.ExpCM
     DISTRIBUTIONMODEL = phydmslib.models.GammaDistributedOmegaModel
 

--- a/tests/test_diffprefsbysite.py
+++ b/tests/test_diffprefsbysite.py
@@ -22,6 +22,7 @@ matplotlib.use('pdf')
 
 class test_DiffPrefsBySiteExpCM(unittest.TestCase):
     """Tests ``--diffprefsbysite`` to ``phydms`` for `ExpCM`."""
+
     gammaomega_arg = []
 
     def setUp(self):
@@ -40,7 +41,7 @@ class test_DiffPrefsBySiteExpCM(unittest.TestCase):
         aas = [INDEX_TO_AA[a] for a in range(N_AA)]
         self.shuffledsites = random.sample(sorted(prefs.keys()), 10)
         self.targetaas = {r: random.choice(aas) for r in self.shuffledsites}
-        prefs = [prefs[r] for r in sorted(list(prefs.keys()))]
+        prefs = [prefs[r] for r in sorted(prefs.keys())]
         hipref = 0.9
         lowpref = (1.0 - hipref) / (N_AA - 1)
         for r in self.shuffledsites:

--- a/tests/test_diffprefsbysite.py
+++ b/tests/test_diffprefsbysite.py
@@ -25,6 +25,7 @@ class test_DiffPrefsBySiteExpCM(unittest.TestCase):
     gammaomega_arg = []
 
     def setUp(self):
+        """Set up test."""
         random.seed(1)
         numpy.random.seed(1)
         self.tree = os.path.abspath(os.path.join(os.path.dirname(__file__),
@@ -38,8 +39,7 @@ class test_DiffPrefsBySiteExpCM(unittest.TestCase):
         prefs = phydmslib.file_io.readPrefs(self.prefs, minpref=0.005)
         aas = [INDEX_TO_AA[a] for a in range(N_AA)]
         self.shuffledsites = random.sample(sorted(prefs.keys()), 10)
-        self.targetaas = dict([(r, random.choice(aas)) for r in
-                               self.shuffledsites])
+        self.targetaas = {r: random.choice(aas) for r in self.shuffledsites}
         prefs = [prefs[r] for r in sorted(list(prefs.keys()))]
         hipref = 0.9
         lowpref = (1.0 - hipref) / (N_AA - 1)

--- a/tests/test_diffprefsbysite.py
+++ b/tests/test_diffprefsbysite.py
@@ -4,7 +4,6 @@ Written by Jesse Bloom.
 """
 
 import os
-import shutil
 import unittest
 import subprocess
 import random
@@ -13,11 +12,12 @@ import scipy.stats
 import phydmslib.file_io
 import phydmslib.models
 import phydmslib.simulate
-from phydmslib.constants import *
+from phydmslib.constants import INDEX_TO_AA, N_AA, AA_TO_INDEX
 import matplotlib
-matplotlib.use('pdf')
 import matplotlib.pyplot as plt
 import pyvolve
+import numpy
+matplotlib.use('pdf')
 
 
 class test_DiffPrefsBySiteExpCM(unittest.TestCase):
@@ -28,17 +28,18 @@ class test_DiffPrefsBySiteExpCM(unittest.TestCase):
         random.seed(1)
         numpy.random.seed(1)
         self.tree = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './NP_data/NP_tree.newick'))
-        self.alignment = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './NP_data/NP_alignment.fasta'))
+                                    './NP_data/NP_tree.newick'))
+        self.align = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                     './NP_data/NP_alignment.fasta'))
         self.prefs = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './NP_data/NP_prefs.tsv'))
-        self.nsites = len(phydmslib.file_io.ReadCodonAlignment(self.alignment,
-                True)[0][1]) // 3
+                                     './NP_data/NP_prefs.tsv'))
+        self.nsites = len(phydmslib.file_io
+                          .ReadCodonAlignment(self.align, True)[0][1]) // 3
         prefs = phydmslib.file_io.readPrefs(self.prefs, minpref=0.005)
         aas = [INDEX_TO_AA[a] for a in range(N_AA)]
         self.shuffledsites = random.sample(sorted(prefs.keys()), 10)
-        self.targetaas = dict([(r, random.choice(aas)) for r in self.shuffledsites])
+        self.targetaas = dict([(r, random.choice(aas)) for r in
+                               self.shuffledsites])
         prefs = [prefs[r] for r in sorted(list(prefs.keys()))]
         hipref = 0.9
         lowpref = (1.0 - hipref) / (N_AA - 1)
@@ -48,7 +49,7 @@ class test_DiffPrefsBySiteExpCM(unittest.TestCase):
             prefs[r - 1] = dict(zip(aas, rprefs))
         self.model = phydmslib.models.ExpCM(prefs, beta=1.5)
         self.outdir = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './diffprefsbysite_test_results/'))
+                                      './diffprefsbysite_test_results/'))
         if self.gammaomega_arg:
             self.modelname = 'ExpCM_gammaomega'
         else:
@@ -64,7 +65,7 @@ class test_DiffPrefsBySiteExpCM(unittest.TestCase):
         numpy.random.seed(1)
         partitions = phydmslib.simulate.pyvolvePartitions(self.model)
         evolver = pyvolve.Evolver(partitions=partitions,
-                tree=pyvolve.read_tree(file=self.tree))
+                                  tree=pyvolve.read_tree(file=self.tree))
         simulateprefix = os.path.join(self.outdir, self.modelname)
         simulatedalignment = simulateprefix + '_simulatedalignment.fasta'
         info = simulateprefix + '_temp_info.txt'
@@ -76,14 +77,16 @@ class test_DiffPrefsBySiteExpCM(unittest.TestCase):
             outprefix = simulateprefix + '_fitprefsmethod{0}'.format(
                     fitprefsmethod)
             subprocess.check_call(['phydms', simulatedalignment, self.tree,
-                    self.modelarg, outprefix, '--diffprefsbysite',
-                    '--brlen', 'scale', '--ncpus', '-1', '--diffprefsprior',
-                    'invquadratic,150,0.5'] + self.gammaomega_arg +
-                    ['--fitprefsmethod', fitprefsmethod])
+                                   self.modelarg, outprefix,
+                                   '--diffprefsbysite', '--brlen', 'scale',
+                                   '--ncpus', '-1', '--diffprefsprior',
+                                   'invquadratic,150,0.5'] +
+                                  self.gammaomega_arg +
+                                  ['--fitprefsmethod', fitprefsmethod])
             diffprefsbysitefile = outprefix + '_diffprefsbysite.txt'
             aas = ['dpi_{0}'.format(INDEX_TO_AA[a]) for a in range(N_AA)]
             diffprefs = pandas.read_csv(diffprefsbysitefile, sep='\t',
-                    comment='#')
+                                        comment='#')
             diffprefs['total'] = diffprefs[aas].abs().sum(axis=1)
             for (site, a) in self.targetaas.items():
                 siteentry = diffprefs[diffprefs['site'] == site]
@@ -94,7 +97,7 @@ class test_DiffPrefsBySiteExpCM(unittest.TestCase):
 
         for (i, (method1, prefs1)) in enumerate(sorted(prefsbymethod.items())):
             total1 = prefs1['total'].values
-            for (method2, prefs2) in sorted(prefsbymethod.items())[i + 1 : ]:
+            for (method2, prefs2) in sorted(prefsbymethod.items())[i + 1:]:
                 total2 = prefs2['total'].values
                 (r, p) = scipy.stats.pearsonr(total1, total2)
                 plt.scatter(total1, total2)
@@ -104,12 +107,12 @@ class test_DiffPrefsBySiteExpCM(unittest.TestCase):
                         method1, method2))
                 plt.savefig(plotfile)
                 self.assertTrue(r > 0.98, "Low correlation between "
-                        "fitprefsmethods: {0}\nSee {1}".format(r, plotfile))
+                                "fitprefsmethods: {0}\nSee {1}"
+                                .format(r, plotfile))
 
         for f in ["custom_matrix_frequencies.txt"]:
             if os.path.isfile(f):
                 os.remove(f)
-
 
 
 if __name__ == '__main__':

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -1,6 +1,7 @@
 """Runs doctests.
 
-Written by Jesse Bloom."""
+Written by Jesse Bloom.
+"""
 
 
 import sys
@@ -12,12 +13,12 @@ import phydmslib
 
 def main():
     """Run the tests."""
-
     sys.stderr.write('Running tests...\n')
     failurestrings = []
 
     # test all modules with doctest
-    for (importer, modname, ispkg) in pkgutil.iter_modules(phydmslib.__path__):
+    for (_importer, modname,
+         ispkg) in pkgutil.iter_modules(phydmslib.__path__):
         if (not ispkg) and modname[0] != '_':
             sys.stderr.write('\nTesting %s with doctest... ' % modname)
             module = __import__('phydmslib.%s' % modname, None, None,
@@ -31,7 +32,7 @@ def main():
                                  .format(result.testsRun))
             else:
                 sys.stderr.write('test FAILED!\n')
-                for (testcase, failstring) in result.failures:
+                for (_testcase, failstring) in result.failures:
                     failurestrings.append(failstring)
 
     # print summary of failures

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -3,12 +3,9 @@
 Written by Jesse Bloom."""
 
 
-import os
 import sys
-import glob
 import doctest
 import unittest
-import doctest
 import pkgutil
 import phydmslib
 
@@ -23,13 +20,15 @@ def main():
     for (importer, modname, ispkg) in pkgutil.iter_modules(phydmslib.__path__):
         if (not ispkg) and modname[0] != '_':
             sys.stderr.write('\nTesting %s with doctest... ' % modname)
-            module = __import__('phydmslib.%s' % modname, None, None, modname.split('.'))
+            module = __import__('phydmslib.%s' % modname, None, None,
+                                modname.split('.'))
             suite = doctest.DocTestSuite(module)
             del module
             result = unittest.TestResult()
             suite.run(result)
             if result.wasSuccessful():
-                sys.stderr.write('all %d tests were successful.\n' % result.testsRun)
+                sys.stderr.write('all {0} tests were successful.\n'
+                                 .format(result.testsRun))
             else:
                 sys.stderr.write('test FAILED!\n')
                 for (testcase, failstring) in result.failures:
@@ -37,12 +36,15 @@ def main():
 
     # print summary of failures
     if not failurestrings:
-        sys.stderr.write('\nTesting complete. All tests were passed successfully.\n')
+        sys.stderr.write('\nTesting complete. '
+                         'All tests were passed successfully.\n')
     else:
-        sys.stderr.write('\nTesting complete. Failed on the following tests:\n')
+        sys.stderr.write('\nTesting complete. '
+                         'Failed on the following tests:\n')
         for failstring in failurestrings:
-            sys.stderr.write('\n*****************\n%s\n\n****************\n' % failstring)
+            sys.stderr.write('\n*****************\n{0}\n\n****************\n'
+                             .format(failstring))
 
 
 if __name__ == '__main__':
-    main() # run the program
+    main()  # run the program

--- a/tests/test_expcm.py
+++ b/tests/test_expcm.py
@@ -12,12 +12,14 @@ import numpy
 import scipy.linalg
 import scipy.optimize
 import sympy
-from phydmslib.constants import *
+from phydmslib.constants import (N_CODON, NT_TO_INDEX, CODON_TO_AA,
+                                 INDEX_TO_CODON, INDEX_TO_AA, CODON_SINGLEMUT,
+                                 CODON_TRANSITION, CODON_NONSYN, N_NT,
+                                 AA_TO_INDEX, N_AA)
 import phydmslib.models
 
 
 class testExpCM(unittest.TestCase):
-
     def test_ExpCM(self):
         """Initialize `ExpCM`, test values, update, test again."""
 
@@ -38,23 +40,35 @@ class testExpCM(unittest.TestCase):
         omega = 0.7
         kappa = 2.5
         beta = 1.9
-        self.expcm = phydmslib.models.ExpCM(self.prefs, phi=phi, omega=omega,
-                kappa=kappa, beta=beta)
+        self.expcm = phydmslib.models.ExpCM(
+            self.prefs, phi=phi, omega=omega, kappa=kappa, beta=beta
+        )
         self.assertTrue(numpy.allclose(phi, self.expcm.phi))
         self.assertTrue(numpy.allclose(omega, self.expcm.omega))
         self.assertTrue(numpy.allclose(kappa, self.expcm.kappa))
         self.assertTrue(numpy.allclose(beta, self.expcm.beta))
 
-        self.assertTrue(numpy.allclose(numpy.repeat(1.0, self.nsites), self.expcm.stationarystate.sum(axis=1)))
+        self.assertTrue(
+            numpy.allclose(
+                numpy.repeat(1.0, self.nsites),
+                self.expcm.stationarystate.sum(axis=1)
+            )
+        )
 
         # now check ExpCM attributes / derivates, updating several times
         for update in range(2):
-            self.params = {'omega':random.uniform(*self.expcm.PARAMLIMITS['omega']),
-                      'kappa':random.uniform(*self.expcm.PARAMLIMITS['kappa']),
-                      'beta':random.uniform(0.5, 2.5),
-                      'eta':numpy.array([random.uniform(*self.expcm.PARAMLIMITS['eta']) for i in range(N_NT - 1)]),
-                      'mu':random.uniform(0.05, 3.0),
-                     }
+            self.params = {
+                "omega": random.uniform(*self.expcm.PARAMLIMITS["omega"]),
+                "kappa": random.uniform(*self.expcm.PARAMLIMITS["kappa"]),
+                "beta": random.uniform(0.5, 2.5),
+                "eta": numpy.array(
+                    [
+                        random.uniform(*self.expcm.PARAMLIMITS["eta"])
+                        for i in range(N_NT - 1)
+                    ]
+                ),
+                "mu": random.uniform(0.05, 3.0),
+            }
             self.expcm.updateParams(self.params)
             self.check_ExpCM_attributes()
             self.check_ExpCM_derivatives()
@@ -67,10 +81,10 @@ class testExpCM(unittest.TestCase):
         # make sure Prxy has rows summing to zero
         self.assertFalse(numpy.isnan(self.expcm.Prxy).any())
         self.assertFalse(numpy.isinf(self.expcm.Prxy).any())
-        diag = numpy.eye(N_CODON, dtype='bool')
+        diag = numpy.eye(N_CODON, dtype="bool")
         for r in range(self.nsites):
             self.assertTrue(numpy.allclose(0, numpy.sum(self.expcm.Prxy[r],
-                    axis=1)))
+                            axis=1)))
             self.assertTrue(numpy.allclose(0, self.expcm.Prxy[r].sum()))
             self.assertTrue((self.expcm.Prxy[r][diag] <= 0).all())
             self.assertTrue((self.expcm.Prxy[r][~diag] >= 0).all())
@@ -82,24 +96,31 @@ class testExpCM(unittest.TestCase):
 
         # prx is eigenvector or Prxy for the same r, but not different r
         for r in range(self.nsites):
-            self.assertTrue(numpy.allclose(0, numpy.dot(self.expcm.prx[r],
-                    self.expcm.Prxy[r])))
+            self.assertTrue(
+                numpy.allclose(0, numpy.dot(self.expcm.prx[r],
+                               self.expcm.Prxy[r])))
             if r > 0:
-                self.assertFalse(numpy.allclose(0, numpy.dot(self.expcm.prx[r],
-                        self.expcm.Prxy[r - 1])))
+                self.assertFalse(
+                    numpy.allclose(
+                        0, numpy.dot(self.expcm.prx[r], self.expcm.Prxy[r - 1])
+                    )
+                )
 
     def check_ExpCM_derivatives(self):
-        """Use `sympy` to check values and derivatives of `ExpCM` attributes."""
-        (Prxy, Qxy, phiw, beta, omega, eta0, eta1, eta2, kappa) = sympy.symbols(
-                'Prxy, Qxy, phiw, beta, omega, eta0, eta1, eta2, kappa')
+        """Use `sympy` to check values & derivatives of `ExpCM` attributes."""
+        (Prxy, Qxy, phiw, beta, omega,
+         eta0, eta1, eta2, kappa) = sympy.symbols("Prxy, Qxy, phiw, beta, "
+                                                  "omega, eta0, eta1, eta2, "
+                                                  "kappa")
 
-        values = {'beta':self.params['beta'],
-                  'omega':self.params['omega'],
-                  'kappa':self.params['kappa'],
-                  'eta0':self.params['eta'][0],
-                  'eta1':self.params['eta'][1],
-                  'eta2':self.params['eta'][2],
-                  }
+        values = {
+            "beta": self.params["beta"],
+            "omega": self.params["omega"],
+            "kappa": self.params["kappa"],
+            "eta0": self.params["eta"][0],
+            "eta1": self.params["eta"][1],
+            "eta2": self.params["eta"][2],
+        }
 
         # check Prxy
         for r in range(self.nsites):
@@ -110,8 +131,15 @@ class testExpCM(unittest.TestCase):
                     if not CODON_SINGLEMUT[x][y]:
                         Prxy = 0
                     else:
-                        w = NT_TO_INDEX[[ynt for (xnt, ynt) in zip(INDEX_TO_CODON[x],
-                                INDEX_TO_CODON[y]) if xnt != ynt][0]]
+                        w = NT_TO_INDEX[
+                            [
+                                ynt
+                                for (xnt, ynt) in zip(
+                                    INDEX_TO_CODON[x], INDEX_TO_CODON[y]
+                                )
+                                if xnt != ynt
+                            ][0]
+                        ]
                         if w == 0:
                             phiw = 1 - eta0
                         elif w == 1:
@@ -122,46 +150,85 @@ class testExpCM(unittest.TestCase):
                             phiw = eta0 * eta1 * eta2
                         else:
                             raise ValueError("Invalid w")
-                        self.assertTrue(numpy.allclose(float(phiw.subs(values)),
-                                self.expcm.phi[w]))
+                        self.assertTrue(
+                            numpy.allclose(float(phiw.subs(values)),
+                                           self.expcm.phi[w])
+                        )
                         if CODON_TRANSITION[x][y]:
                             Qxy = kappa * phiw
                         else:
                             Qxy = phiw
-                        self.assertTrue(numpy.allclose(float(Qxy.subs(values)),
-                                self.expcm.Qxy[x][y]))
+                        self.assertTrue(
+                            numpy.allclose(
+                                float(Qxy.subs(values)), self.expcm.Qxy[x][y]
+                            )
+                        )
                         if CODON_NONSYN[x][y]:
                             if pirAx == pirAy:
                                 Prxy = Qxy * omega
                             else:
-                                Prxy = Qxy * omega * (-beta * numpy.log(pirAx / pirAy) / (1 - (pirAx / pirAy)**beta))
+                                Prxy = (
+                                    Qxy
+                                    * omega
+                                    * (
+                                        -beta
+                                        * numpy.log(pirAx / pirAy)
+                                        / (1 - (pirAx / pirAy) ** beta)
+                                    )
+                                )
                         else:
                             Prxy = Qxy
                     for (name, actual, expect) in [
-                            ('Prxy', self.expcm.Prxy[r][x][y], Prxy),
-                            ('dPrxy_dkappa', self.expcm.dPrxy['kappa'][r][x][y], sympy.diff(Prxy, kappa)),
-                            ('dPrxy_domega', self.expcm.dPrxy['omega'][r][x][y], sympy.diff(Prxy, omega)),
-                            ('dPrxy_dbeta', self.expcm.dPrxy['beta'][r][x][y], sympy.diff(Prxy, beta)),
-                            ('dPrxy_deta0', self.expcm.dPrxy['eta'][0][r][x][y], sympy.diff(Prxy, eta0)),
-                            ('dPrxy_deta1', self.expcm.dPrxy['eta'][1][r][x][y], sympy.diff(Prxy, eta1)),
-                            ('dPrxy_deta2', self.expcm.dPrxy['eta'][2][r][x][y], sympy.diff(Prxy, eta2)),
-                            ]:
+                        ("Prxy", self.expcm.Prxy[r][x][y], Prxy),
+                        (
+                            "dPrxy_dkappa",
+                            self.expcm.dPrxy["kappa"][r][x][y],
+                            sympy.diff(Prxy, kappa),
+                        ),
+                        (
+                            "dPrxy_domega",
+                            self.expcm.dPrxy["omega"][r][x][y],
+                            sympy.diff(Prxy, omega),
+                        ),
+                        (
+                            "dPrxy_dbeta",
+                            self.expcm.dPrxy["beta"][r][x][y],
+                            sympy.diff(Prxy, beta),
+                        ),
+                        (
+                            "dPrxy_deta0",
+                            self.expcm.dPrxy["eta"][0][r][x][y],
+                            sympy.diff(Prxy, eta0),
+                        ),
+                        (
+                            "dPrxy_deta1",
+                            self.expcm.dPrxy["eta"][1][r][x][y],
+                            sympy.diff(Prxy, eta1),
+                        ),
+                        (
+                            "dPrxy_deta2",
+                            self.expcm.dPrxy["eta"][2][r][x][y],
+                            sympy.diff(Prxy, eta2),
+                        ),
+                    ]:
                         if Prxy == 0:
                             expectval = 0
                         else:
                             expectval = float(expect.subs(values))
-                        self.assertTrue(numpy.allclose(actual, expectval, atol=1e-4),
-                                "{0}: {1} vs {2}".format(name, actual, expectval))
+                        self.assertTrue(
+                            numpy.allclose(actual, expectval, atol=1e-4),
+                            "{0}: {1} vs {2}".format(name, actual, expectval),
+                        )
 
         # check prx
-        qxs = [sympy.Symbol('qx{0}'.format(x)) for x in range(N_CODON)]
-        frxs = [sympy.Symbol('frx{0}'.format(x)) for x in range(N_CODON)]
-        prx = sympy.Symbol('prx')
-        phixs = [sympy.Symbol('phix{0}'.format(w)) for w in range(3)]
+        qxs = [sympy.Symbol("qx{0}".format(x)) for x in range(N_CODON)]
+        frxs = [sympy.Symbol("frx{0}".format(x)) for x in range(N_CODON)]
+        prx = sympy.Symbol("prx")
+        phixs = [sympy.Symbol("phix{0}".format(w)) for w in range(3)]
         for r in range(self.nsites):
             for x in range(N_CODON):
                 pirAx = self.prefs[r][INDEX_TO_AA[CODON_TO_AA[x]]]
-                frxs[x] = pirAx**beta
+                frxs[x] = pirAx ** beta
                 xcodon = INDEX_TO_CODON[x]
                 assert len(phixs) == len(xcodon)
                 for (w, xwnt) in enumerate(xcodon):
@@ -178,81 +245,124 @@ class testExpCM(unittest.TestCase):
                         raise ValueError("invalid xw")
                 qxs[x] = phixs[0] * phixs[1] * phixs[2]
             for x in range(N_CODON):
-                prx = frxs[x] * qxs[x] / sum(frx * qx for (frx, qx) in zip(frxs, qxs))
+                prx = frxs[x] * qxs[x] / sum(frx * qx for (frx, qx)
+                                             in zip(frxs, qxs))
                 for (name, actual, expect) in [
-                        ('prx', self.expcm.prx[r][x], prx),
-                        ('dprx_dbeta', self.expcm.dprx['beta'][r][x], sympy.diff(prx, beta)),
-                        ('dprx_deta0', self.expcm.dprx['eta'][0][r][x], sympy.diff(prx, eta0)),
-                        ('dprx_deta1', self.expcm.dprx['eta'][1][r][x], sympy.diff(prx, eta1)),
-                        ('dprx_deta2', self.expcm.dprx['eta'][2][r][x], sympy.diff(prx, eta2)),
-                        ]:
+                    ("prx", self.expcm.prx[r][x], prx),
+                    (
+                        "dprx_dbeta",
+                        self.expcm.dprx["beta"][r][x],
+                        sympy.diff(prx, beta),
+                    ),
+                    (
+                        "dprx_deta0",
+                        self.expcm.dprx["eta"][0][r][x],
+                        sympy.diff(prx, eta0),
+                    ),
+                    (
+                        "dprx_deta1",
+                        self.expcm.dprx["eta"][1][r][x],
+                        sympy.diff(prx, eta1),
+                    ),
+                    (
+                        "dprx_deta2",
+                        self.expcm.dprx["eta"][2][r][x],
+                        sympy.diff(prx, eta2),
+                    ),
+                ]:
                     expectval = float(expect.subs(values))
-                    self.assertTrue(numpy.allclose(actual, expectval, atol=1e-5),
-                            "{0}: {1} vs {2}".format(name, actual, expectval))
+                    self.assertTrue(
+                        numpy.allclose(actual, expectval, atol=1e-5),
+                        "{0}: {1} vs {2}".format(name, actual, expectval),
+                    )
 
     def check_ExpCM_matrix_exponentials(self):
         """Makes sure matrix exponentials of ExpCM are as expected."""
         for r in range(self.nsites):
             # fromdiag is recomputed Prxy after diagonalization
-            fromdiag = numpy.dot(self.expcm.A[r], numpy.dot(numpy.diag(
-                    self.expcm.D[r]), self.expcm.Ainv[r]))
-            self.assertTrue(numpy.allclose(self.expcm.Prxy[r], fromdiag,
-                    atol=1e-5), "Max diff {0}".format((self.expcm.Prxy[r] - fromdiag).max()))
+            fromdiag = numpy.dot(
+                self.expcm.A[r],
+                numpy.dot(numpy.diag(self.expcm.D[r]), self.expcm.Ainv[r]),
+            )
+            self.assertTrue(
+                numpy.allclose(self.expcm.Prxy[r], fromdiag, atol=1e-5),
+                "Max diff {0}".format((self.expcm.Prxy[r] - fromdiag).max()),
+            )
 
             for t in [0.02, 0.2, 0.5]:
-                direct = scipy.linalg.expm(self.expcm.Prxy[r] * self.expcm.mu * t)
-                self.assertTrue(numpy.allclose(self.expcm.M(t)[r], direct, atol=1e-6),
-                        "Max diff {0}".format((self.expcm.M(t)[r] - direct).max()))
+                direct = scipy.linalg.expm(self.expcm.Prxy[r] *
+                                           self.expcm.mu * t)
+                self.assertTrue(
+                    numpy.allclose(self.expcm.M(t)[r], direct, atol=1e-6),
+                    "Max diff {0}".format((self.expcm.M(t)[r] - direct).max()),
+                )
+
         # check derivatives of M calculated by dM
         # implementation looks a bit complex because `check_grad` function
         # can only be used for single values at a time, so have to loop
         # over r, x, y and so hash values to make faster
         def funcM(paramvalue, paramname, t, expcm, r, x, y, storedvalues):
             """Gets `M(t)[r][x][y]`."""
-            key = ('M', tuple(paramvalue), paramname, t)
+            key = ("M", tuple(paramvalue), paramname, t)
             if key not in storedvalues:
                 if len(paramvalue) == 1:
-                    expcm.updateParams({paramname:paramvalue[0]})
+                    expcm.updateParams({paramname: paramvalue[0]})
                 else:
-                    expcm.updateParams({paramname:paramvalue})
+                    expcm.updateParams({paramname: paramvalue})
                 storedvalues[key] = expcm.M(t)
             if len(storedvalues[key].shape) == 3:
                 return storedvalues[key][r][x][y]
             else:
-                return storedvalues[key][:,r,x,y]
+                return storedvalues[key][:, r, x, y]
+
         def funcdM(paramvalue, paramname, t, expcm, r, x, y, storedvalues):
             """Gets `dM`."""
-            key = ('dM', tuple(paramvalue), paramname, t)
+            key = ("dM", tuple(paramvalue), paramname, t)
             if key not in storedvalues:
                 if len(paramvalue) == 1:
-                    expcm.updateParams({paramname:paramvalue[0]})
+                    expcm.updateParams({paramname: paramvalue[0]})
                 else:
-                    expcm.updateParams({paramname:paramvalue})
+                    expcm.updateParams({paramname: paramvalue})
                 storedvalues[key] = expcm.dM(t, paramname, expcm.M(t))
             if len(storedvalues[key].shape) == 3:
                 return storedvalues[key][r][x][y]
             else:
-                return storedvalues[key][:,r,x,y]
+                return storedvalues[key][:, r, x, y]
+
         for (pname, pvalue) in sorted(self.params.items()):
-            storedvalues = {} # used to hash values
+            storedvalues = {}  # used to hash values
             if isinstance(pvalue, float):
                 pvalue = [pvalue]
             for t in [0.01, 0.2, 0.5]:
                 for r in range(self.expcm.nsites):
                     for x in range(N_CODON):
                         for y in range(N_CODON):
-                            diff = scipy.optimize.check_grad(funcM, funcdM, pvalue,
-                                    pname, t, self.expcm, r, x, y, storedvalues)
-                            self.assertTrue(diff < 2e-3, ("diff {0} for {1}:" +
-                                " r = {2}, x = {3}, y = {4}, beta = {5} " +
-                                "pirAx = {6}, pirAy = {7}, t = {8}, mu = {9}"
-                                ).format(diff, pname, r, x, y,
-                                self.params['beta'], self.expcm.pi_codon[r][x],
-                                self.expcm.pi_codon[r][y], t, self.expcm.mu))
-                self.expcm.updateParams(self.params) # back to original value
+                            diff = scipy.optimize.check_grad(
+                                funcM,
+                                funcdM,
+                                pvalue,
+                                pname,
+                                t,
+                                self.expcm,
+                                r,
+                                x,
+                                y,
+                                storedvalues,
+                            )
+                            self.assertTrue(
+                                diff < 2e-3,
+                                ("diff {0} for {1}: r = {2}, x = {3}, "
+                                 "y = {4}, beta = {5} pirAx = {6}, "
+                                 "pirAy = {7}, t = {8}, mu = {9}"
+                                 .format(diff, pname, r, x, y,
+                                         self.params["beta"],
+                                         self.expcm.pi_codon[r][x],
+                                         self.expcm.pi_codon[r][y],
+                                         t,
+                                         self.expcm.mu)))
+                self.expcm.updateParams(self.params)  # back to original value
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     runner = unittest.TextTestRunner()
     unittest.main(testRunner=runner)

--- a/tests/test_expcm.py
+++ b/tests/test_expcm.py
@@ -53,9 +53,7 @@ class testExpCM(unittest.TestCase):
         self.assertTrue(
             numpy.allclose(
                 numpy.repeat(1.0, self.nsites),
-                self.expcm.stationarystate.sum(axis=1)
-            )
-        )
+                self.expcm.stationarystate.sum(axis=1)))
 
         # now check ExpCM attributes / derivates, updating several times
         for _update in range(2):
@@ -64,13 +62,9 @@ class testExpCM(unittest.TestCase):
                 "kappa": random.uniform(*self.expcm.PARAMLIMITS["kappa"]),
                 "beta": random.uniform(0.5, 2.5),
                 "eta": numpy.array(
-                    [
-                        random.uniform(*self.expcm.PARAMLIMITS["eta"])
-                        for i in range(N_NT - 1)
-                    ]
-                ),
-                "mu": random.uniform(0.05, 3.0),
-            }
+                    [random.uniform(*self.expcm.PARAMLIMITS["eta"])
+                     for i in range(N_NT - 1)]),
+                "mu": random.uniform(0.05, 3.0)}
             self.expcm.updateParams(self.params)
             self.check_ExpCM_attributes()
             self.check_ExpCM_derivatives()
@@ -105,8 +99,7 @@ class testExpCM(unittest.TestCase):
                 self.assertFalse(
                     numpy.allclose(
                         0, numpy.dot(self.expcm.prx[r], self.expcm.Prxy[r - 1])
-                    )
-                )
+                    ))
 
     def check_ExpCM_derivatives(self):
         """Use `sympy` to check values & derivatives of `ExpCM` attributes."""
@@ -115,14 +108,12 @@ class testExpCM(unittest.TestCase):
                                                   "omega, eta0, eta1, eta2, "
                                                   "kappa")
 
-        values = {
-            "beta": self.params["beta"],
-            "omega": self.params["omega"],
-            "kappa": self.params["kappa"],
-            "eta0": self.params["eta"][0],
-            "eta1": self.params["eta"][1],
-            "eta2": self.params["eta"][2],
-        }
+        values = {"beta": self.params["beta"],
+                  "omega": self.params["omega"],
+                  "kappa": self.params["kappa"],
+                  "eta0": self.params["eta"][0],
+                  "eta1": self.params["eta"][1],
+                  "eta2": self.params["eta"][2]}
 
         # check Prxy
         for r in range(self.nsites):
@@ -134,14 +125,9 @@ class testExpCM(unittest.TestCase):
                         Prxy = 0
                     else:
                         w = NT_TO_INDEX[
-                            [
-                                ynt
-                                for (xnt, ynt) in zip(
-                                    INDEX_TO_CODON[x], INDEX_TO_CODON[y]
-                                )
-                                if xnt != ynt
-                            ][0]
-                        ]
+                            [ynt for (xnt, ynt) in zip(INDEX_TO_CODON[x],
+                                                       INDEX_TO_CODON[y])
+                             if xnt != ynt][0]]
                         if w == 0:
                             phiw = 1 - eta0
                         elif w == 1:
@@ -154,73 +140,45 @@ class testExpCM(unittest.TestCase):
                             raise ValueError("Invalid w")
                         self.assertTrue(
                             numpy.allclose(float(phiw.subs(values)),
-                                           self.expcm.phi[w])
-                        )
+                                           self.expcm.phi[w]))
                         if CODON_TRANSITION[x][y]:
                             Qxy = kappa * phiw
                         else:
                             Qxy = phiw
                         self.assertTrue(
                             numpy.allclose(
-                                float(Qxy.subs(values)), self.expcm.Qxy[x][y]
-                            )
-                        )
+                                float(Qxy.subs(values)), self.expcm.Qxy[x][y]))
                         if CODON_NONSYN[x][y]:
                             if pirAx == pirAy:
                                 Prxy = Qxy * omega
                             else:
-                                Prxy = (
-                                    Qxy
-                                    * omega
-                                    * (
-                                        -beta
-                                        * numpy.log(pirAx / pirAy)
-                                        / (1 - (pirAx / pirAy) ** beta)
-                                    )
-                                )
+                                Prxy = (Qxy * omega * (
+                                        -beta * numpy.log(pirAx / pirAy)
+                                        / (1 - (pirAx / pirAy) ** beta)))
                         else:
                             Prxy = Qxy
                     for (name, actual, expect) in [
                         ("Prxy", self.expcm.Prxy[r][x][y], Prxy),
-                        (
-                            "dPrxy_dkappa",
-                            self.expcm.dPrxy["kappa"][r][x][y],
-                            sympy.diff(Prxy, kappa),
-                        ),
-                        (
-                            "dPrxy_domega",
-                            self.expcm.dPrxy["omega"][r][x][y],
-                            sympy.diff(Prxy, omega),
-                        ),
-                        (
-                            "dPrxy_dbeta",
-                            self.expcm.dPrxy["beta"][r][x][y],
-                            sympy.diff(Prxy, beta),
-                        ),
-                        (
-                            "dPrxy_deta0",
-                            self.expcm.dPrxy["eta"][0][r][x][y],
-                            sympy.diff(Prxy, eta0),
-                        ),
-                        (
-                            "dPrxy_deta1",
-                            self.expcm.dPrxy["eta"][1][r][x][y],
-                            sympy.diff(Prxy, eta1),
-                        ),
-                        (
-                            "dPrxy_deta2",
-                            self.expcm.dPrxy["eta"][2][r][x][y],
-                            sympy.diff(Prxy, eta2),
-                        ),
-                    ]:
+                        ("dPrxy_dkappa",
+                         self.expcm.dPrxy["kappa"][r][x][y],
+                         sympy.diff(Prxy, kappa)),
+                        ("dPrxy_domega", self.expcm.dPrxy["omega"][r][x][y],
+                         sympy.diff(Prxy, omega)),
+                        ("dPrxy_dbeta", self.expcm.dPrxy["beta"][r][x][y],
+                         sympy.diff(Prxy, beta)),
+                        ("dPrxy_deta0", self.expcm.dPrxy["eta"][0][r][x][y],
+                         sympy.diff(Prxy, eta0)),
+                        ("dPrxy_deta1", self.expcm.dPrxy["eta"][1][r][x][y],
+                         sympy.diff(Prxy, eta1)),
+                        ("dPrxy_deta2", self.expcm.dPrxy["eta"][2][r][x][y],
+                         sympy.diff(Prxy, eta2))]:
                         if Prxy == 0:
                             expectval = 0
                         else:
                             expectval = float(expect.subs(values))
                         self.assertTrue(
                             numpy.allclose(actual, expectval, atol=1e-4),
-                            "{0}: {1} vs {2}".format(name, actual, expectval),
-                        )
+                            "{0}: {1} vs {2}".format(name, actual, expectval))
 
         # check prx
         qxs = [sympy.Symbol("qx{0}".format(x)) for x in range(N_CODON)]
@@ -251,32 +209,19 @@ class testExpCM(unittest.TestCase):
                                              in zip(frxs, qxs))
                 for (name, actual, expect) in [
                     ("prx", self.expcm.prx[r][x], prx),
-                    (
-                        "dprx_dbeta",
-                        self.expcm.dprx["beta"][r][x],
-                        sympy.diff(prx, beta),
-                    ),
-                    (
-                        "dprx_deta0",
-                        self.expcm.dprx["eta"][0][r][x],
-                        sympy.diff(prx, eta0),
-                    ),
-                    (
-                        "dprx_deta1",
-                        self.expcm.dprx["eta"][1][r][x],
-                        sympy.diff(prx, eta1),
-                    ),
-                    (
-                        "dprx_deta2",
-                        self.expcm.dprx["eta"][2][r][x],
-                        sympy.diff(prx, eta2),
-                    ),
-                ]:
+                    ("dprx_dbeta", self.expcm.dprx["beta"][r][x],
+                     sympy.diff(prx, beta)),
+                    ("dprx_deta0",
+                     self.expcm.dprx["eta"][0][r][x],
+                     sympy.diff(prx, eta0)),
+                    ("dprx_deta1", self.expcm.dprx["eta"][1][r][x],
+                     sympy.diff(prx, eta1)),
+                    ("dprx_deta2", self.expcm.dprx["eta"][2][r][x],
+                     sympy.diff(prx, eta2))]:
                     expectval = float(expect.subs(values))
                     self.assertTrue(
                         numpy.allclose(actual, expectval, atol=1e-5),
-                        "{0}: {1} vs {2}".format(name, actual, expectval),
-                    )
+                        "{0}: {1} vs {2}".format(name, actual, expectval))
 
     def check_ExpCM_matrix_exponentials(self):
         """Makes sure matrix exponentials of ExpCM are as expected."""
@@ -284,20 +229,17 @@ class testExpCM(unittest.TestCase):
             # fromdiag is recomputed Prxy after diagonalization
             fromdiag = numpy.dot(
                 self.expcm.A[r],
-                numpy.dot(numpy.diag(self.expcm.D[r]), self.expcm.Ainv[r]),
-            )
+                numpy.dot(numpy.diag(self.expcm.D[r]), self.expcm.Ainv[r]))
             self.assertTrue(
                 numpy.allclose(self.expcm.Prxy[r], fromdiag, atol=1e-5),
-                "Max diff {0}".format((self.expcm.Prxy[r] - fromdiag).max()),
-            )
+                "Max diff {0}".format((self.expcm.Prxy[r] - fromdiag).max()))
 
             for t in [0.02, 0.2, 0.5]:
                 direct = scipy.linalg.expm(self.expcm.Prxy[r] *
                                            self.expcm.mu * t)
                 self.assertTrue(
                     numpy.allclose(self.expcm.M(t)[r], direct, atol=1e-6),
-                    "Max diff {0}".format((self.expcm.M(t)[r] - direct).max()),
-                )
+                    "Max diff {0}".format((self.expcm.M(t)[r] - direct).max()))
 
         # check derivatives of M calculated by dM
         # implementation looks a bit complex because `check_grad` function
@@ -339,18 +281,16 @@ class testExpCM(unittest.TestCase):
                 for r in range(self.expcm.nsites):
                     for x in range(N_CODON):
                         for y in range(N_CODON):
-                            diff = scipy.optimize.check_grad(
-                                funcM,
-                                funcdM,
-                                pvalue,
-                                pname,
-                                t,
-                                self.expcm,
-                                r,
-                                x,
-                                y,
-                                storedvalues,
-                            )
+                            diff = scipy.optimize.check_grad(funcM,
+                                                             funcdM,
+                                                             pvalue,
+                                                             pname,
+                                                             t,
+                                                             self.expcm,
+                                                             r,
+                                                             x,
+                                                             y,
+                                                             storedvalues)
                             self.assertTrue(
                                 diff < 2e-3,
                                 ("diff {0} for {1}: r = {2}, x = {3}, "

--- a/tests/test_expcm.py
+++ b/tests/test_expcm.py
@@ -3,7 +3,8 @@
 Written by Jesse Bloom.
 
 Uses `sympy` to make sure attributes and derivatives of attributes
-are correct for `ExpCM` implemented in `phydmslib.models`."""
+are correct for `ExpCM` implemented in `phydmslib.models`.
+"""
 
 
 import random
@@ -20,16 +21,17 @@ import phydmslib.models
 
 
 class testExpCM(unittest.TestCase):
+    """Tests ``ExpCM`` model."""
+
     def test_ExpCM(self):
         """Initialize `ExpCM`, test values, update, test again."""
-
         # create preferences
         random.seed(1)
         numpy.random.seed(1)
         self.nsites = 2
         self.prefs = []
         minpref = 0.01
-        for r in range(self.nsites):
+        for _r in range(self.nsites):
             rprefs = numpy.random.dirichlet([0.5] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
@@ -56,7 +58,7 @@ class testExpCM(unittest.TestCase):
         )
 
         # now check ExpCM attributes / derivates, updating several times
-        for update in range(2):
+        for _update in range(2):
             self.params = {
                 "omega": random.uniform(*self.expcm.PARAMLIMITS["omega"]),
                 "kappa": random.uniform(*self.expcm.PARAMLIMITS["kappa"]),

--- a/tests/test_expcm.py
+++ b/tests/test_expcm.py
@@ -43,8 +43,7 @@ class testExpCM(unittest.TestCase):
         kappa = 2.5
         beta = 1.9
         self.expcm = phydmslib.models.ExpCM(
-            self.prefs, phi=phi, omega=omega, kappa=kappa, beta=beta
-        )
+            self.prefs, phi=phi, omega=omega, kappa=kappa, beta=beta)
         self.assertTrue(numpy.allclose(phi, self.expcm.phi))
         self.assertTrue(numpy.allclose(omega, self.expcm.omega))
         self.assertTrue(numpy.allclose(kappa, self.expcm.kappa))
@@ -98,8 +97,8 @@ class testExpCM(unittest.TestCase):
             if r > 0:
                 self.assertFalse(
                     numpy.allclose(
-                        0, numpy.dot(self.expcm.prx[r], self.expcm.Prxy[r - 1])
-                    ))
+                        0,
+                        numpy.dot(self.expcm.prx[r], self.expcm.Prxy[r - 1])))
 
     def check_ExpCM_derivatives(self):
         """Use `sympy` to check values & derivatives of `ExpCM` attributes."""

--- a/tests/test_expcm_divpressure.py
+++ b/tests/test_expcm_divpressure.py
@@ -10,7 +10,8 @@ import unittest
 import scipy.linalg
 import scipy.optimize
 import numpy
-from phydmslib.constants import N_CODON, N_NT, AA_TO_INDEX, N_AA, CODON_NT_COUNT
+from phydmslib.constants import (N_CODON, N_NT, AA_TO_INDEX, N_AA,
+                                 CODON_NT_COUNT)
 import phydmslib.models
 
 
@@ -171,12 +172,14 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
             return expcm.dphi_dbeta[w]
 
         for w in range(N_NT):
-            diff = scipy.optimize.check_grad(
-                func_phi, func_dphi, [self.model.beta], self.model, w, epsilon=1e-4
-            )
-            self.assertTrue(
-                diff < 1e-4, "dphi_dbeta diff {0} for w = {1}".format(diff, w)
-            )
+            diff = scipy.optimize.check_grad(func_phi,
+                                             func_dphi,
+                                             [self.model.beta],
+                                             self.model,
+                                             w,
+                                             epsilon=1e-4)
+            self.assertTrue(diff < 1e-4,
+                            "dphi_dbeta diff {0} for w = {1}".format(diff, w))
         # back to original value
         self.model.updateParams(self.params)
 
@@ -193,19 +196,16 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
 
         for r in range(self.nsites):
             for x in range(N_CODON):
-                diff = scipy.optimize.check_grad(
-                    func_prx,
-                    func_dprx,
-                    [self.model.beta],
-                    self.model,
-                    r,
-                    x,
-                    epsilon=1e-4,
-                )
-                self.assertTrue(
-                    diff < 1e-4,
-                    "dprx_dbeta diff {0} for r = {1}, x = {2}".format(diff, r, x),
-                )
+                diff = scipy.optimize.check_grad(func_prx,
+                                                 func_dprx,
+                                                 [self.model.beta],
+                                                 self.model,
+                                                 r,
+                                                 x,
+                                                 epsilon=1e-4,)
+                self.assertTrue(diff < 1e-4,
+                                "dprx_dbeta diff {0} for r = {1}, x = {2}"
+                                .format(diff, r, x))
         # back to original value
         self.model.updateParams(self.params)
 
@@ -233,7 +233,8 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
                 )
                 self.assertTrue(
                     diff < 1e-4,
-                    "dQxy_dbeta diff {0} for x = {1}, y = {2}".format(diff, x, y),
+                    "dQxy_dbeta diff {0} for x = {1}, y = {2}"
+                    .format(diff, x, y),
                 )
         # back to original value
         self.model.updateParams(self.params)
@@ -247,7 +248,8 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
         self.assertFalse(numpy.isinf(self.model.Prxy).any())
         diag = numpy.eye(N_CODON, dtype="bool")
         for r in range(self.nsites):
-            self.assertTrue(numpy.allclose(0, numpy.sum(self.model.Prxy[r], axis=1)))
+            self.assertTrue(numpy.allclose(0, numpy.sum(self.model.Prxy[r],
+                                           axis=1)))
             self.assertTrue(numpy.allclose(0, self.model.Prxy[r].sum()))
             self.assertTrue((self.model.Prxy[r][diag] <= 0).all())
             self.assertTrue((self.model.Prxy[r][~diag] >= 0).all())
@@ -259,17 +261,12 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
 
         # prx is eigenvector or Prxy for the same r, but not different r
         for r in range(self.nsites):
-            self.assertTrue(
-                numpy.allclose(0, numpy.dot(self.model.prx[r], self.model.Prxy[r]))
-            )
+            self.assertTrue(numpy.allclose(0, numpy.dot(self.model.prx[r],
+                                                        self.model.Prxy[r])))
             if r > 0:
-                (
-                    self.assertFalse(
-                        numpy.allclose(
-                            0, numpy.dot(self.model.prx[r], self.model.Prxy[r - 1])
-                        )
-                    )
-                )
+                (self.assertFalse(
+                    numpy.allclose(0, numpy.dot(self.model.prx[r],
+                                                self.model.Prxy[r - 1]))))
 
         # phi sums to one
         self.assertTrue(numpy.allclose(1, self.model.phi.sum()))
@@ -362,7 +359,8 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
             )
 
             for t in [0.02, 0.2, 0.5]:
-                direct = scipy.linalg.expm(self.model.Prxy[r] * self.model.mu * t)
+                direct = scipy.linalg.expm(self.model.Prxy[r] *
+                                           self.model.mu * t)
                 self.assertTrue(
                     numpy.allclose(self.model.M(t)[r], direct, atol=1e-6),
                     "Max diff {0}".format((self.model.M(t)[r] - direct).max()),
@@ -441,12 +439,8 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
                                         self.model.pi_codon[r][y],
                                         t,
                                         self.model.mu,
-                                        funcdM(
-                                            pvalue, pname, t, self.model, r, x, y, {}
-                                        ),
-                                    ),
-                                )
-                            )
+                                        funcdM(pvalue, pname, t, self.model,
+                                               r, x, y, {}))))
                 # back to original value
                 self.model.updateParams(self.params)
 

--- a/tests/test_expcm_divpressure.py
+++ b/tests/test_expcm_divpressure.py
@@ -314,7 +314,7 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
                             f"dQxy_dbeta = {self.model.dQxy_dbeta[x][y]}, "
                             f"dphi_dbeta = {self.model.dphi_dbeta}, "
                             f"dPrxy_dbeta = "
-                            f"{self.model.dPrxy["beta"][r][x][y]}, "
+                            f"{self.model.dPrxy['beta'][r][x][y]}, "
                             f"piAx_piAy_beta[r][x][y] = "
                             f"{self.model.piAx_piAy_beta[r][x][y]}"))
             # back to original value

--- a/tests/test_expcm_divpressure.py
+++ b/tests/test_expcm_divpressure.py
@@ -16,17 +16,17 @@ import phydmslib.models
 
 
 class test_compare_ExpCM_emp_phi_with_without_divpress(unittest.TestCase):
+    """Tests ``ExpCM`` with and without div pressure."""
 
     def test_compare(self):
         """Make sure all attributes are the same when `divpressure` is 0."""
-
         random.seed(1)
         numpy.random.seed(1)
 
         nsites = 6
         prefs = []
         minpref = 0.01
-        for r in range(nsites):
+        for _r in range(nsites):
             rprefs = numpy.random.dirichlet([0.5] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
@@ -77,17 +77,17 @@ class test_compare_ExpCM_emp_phi_with_without_divpress(unittest.TestCase):
 
 
 class testExpCM_empirical_phi_divpressure(unittest.TestCase):
+    """Tests ``ExpCM`` with div pressure."""
 
     def test_ExpCM_empirical_phi_divpressure(self):
-        """init `ExpCM_empirical_phi_divpressure`, test, update, test again."""
-
+        """Init `ExpCM_empirical_phi_divpressure`, test, update, test again."""
         # create preferences
         random.seed(1)
         numpy.random.seed(1)
         self.nsites = 6
         self.prefs = []
         minpref = 0.01
-        for r in range(self.nsites):
+        for _r in range(self.nsites):
             rprefs = numpy.random.dirichlet([0.5] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
@@ -108,7 +108,7 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
                                                        beta=beta,
                                                        omega2=omega2))
         # now check ExpCM attributes / derivates, updating several times
-        for update in range(2):
+        for _update in range(2):
             self.params = {'omega': random.uniform(0.1, 2),
                            'kappa': random.uniform(0.5, 10),
                            'beta': random.uniform(0.5, 3),

--- a/tests/test_expcm_divpressure.py
+++ b/tests/test_expcm_divpressure.py
@@ -51,11 +51,11 @@ class test_compare_ExpCM_emp_phi_with_without_divpress(unittest.TestCase):
             omega2=omega2,
         )
 
-        self.assertTrue(
-            numpy.allclose(expcm.stationarystate, expcm_divpressure.stationarystate),
-            "stationarystate differs.",
-        )
-        self.assertTrue(numpy.allclose(expcm.Qxy, expcm_divpressure.Qxy), "Qxy differs")
+        self.assertTrue(numpy.allclose(expcm.stationarystate,
+                                       expcm_divpressure.stationarystate),
+                        "stationarystate differs.")
+        self.assertTrue(numpy.allclose(expcm.Qxy, expcm_divpressure.Qxy),
+                        "Qxy differs")
         self.assertTrue(
             numpy.allclose(expcm.Frxy, expcm_divpressure.Frxy), "Frxy differs"
         )
@@ -159,8 +159,8 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
         nt_freqs /= nt_freqs.sum()
         self.assertTrue(
             numpy.allclose(nt_freqs, self.model.g, atol=1e-5),
-            "Actual nt_freqs: {0}\nExpected (g): {1}".format(nt_freqs, self.model.g),
-        )
+            "Actual nt_freqs: {0}\nExpected (g): {1}"
+            .format(nt_freqs, self.model.g))
 
         def func_phi(beta, expcm, w):
             expcm.updateParams({"beta": beta[0]})

--- a/tests/test_expcm_divpressure.py
+++ b/tests/test_expcm_divpressure.py
@@ -9,13 +9,13 @@ import random
 import unittest
 import scipy.linalg
 import scipy.optimize
-import sympy
 import numpy
-from phydmslib.constants import *
+from phydmslib.constants import (N_CODON, N_NT, AA_TO_INDEX,
+                                 N_AA, CODON_NT_COUNT)
 import phydmslib.models
 
 
-class test_compare_ExpCM_empirical_phi_with_and_without_divpressure(unittest.TestCase):
+class test_compare_ExpCM_emp_phi_with_without_divpress(unittest.TestCase):
 
     def test_compare(self):
         """Make sure all attributes are the same when `divpressure` is 0."""
@@ -46,37 +46,40 @@ class test_compare_ExpCM_empirical_phi_with_and_without_divpressure(unittest.Tes
                 kappa=kappa, beta=beta, omega2=omega2)
 
         self.assertTrue(numpy.allclose(expcm.stationarystate,
-                expcm_divpressure.stationarystate),
-                "stationarystate differs.")
+                                       expcm_divpressure.stationarystate),
+                        "stationarystate differs.")
         self.assertTrue(numpy.allclose(expcm.Qxy,
-                expcm_divpressure.Qxy),
-                "Qxy differs")
+                                       expcm_divpressure.Qxy),
+                        "Qxy differs")
         self.assertTrue(numpy.allclose(expcm.Frxy,
-                expcm_divpressure.Frxy),
-                "Frxy differs")
+                                       expcm_divpressure.Frxy),
+                        "Frxy differs")
         self.assertTrue(numpy.allclose(expcm.Prxy,
-                expcm_divpressure.Prxy),
-                "Prxy differs")
+                                       expcm_divpressure.Prxy),
+                        "Prxy differs")
         t = 0.02
         self.assertTrue(numpy.allclose(expcm.M(t),
-                expcm_divpressure.M(t)),
-                "M({0}) differs".format(t))
+                                       expcm_divpressure.M(t)),
+                        "M({0}) differs".format(t))
         for param in ['kappa', 'omega', 'beta']:
             self.assertTrue(numpy.allclose(getattr(expcm, param),
-                    getattr(expcm_divpressure, param)),
-                    "param values differ for {0}".format(param))
+                                           getattr(expcm_divpressure, param)),
+                            "param values differ for {0}".format(param))
             self.assertTrue(numpy.allclose(expcm.dstationarystate(param),
-                    expcm_divpressure.dstationarystate(param)),
-                    "dstationarystate differs for {0}".format(param))
+                                           (expcm_divpressure
+                                            .dstationarystate(param))),
+                            "dstationarystate differs for {0}".format(param))
             self.assertTrue(numpy.allclose(expcm.dM(t, param, expcm.M(t)),
-                    expcm_divpressure.dM(t, param, expcm_divpressure.M(t))),
-                    "dM({0}) differs for {1}".format(t, param))
+                                           (expcm_divpressure
+                                            .dM(t, param,
+                                                expcm_divpressure.M(t)))),
+                            "dM({0}) differs for {1}".format(t, param))
 
 
 class testExpCM_empirical_phi_divpressure(unittest.TestCase):
 
     def test_ExpCM_empirical_phi_divpressure(self):
-        """Initialize `ExpCM_empirical_phi_divpressure`, test values, update, test again."""
+        """init `ExpCM_empirical_phi_divpressure`, test, update, test again."""
 
         # create preferences
         random.seed(1)
@@ -97,19 +100,23 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
         omega2 = 0.2
         kappa = 2.5
         beta = 1.2
-        self.expcm_divpressure = phydmslib.models.ExpCM_empirical_phi_divpressure(
-                self.prefs, g=g, divPressureValues=self.divpressure, omega=omega,
-                kappa=kappa, beta=beta, omega2=omega2)
+        self.model = (phydmslib.models
+                      .ExpCM_empirical_phi_divpressure(self.prefs, g=g,
+                                                       divPressureValues=self.divpressure,
+                                                       omega=omega,
+                                                       kappa=kappa,
+                                                       beta=beta,
+                                                       omega2=omega2))
         # now check ExpCM attributes / derivates, updating several times
         for update in range(2):
-            self.params = {'omega':random.uniform(0.1, 2),
-                      'kappa':random.uniform(0.5, 10),
-                      'beta':random.uniform(0.5, 3),
-                      'mu':random.uniform(0.05, 5.0),
-                      'omega2': random.uniform(0.1,0.3)
-                     }
-            self.expcm_divpressure.updateParams(self.params)
-            self.assertTrue(numpy.allclose(g, self.expcm_divpressure.g))
+            self.params = {'omega': random.uniform(0.1, 2),
+                           'kappa': random.uniform(0.5, 10),
+                           'beta': random.uniform(0.5, 3),
+                           'mu': random.uniform(0.05, 5.0),
+                           'omega2': random.uniform(0.1, 0.3)
+                           }
+            self.model.updateParams(self.params)
+            self.assertTrue(numpy.allclose(g, self.model.g))
 
             self.check_empirical_phi()
 
@@ -129,100 +136,121 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
         for r in range(self.nsites):
             for x in range(N_CODON):
                 for w in range(N_NT):
-                    nt_freqs[w] += self.expcm_divpressure.prx[r][x] * CODON_NT_COUNT[w][x]
+                    nt_freqs[w] += (self.model.prx[r][x] *
+                                    CODON_NT_COUNT[w][x])
         self.assertTrue(numpy.allclose(sum(nt_freqs), 3 * self.nsites))
         nt_freqs = numpy.array(nt_freqs)
         nt_freqs /= nt_freqs.sum()
-        self.assertTrue(numpy.allclose(nt_freqs, self.expcm_divpressure.g, atol=1e-5),
-                "Actual nt_freqs: {0}\nExpected (g): {1}".format(
-                nt_freqs, self.expcm_divpressure.g))
+        self.assertTrue(numpy.allclose(nt_freqs,
+                                       self.model.g,
+                        atol=1e-5),
+                        "Actual nt_freqs: {0}\nExpected (g): {1}"
+                        .format(nt_freqs, self.model.g))
 
         def func_phi(beta, expcm, w):
-            expcm.updateParams({'beta':beta[0]})
+            expcm.updateParams({'beta': beta[0]})
             return expcm.phi[w]
 
         def func_dphi(beta, expcm, w):
-            expcm.updateParams({'beta':beta[0]})
+            expcm.updateParams({'beta': beta[0]})
             return expcm.dphi_dbeta[w]
 
         for w in range(N_NT):
             diff = scipy.optimize.check_grad(func_phi, func_dphi,
-                    [self.expcm_divpressure.beta], self.expcm_divpressure, w, epsilon=1e-4)
+                                             [self.model.beta],
+                                             self.model, w,
+                                             epsilon=1e-4)
             self.assertTrue(diff < 1e-4,
-                    "dphi_dbeta diff {0} for w = {1}".format(diff, w))
-        self.expcm_divpressure.updateParams(self.params) # back to original value
-
+                            "dphi_dbeta diff {0} for w = {1}"
+                            .format(diff, w))
+        # back to original value
+        self.model.updateParams(self.params)
 
     def check_dprx_dbeta(self):
         """Checks derivatives of `prx` with respect to `beta`."""
 
         def func_prx(beta, expcm, r, x):
-            expcm.updateParams({'beta':beta[0]})
+            expcm.updateParams({'beta': beta[0]})
             return expcm.prx[r][x]
 
         def func_dprx(beta, expcm, r, x):
-            expcm.updateParams({'beta':beta[0]})
+            expcm.updateParams({'beta': beta[0]})
             return expcm.dprx['beta'][r][x]
 
         for r in range(self.nsites):
             for x in range(N_CODON):
                 diff = scipy.optimize.check_grad(func_prx, func_dprx,
-                        [self.expcm_divpressure.beta], self.expcm_divpressure, r, x, epsilon=1e-4)
+                                                 [self.model.beta],
+                                                 self.model, r, x,
+                                                 epsilon=1e-4)
                 self.assertTrue(diff < 1e-4,
-                        "dprx_dbeta diff {0} for r = {1}, x = {2}".format(
-                        diff, r, x))
-        self.expcm_divpressure.updateParams(self.params) # back to original value
+                                "dprx_dbeta diff {0} for r = {1}, x = {2}"
+                                .format(diff, r, x))
+        # back to original value
+        self.model.updateParams(self.params)
 
     def check_dQxy_dbeta(self):
         """Checks derivatives of `Qxy` with respect to `beta`."""
 
         def func_Qxy(beta, expcm, x, y):
-            expcm.updateParams({'beta':beta[0]})
+            expcm.updateParams({'beta': beta[0]})
             return expcm.Qxy[x][y]
 
         def func_dQxy(beta, expcm, x, y):
-            expcm.updateParams({'beta':beta[0]})
+            expcm.updateParams({'beta': beta[0]})
             return expcm.dQxy_dbeta[x][y]
 
         for x in random.sample(range(N_CODON), 3):
             for y in range(N_CODON):
                 diff = scipy.optimize.check_grad(func_Qxy, func_dQxy,
-                        [self.expcm_divpressure.beta], self.expcm_divpressure, x, y, epsilon=1e-4)
+                                                 [self.model.beta],
+                                                 self.model, x, y,
+                                                 epsilon=1e-4)
                 self.assertTrue(diff < 1e-4,
-                        "dQxy_dbeta diff {0} for x = {1}, y = {2}".format(
-                        diff, x, y))
-        self.expcm_divpressure.updateParams(self.params) # back to original value
+                                "dQxy_dbeta diff {0} for x = {1}, y = {2}"
+                                .format(diff, x, y))
+        # back to original value
+        self.model.updateParams(self.params)
 
     def check_ExpCM_attributes(self):
         """Make sure has the expected attribute values."""
-        self.assertEqual(self.nsites, self.expcm_divpressure.nsites)
+        self.assertEqual(self.nsites, self.model.nsites)
 
         # make sure Prxy has rows summing to zero
-        self.assertFalse(numpy.isnan(self.expcm_divpressure.Prxy).any())
-        self.assertFalse(numpy.isinf(self.expcm_divpressure.Prxy).any())
+        self.assertFalse(numpy.isnan(self.model.Prxy).any())
+        self.assertFalse(numpy.isinf(self.model.Prxy).any())
         diag = numpy.eye(N_CODON, dtype='bool')
         for r in range(self.nsites):
-            self.assertTrue(numpy.allclose(0, numpy.sum(self.expcm_divpressure.Prxy[r],
-                    axis=1)))
-            self.assertTrue(numpy.allclose(0, self.expcm_divpressure.Prxy[r].sum()))
-            self.assertTrue((self.expcm_divpressure.Prxy[r][diag] <= 0).all())
-            self.assertTrue((self.expcm_divpressure.Prxy[r][~diag] >= 0).all())
+            self.assertTrue(numpy.allclose(0,
+                                           numpy.sum(self.model.Prxy[r], axis=1
+                                                     )))
+            self.assertTrue(numpy.allclose(0,
+                                           self.model.Prxy[r].sum()
+                                           ))
+            self.assertTrue((self.model.Prxy[r][diag] <= 0).all())
+            self.assertTrue((self.model.Prxy[r][~diag] >= 0).all())
 
         # make sure prx sums to 1 for each r
-        self.assertTrue((self.expcm_divpressure.prx >= 0).all())
+        self.assertTrue((self.model.prx >= 0).all())
         for r in range(self.nsites):
-            self.assertTrue(numpy.allclose(1, self.expcm_divpressure.prx[r].sum()))
+            self.assertTrue(numpy.allclose(1,
+                                           self.model.prx[r].sum()
+                                           ))
 
         # prx is eigenvector or Prxy for the same r, but not different r
         for r in range(self.nsites):
-            self.assertTrue(numpy.allclose(0, numpy.dot(self.expcm_divpressure.prx[r],
-                    self.expcm_divpressure.Prxy[r])))
+            self.assertTrue(numpy.allclose(0,
+                                           numpy.dot(self.model.prx[r],
+                                                     self.model.Prxy[r])))
             if r > 0:
-                self.assertFalse(numpy.allclose(0, numpy.dot(self.expcm_divpressure.prx[r],
-                        self.expcm_divpressure.Prxy[r - 1])))
+                (self
+                 .assertFalse(numpy.allclose(0,
+                                             numpy.dot(self.model.prx[r],
+                                                       self.model.Prxy[r - 1])
+                                             )))
 
         # phi sums to one
-        self.assertTrue(numpy.allclose(1, self.expcm_divpressure.phi.sum()))
+        self.assertTrue(numpy.allclose(1, self.model.phi.sum()))
 
     def check_ExpCM_derivatives(self):
         """Makes sure derivatives are as expected."""
@@ -233,16 +261,16 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
 
         def funcPrxy(paramvalue, paramname, expcm, r, x, y):
             if len(paramvalue) == 1:
-                expcm.updateParams({paramname:paramvalue[0]})
+                expcm.updateParams({paramname: paramvalue[0]})
             else:
-                expcm.updateParams({paramname:paramvalue})
+                expcm.updateParams({paramname: paramvalue})
             return expcm.Prxy[r][x][y]
 
         def funcdPrxy(paramvalue, paramname, expcm, r, x, y):
             if len(paramvalue) == 1:
-                expcm.updateParams({paramname:paramvalue[0]})
+                expcm.updateParams({paramname: paramvalue[0]})
             else:
-                expcm.updateParams({paramname:paramvalue})
+                expcm.updateParams({paramname: paramvalue})
             return expcm.dPrxy[paramname][r][x][y]
 
         for (pname, pvalue) in sorted(self.params.items())[::-1]:
@@ -250,96 +278,125 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
                 continue
             if isinstance(pvalue, float):
                 pvalue = [pvalue]
-            for r in random.sample(range(self.nsites), 2): # check a few sites
-                for x in random.sample(range(N_CODON), 3): # check a few codons
+            for r in random.sample(range(self.nsites), 2):  # check a few sites
+                for x in random.sample(range(N_CODON), 3):  # check a few codon
                     for y in range(N_CODON):
-                        diff = scipy.optimize.check_grad(funcPrxy, funcdPrxy,
-                                pvalue, pname, self.expcm_divpressure, r, x, y, epsilon=1e-4)
-                        self.assertTrue(diff < 1e-3, ("diff {0} for {1}:" +
-                                " r = {2}, x = {3}, y = {4}, beta = {5} " +
-                                "pirAx = {6}, pirAy = {7}, mu = {8}, " +
-                                "omega = {9}, Frxy = {10}, Prxy = {11}, " +
-                                "phi = {12}, kappa = {13}, dQxy_dbeta = {14}, " +
-                                "dphi_dbeta = {15}, dPrxy_dbeta = {16}, piAx_piAy_beta[r][x][y] = {17}"
-                                ).format(diff, pname, r, x, y,
-                                self.params['beta'], self.expcm_divpressure.pi_codon[r][x],
-                                self.expcm_divpressure.pi_codon[r][y], self.expcm_divpressure.mu,
-                                self.expcm_divpressure.omega, self.expcm_divpressure.Frxy[r][x][y],
-                                self.expcm_divpressure.Prxy[r][x][y], self.expcm_divpressure.phi,
-                                self.expcm_divpressure.kappa, self.expcm_divpressure.dQxy_dbeta[x][y],
-                                self.expcm_divpressure.dphi_dbeta,
-                                self.expcm_divpressure.dPrxy['beta'][r][x][y],
-                                self.expcm_divpressure.piAx_piAy_beta[r][x][y]))
-            self.expcm_divpressure.updateParams(self.params) # back to original value
+                        diff = (scipy.optimize
+                                .check_grad(funcPrxy, funcdPrxy, pvalue,
+                                            pname, self.model, r, x, y,
+                                            epsilon=1e-4))
+                        (self
+                         .assertTrue(diff < 1e-3,
+                                     "diff {0} for {1}: r = {2}, x = {3}, "
+                                     "y = {4}, beta = {5} pirAx = {6}, "
+                                     "pirAy = {7}, mu = {8}, omega = {9}, "
+                                     "Frxy = {10}, Prxy = {11}, phi = {12}, "
+                                     "kappa = {13}, dQxy_dbeta = {14}, "
+                                     "dphi_dbeta = {15}, dPrxy_dbeta = {16}, "
+                                     "piAx_piAy_beta[r][x][y] = {17}"
+                                     .format(diff, pname, r, x, y,
+                                             self.params['beta'],
+                                             self.model.pi_codon[r][x],
+                                             self.model.pi_codon[r][y],
+                                             self.model.mu,
+                                             self.model.omega,
+                                             self.model.Frxy[r][x][y],
+                                             self.model.Prxy[r][x][y],
+                                             self.model.phi,
+                                             self.model.kappa,
+                                             self.model.dQxy_dbeta[x][y],
+                                             self.model.dphi_dbeta,
+                                             self.model.dPrxy['beta'][r][x][y],
+                                             self.model.piAx_piAy_beta[r][x][y]
+                                             )))
+            # back to original value
+            self.model.updateParams(self.params)
 
     def check_ExpCM_matrix_exponentials(self):
         """Makes sure matrix exponentials are as expected."""
         for r in range(self.nsites):
             # fromdiag is recomputed Prxy after diagonalization
-            fromdiag = numpy.dot(self.expcm_divpressure.A[r], numpy.dot(numpy.diag(
-                    self.expcm_divpressure.D[r]), self.expcm_divpressure.Ainv[r]))
-            self.assertTrue(numpy.allclose(self.expcm_divpressure.Prxy[r], fromdiag,
-                    atol=1e-5), "Max diff {0}".format(
-                    (self.expcm_divpressure.Prxy[r] - fromdiag).max()))
+            fromdiag = numpy.dot(self.model.A[r],
+                                 numpy.dot(numpy.diag(self.model.D[r]),
+                                           self.model.Ainv[r]))
+            self.assertTrue(numpy.allclose(self.model.Prxy[r],
+                                           fromdiag,
+                                           atol=1e-5),
+                            "Max diff {0}".format(
+                    (self.model.Prxy[r] - fromdiag).max()))
 
             for t in [0.02, 0.2, 0.5]:
-                direct = scipy.linalg.expm(self.expcm_divpressure.Prxy[r] * self.expcm_divpressure.mu * t)
-                self.assertTrue(numpy.allclose(self.expcm_divpressure.M(t)[r], direct, atol=1e-6),
-                        "Max diff {0}".format((self.expcm_divpressure.M(t)[r] - direct).max()))
+                direct = scipy.linalg.expm(self.model.Prxy[r] *
+                                           self.model.mu * t)
+                self.assertTrue(numpy.allclose(self.model.M(t)[r],
+                                direct,
+                                atol=1e-6),
+                                "Max diff {0}".format((self.model.M(t)[r] -
+                                                       direct).max()))
         # check derivatives of M calculated by dM
         # implementation looks a bit complex because `check_grad` function
         # can only be used for single values at a time, so have to loop
         # over r, x, y and so hash values to make faster
+
         def funcM(paramvalue, paramname, t, expcm, r, x, y, storedvalues):
             """Gets `M(t)[r][x][y]`."""
             key = ('M', tuple(paramvalue), paramname, t)
             if key not in storedvalues:
                 if len(paramvalue) == 1:
-                    expcm.updateParams({paramname:paramvalue[0]})
+                    expcm.updateParams({paramname: paramvalue[0]})
                 else:
-                    expcm.updateParams({paramname:paramvalue})
+                    expcm.updateParams({paramname: paramvalue})
                 storedvalues[key] = expcm.M(t)
             if len(storedvalues[key].shape) == 3:
                 return storedvalues[key][r][x][y]
             else:
-                return storedvalues[key][:,r,x,y]
+                return storedvalues[key][:, r, x, y]
+
         def funcdM(paramvalue, paramname, t, expcm, r, x, y, storedvalues):
             """Gets `dM`."""
             key = ('dM', tuple(paramvalue), paramname, t)
             if key not in storedvalues:
                 if len(paramvalue) == 1:
-                    expcm.updateParams({paramname:paramvalue[0]})
+                    expcm.updateParams({paramname: paramvalue[0]})
                 else:
-                    expcm.updateParams({paramname:paramvalue})
+                    expcm.updateParams({paramname: paramvalue})
                 storedvalues[key] = expcm.dM(t, paramname, expcm.M(t))
             if len(storedvalues[key].shape) == 3:
                 return storedvalues[key][r][x][y]
             else:
-                return storedvalues[key][:,r,x,y]
+                return storedvalues[key][:, r, x, y]
         for (pname, pvalue) in sorted(self.params.items()):
-            storedvalues = {} # used to hash values
+            storedvalues = {}  # used to hash values
             if isinstance(pvalue, float):
                 pvalue = [pvalue]
             for t in [0.01, 0.2]:
-                for r in random.sample(range(self.expcm_divpressure.nsites), 2):
+                for r in random.sample(range(self.model.nsites), 2):
                     for x in random.sample(range(N_CODON), 3):
                         for y in range(N_CODON):
                             if x == y:
                                 continue
-                            diff = scipy.optimize.check_grad(funcM, funcdM, pvalue,
-                                    pname, t, self.expcm_divpressure, r, x, y, storedvalues,
-                                    epsilon=1e-4)
-                            self.assertTrue(diff < 1e-3, ("diff {0} for {1}:" +
-                                " computed derivative = {10}, " +
-                                " r = {2}, x = {3}, y = {4}, beta = {5}, " +
-                                "pirAx = {6}, pirAy = {7}, t = {8}, mu = {9}"
-                                ).format(diff, pname, r, x, y,
-                                self.params['beta'], self.expcm_divpressure.pi_codon[r][x],
-                                self.expcm_divpressure.pi_codon[r][y], t, self.expcm_divpressure.mu,
-                                funcdM(pvalue, pname, t, self.expcm_divpressure,
-                                r, x, y, {})))
-                self.expcm_divpressure.updateParams(self.params) # back to original value
-
+                            diff = (scipy.optimize
+                                    .check_grad(funcM, funcdM, pvalue, pname,
+                                                t, self.model, r,
+                                                x, y, storedvalues,
+                                                epsilon=1e-4))
+                            (self
+                             .assertTrue(diff < 1e-3,
+                                         "diff {0} for {1}: "
+                                         "computed derivative = {10}, "
+                                         "r = {2}, x = {3}, y = {4}, "
+                                         "beta = {5}, pirAx = {6}, "
+                                         "pirAy = {7}, t = {8}, mu = {9}"
+                                         .format(diff, pname, r, x, y,
+                                                 self.params['beta'],
+                                                 self.model.pi_codon[r][x],
+                                                 self.model.pi_codon[r][y],
+                                                 t, self.model.mu,
+                                                 funcdM(pvalue, pname, t,
+                                                        self.model, r, x, y,
+                                                        {}))))
+                # back to original value
+                self.model.updateParams(self.params)
 
 
 if __name__ == '__main__':

--- a/tests/test_expcm_divpressure.py
+++ b/tests/test_expcm_divpressure.py
@@ -301,22 +301,30 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
                             epsilon=1e-4,)
                         (self.assertTrue(
                             diff < 1e-3,
-                            f"diff {diff} for {pname}: r = {r}, x = {x}, "
-                            f"y = {y}, beta = {self.params['beta']} "
-                            f"pirAx = {self.model.pi_codon[r][x]}, "
-                            f"pirAy = {self.model.pi_codon[r][y]}, "
-                            f"mu = {self.model.mu}, "
-                            f"omega = {self.model.omega}, "
-                            f"Frxy = {self.model.Frxy[r][x][y]}, "
-                            f"Prxy = {self.model.Prxy[r][x][y]}, "
-                            f"phi = {self.model.phi}, "
-                            f"kappa = {self.model.kappa}, "
-                            f"dQxy_dbeta = {self.model.dQxy_dbeta[x][y]}, "
-                            f"dphi_dbeta = {self.model.dphi_dbeta}, "
-                            f"dPrxy_dbeta = "
-                            f"{self.model.dPrxy['beta'][r][x][y]}, "
-                            f"piAx_piAy_beta[r][x][y] = "
-                            f"{self.model.piAx_piAy_beta[r][x][y]}"))
+                            "diff {0} for {1}: r = {2}, x = {3}, y = {4}, "
+                            "beta = {5} pirAx = {6}, pirAy = {7}, mu = {8}, "
+                            "omega = {9}, Frxy = {10}, Prxy = {11}, "
+                            "phi = {12}, kappa = {13}, dQxy_dbeta = {14}, "
+                            "dphi_dbeta = {15}, dPrxy_dbeta = {16}, "
+                            "piAx_piAy_beta[r][x][y] = {17}".format(
+                                    diff,
+                                    pname,
+                                    r,
+                                    x,
+                                    y,
+                                    self.params["beta"],
+                                    self.model.pi_codon[r][x],
+                                    self.model.pi_codon[r][y],
+                                    self.model.mu,
+                                    self.model.omega,
+                                    self.model.Frxy[r][x][y],
+                                    self.model.Prxy[r][x][y],
+                                    self.model.phi,
+                                    self.model.kappa,
+                                    self.model.dQxy_dbeta[x][y],
+                                    self.model.dphi_dbeta,
+                                    self.model.dPrxy["beta"][r][x][y],
+                                    self.model.piAx_piAy_beta[r][x][y])))
             # back to original value
             self.model.updateParams(self.params)
 
@@ -391,17 +399,28 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
                                 x,
                                 y,
                                 storedvalues,
-                                epsilon=1e-4,)
-                            (self.assertTrue(
-                                diff < 1e-3,
-                                f"diff {diff} for {pname}: computed "
-                                f"derivative = {funcdM(pvalue, pname, t,\
-                                                self.model,r, x, y, {})}, "
-                                f"r = {r}, x = {x}, y = {u}, beta = "
-                                f"{self.params['beta']}, pirAx = "
-                                f"{self.model.pi_codon[r][x]}, pirAy = "
-                                f"{self.model.pi_codon[r][y]}, t = {t}, "
-                                f"mu = {self.model.mu}"))
+                                epsilon=1e-4,
+                            )
+                            (
+                                self.assertTrue(
+                                    diff < 1e-3,
+                                    "diff {0} for {1}: "
+                                    "computed derivative = {10}, "
+                                    "r = {2}, x = {3}, y = {4}, "
+                                    "beta = {5}, pirAx = {6}, "
+                                    "pirAy = {7}, t = {8}, mu = {9}".format(
+                                        diff,
+                                        pname,
+                                        r,
+                                        x,
+                                        y,
+                                        self.params["beta"],
+                                        self.model.pi_codon[r][x],
+                                        self.model.pi_codon[r][y],
+                                        t,
+                                        self.model.mu,
+                                        funcdM(pvalue, pname, t, self.model,
+                                               r, x, y, {}))))
                 # back to original value
                 self.model.updateParams(self.params)
 

--- a/tests/test_expcm_divpressure.py
+++ b/tests/test_expcm_divpressure.py
@@ -10,8 +10,7 @@ import unittest
 import scipy.linalg
 import scipy.optimize
 import numpy
-from phydmslib.constants import (N_CODON, N_NT, AA_TO_INDEX,
-                                 N_AA, CODON_NT_COUNT)
+from phydmslib.constants import N_CODON, N_NT, AA_TO_INDEX, N_AA, CODON_NT_COUNT
 import phydmslib.models
 
 
@@ -39,41 +38,56 @@ class test_compare_ExpCM_emp_phi_with_without_divpress(unittest.TestCase):
         divpressure = numpy.zeros(nsites)
 
         expcm = phydmslib.models.ExpCM_empirical_phi(
-                prefs, g, omega=omega, kappa=kappa, beta=beta)
+            prefs, g, omega=omega, kappa=kappa, beta=beta
+        )
 
         expcm_divpressure = phydmslib.models.ExpCM_empirical_phi_divpressure(
-                prefs, g, divPressureValues=divpressure, omega=omega,
-                kappa=kappa, beta=beta, omega2=omega2)
+            prefs,
+            g,
+            divPressureValues=divpressure,
+            omega=omega,
+            kappa=kappa,
+            beta=beta,
+            omega2=omega2,
+        )
 
-        self.assertTrue(numpy.allclose(expcm.stationarystate,
-                                       expcm_divpressure.stationarystate),
-                        "stationarystate differs.")
-        self.assertTrue(numpy.allclose(expcm.Qxy,
-                                       expcm_divpressure.Qxy),
-                        "Qxy differs")
-        self.assertTrue(numpy.allclose(expcm.Frxy,
-                                       expcm_divpressure.Frxy),
-                        "Frxy differs")
-        self.assertTrue(numpy.allclose(expcm.Prxy,
-                                       expcm_divpressure.Prxy),
-                        "Prxy differs")
+        self.assertTrue(
+            numpy.allclose(expcm.stationarystate, expcm_divpressure.stationarystate),
+            "stationarystate differs.",
+        )
+        self.assertTrue(numpy.allclose(expcm.Qxy, expcm_divpressure.Qxy), "Qxy differs")
+        self.assertTrue(
+            numpy.allclose(expcm.Frxy, expcm_divpressure.Frxy), "Frxy differs"
+        )
+        self.assertTrue(
+            numpy.allclose(expcm.Prxy, expcm_divpressure.Prxy), "Prxy differs"
+        )
         t = 0.02
-        self.assertTrue(numpy.allclose(expcm.M(t),
-                                       expcm_divpressure.M(t)),
-                        "M({0}) differs".format(t))
-        for param in ['kappa', 'omega', 'beta']:
-            self.assertTrue(numpy.allclose(getattr(expcm, param),
-                                           getattr(expcm_divpressure, param)),
-                            "param values differ for {0}".format(param))
-            self.assertTrue(numpy.allclose(expcm.dstationarystate(param),
-                                           (expcm_divpressure
-                                            .dstationarystate(param))),
-                            "dstationarystate differs for {0}".format(param))
-            self.assertTrue(numpy.allclose(expcm.dM(t, param, expcm.M(t)),
-                                           (expcm_divpressure
-                                            .dM(t, param,
-                                                expcm_divpressure.M(t)))),
-                            "dM({0}) differs for {1}".format(t, param))
+        self.assertTrue(
+            numpy.allclose(expcm.M(t), expcm_divpressure.M(t)),
+            "M({0}) differs".format(t),
+        )
+        for param in ["kappa", "omega", "beta"]:
+            self.assertTrue(
+                numpy.allclose(
+                    getattr(expcm, param), getattr(expcm_divpressure, param)
+                ),
+                "param values differ for {0}".format(param),
+            )
+            self.assertTrue(
+                numpy.allclose(
+                    expcm.dstationarystate(param),
+                    (expcm_divpressure.dstationarystate(param)),
+                ),
+                "dstationarystate differs for {0}".format(param),
+            )
+            self.assertTrue(
+                numpy.allclose(
+                    expcm.dM(t, param, expcm.M(t)),
+                    (expcm_divpressure.dM(t, param, expcm_divpressure.M(t))),
+                ),
+                "dM({0}) differs for {1}".format(t, param),
+            )
 
 
 class testExpCM_empirical_phi_divpressure(unittest.TestCase):
@@ -100,21 +114,24 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
         omega2 = 0.2
         kappa = 2.5
         beta = 1.2
-        self.model = (phydmslib.models
-                      .ExpCM_empirical_phi_divpressure(self.prefs, g=g,
-                                                       divPressureValues=self.divpressure,
-                                                       omega=omega,
-                                                       kappa=kappa,
-                                                       beta=beta,
-                                                       omega2=omega2))
+        self.model = phydmslib.models.ExpCM_empirical_phi_divpressure(
+            self.prefs,
+            g=g,
+            divPressureValues=self.divpressure,
+            omega=omega,
+            kappa=kappa,
+            beta=beta,
+            omega2=omega2,
+        )
         # now check ExpCM attributes / derivates, updating several times
         for _update in range(2):
-            self.params = {'omega': random.uniform(0.1, 2),
-                           'kappa': random.uniform(0.5, 10),
-                           'beta': random.uniform(0.5, 3),
-                           'mu': random.uniform(0.05, 5.0),
-                           'omega2': random.uniform(0.1, 0.3)
-                           }
+            self.params = {
+                "omega": random.uniform(0.1, 2),
+                "kappa": random.uniform(0.5, 10),
+                "beta": random.uniform(0.5, 3),
+                "mu": random.uniform(0.05, 5.0),
+                "omega2": random.uniform(0.1, 0.3),
+            }
             self.model.updateParams(self.params)
             self.assertTrue(numpy.allclose(g, self.model.g))
 
@@ -136,33 +153,30 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
         for r in range(self.nsites):
             for x in range(N_CODON):
                 for w in range(N_NT):
-                    nt_freqs[w] += (self.model.prx[r][x] *
-                                    CODON_NT_COUNT[w][x])
+                    nt_freqs[w] += self.model.prx[r][x] * CODON_NT_COUNT[w][x]
         self.assertTrue(numpy.allclose(sum(nt_freqs), 3 * self.nsites))
         nt_freqs = numpy.array(nt_freqs)
         nt_freqs /= nt_freqs.sum()
-        self.assertTrue(numpy.allclose(nt_freqs,
-                                       self.model.g,
-                        atol=1e-5),
-                        "Actual nt_freqs: {0}\nExpected (g): {1}"
-                        .format(nt_freqs, self.model.g))
+        self.assertTrue(
+            numpy.allclose(nt_freqs, self.model.g, atol=1e-5),
+            "Actual nt_freqs: {0}\nExpected (g): {1}".format(nt_freqs, self.model.g),
+        )
 
         def func_phi(beta, expcm, w):
-            expcm.updateParams({'beta': beta[0]})
+            expcm.updateParams({"beta": beta[0]})
             return expcm.phi[w]
 
         def func_dphi(beta, expcm, w):
-            expcm.updateParams({'beta': beta[0]})
+            expcm.updateParams({"beta": beta[0]})
             return expcm.dphi_dbeta[w]
 
         for w in range(N_NT):
-            diff = scipy.optimize.check_grad(func_phi, func_dphi,
-                                             [self.model.beta],
-                                             self.model, w,
-                                             epsilon=1e-4)
-            self.assertTrue(diff < 1e-4,
-                            "dphi_dbeta diff {0} for w = {1}"
-                            .format(diff, w))
+            diff = scipy.optimize.check_grad(
+                func_phi, func_dphi, [self.model.beta], self.model, w, epsilon=1e-4
+            )
+            self.assertTrue(
+                diff < 1e-4, "dphi_dbeta diff {0} for w = {1}".format(diff, w)
+            )
         # back to original value
         self.model.updateParams(self.params)
 
@@ -170,22 +184,28 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
         """Checks derivatives of `prx` with respect to `beta`."""
 
         def func_prx(beta, expcm, r, x):
-            expcm.updateParams({'beta': beta[0]})
+            expcm.updateParams({"beta": beta[0]})
             return expcm.prx[r][x]
 
         def func_dprx(beta, expcm, r, x):
-            expcm.updateParams({'beta': beta[0]})
-            return expcm.dprx['beta'][r][x]
+            expcm.updateParams({"beta": beta[0]})
+            return expcm.dprx["beta"][r][x]
 
         for r in range(self.nsites):
             for x in range(N_CODON):
-                diff = scipy.optimize.check_grad(func_prx, func_dprx,
-                                                 [self.model.beta],
-                                                 self.model, r, x,
-                                                 epsilon=1e-4)
-                self.assertTrue(diff < 1e-4,
-                                "dprx_dbeta diff {0} for r = {1}, x = {2}"
-                                .format(diff, r, x))
+                diff = scipy.optimize.check_grad(
+                    func_prx,
+                    func_dprx,
+                    [self.model.beta],
+                    self.model,
+                    r,
+                    x,
+                    epsilon=1e-4,
+                )
+                self.assertTrue(
+                    diff < 1e-4,
+                    "dprx_dbeta diff {0} for r = {1}, x = {2}".format(diff, r, x),
+                )
         # back to original value
         self.model.updateParams(self.params)
 
@@ -193,22 +213,28 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
         """Checks derivatives of `Qxy` with respect to `beta`."""
 
         def func_Qxy(beta, expcm, x, y):
-            expcm.updateParams({'beta': beta[0]})
+            expcm.updateParams({"beta": beta[0]})
             return expcm.Qxy[x][y]
 
         def func_dQxy(beta, expcm, x, y):
-            expcm.updateParams({'beta': beta[0]})
+            expcm.updateParams({"beta": beta[0]})
             return expcm.dQxy_dbeta[x][y]
 
         for x in random.sample(range(N_CODON), 3):
             for y in range(N_CODON):
-                diff = scipy.optimize.check_grad(func_Qxy, func_dQxy,
-                                                 [self.model.beta],
-                                                 self.model, x, y,
-                                                 epsilon=1e-4)
-                self.assertTrue(diff < 1e-4,
-                                "dQxy_dbeta diff {0} for x = {1}, y = {2}"
-                                .format(diff, x, y))
+                diff = scipy.optimize.check_grad(
+                    func_Qxy,
+                    func_dQxy,
+                    [self.model.beta],
+                    self.model,
+                    x,
+                    y,
+                    epsilon=1e-4,
+                )
+                self.assertTrue(
+                    diff < 1e-4,
+                    "dQxy_dbeta diff {0} for x = {1}, y = {2}".format(diff, x, y),
+                )
         # back to original value
         self.model.updateParams(self.params)
 
@@ -219,35 +245,31 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
         # make sure Prxy has rows summing to zero
         self.assertFalse(numpy.isnan(self.model.Prxy).any())
         self.assertFalse(numpy.isinf(self.model.Prxy).any())
-        diag = numpy.eye(N_CODON, dtype='bool')
+        diag = numpy.eye(N_CODON, dtype="bool")
         for r in range(self.nsites):
-            self.assertTrue(numpy.allclose(0,
-                                           numpy.sum(self.model.Prxy[r], axis=1
-                                                     )))
-            self.assertTrue(numpy.allclose(0,
-                                           self.model.Prxy[r].sum()
-                                           ))
+            self.assertTrue(numpy.allclose(0, numpy.sum(self.model.Prxy[r], axis=1)))
+            self.assertTrue(numpy.allclose(0, self.model.Prxy[r].sum()))
             self.assertTrue((self.model.Prxy[r][diag] <= 0).all())
             self.assertTrue((self.model.Prxy[r][~diag] >= 0).all())
 
         # make sure prx sums to 1 for each r
         self.assertTrue((self.model.prx >= 0).all())
         for r in range(self.nsites):
-            self.assertTrue(numpy.allclose(1,
-                                           self.model.prx[r].sum()
-                                           ))
+            self.assertTrue(numpy.allclose(1, self.model.prx[r].sum()))
 
         # prx is eigenvector or Prxy for the same r, but not different r
         for r in range(self.nsites):
-            self.assertTrue(numpy.allclose(0,
-                                           numpy.dot(self.model.prx[r],
-                                                     self.model.Prxy[r])))
+            self.assertTrue(
+                numpy.allclose(0, numpy.dot(self.model.prx[r], self.model.Prxy[r]))
+            )
             if r > 0:
-                (self
-                 .assertFalse(numpy.allclose(0,
-                                             numpy.dot(self.model.prx[r],
-                                                       self.model.Prxy[r - 1])
-                                             )))
+                (
+                    self.assertFalse(
+                        numpy.allclose(
+                            0, numpy.dot(self.model.prx[r], self.model.Prxy[r - 1])
+                        )
+                    )
+                )
 
         # phi sums to one
         self.assertTrue(numpy.allclose(1, self.model.phi.sum()))
@@ -274,41 +296,55 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
             return expcm.dPrxy[paramname][r][x][y]
 
         for (pname, pvalue) in sorted(self.params.items())[::-1]:
-            if pname == 'mu':
+            if pname == "mu":
                 continue
             if isinstance(pvalue, float):
                 pvalue = [pvalue]
             for r in random.sample(range(self.nsites), 2):  # check a few sites
                 for x in random.sample(range(N_CODON), 3):  # check a few codon
                     for y in range(N_CODON):
-                        diff = (scipy.optimize
-                                .check_grad(funcPrxy, funcdPrxy, pvalue,
-                                            pname, self.model, r, x, y,
-                                            epsilon=1e-4))
-                        (self
-                         .assertTrue(diff < 1e-3,
-                                     "diff {0} for {1}: r = {2}, x = {3}, "
-                                     "y = {4}, beta = {5} pirAx = {6}, "
-                                     "pirAy = {7}, mu = {8}, omega = {9}, "
-                                     "Frxy = {10}, Prxy = {11}, phi = {12}, "
-                                     "kappa = {13}, dQxy_dbeta = {14}, "
-                                     "dphi_dbeta = {15}, dPrxy_dbeta = {16}, "
-                                     "piAx_piAy_beta[r][x][y] = {17}"
-                                     .format(diff, pname, r, x, y,
-                                             self.params['beta'],
-                                             self.model.pi_codon[r][x],
-                                             self.model.pi_codon[r][y],
-                                             self.model.mu,
-                                             self.model.omega,
-                                             self.model.Frxy[r][x][y],
-                                             self.model.Prxy[r][x][y],
-                                             self.model.phi,
-                                             self.model.kappa,
-                                             self.model.dQxy_dbeta[x][y],
-                                             self.model.dphi_dbeta,
-                                             self.model.dPrxy['beta'][r][x][y],
-                                             self.model.piAx_piAy_beta[r][x][y]
-                                             )))
+                        diff = scipy.optimize.check_grad(
+                            funcPrxy,
+                            funcdPrxy,
+                            pvalue,
+                            pname,
+                            self.model,
+                            r,
+                            x,
+                            y,
+                            epsilon=1e-4,
+                        )
+                        (
+                            self.assertTrue(
+                                diff < 1e-3,
+                                "diff {0} for {1}: r = {2}, x = {3}, "
+                                "y = {4}, beta = {5} pirAx = {6}, "
+                                "pirAy = {7}, mu = {8}, omega = {9}, "
+                                "Frxy = {10}, Prxy = {11}, phi = {12}, "
+                                "kappa = {13}, dQxy_dbeta = {14}, "
+                                "dphi_dbeta = {15}, dPrxy_dbeta = {16}, "
+                                "piAx_piAy_beta[r][x][y] = {17}".format(
+                                    diff,
+                                    pname,
+                                    r,
+                                    x,
+                                    y,
+                                    self.params["beta"],
+                                    self.model.pi_codon[r][x],
+                                    self.model.pi_codon[r][y],
+                                    self.model.mu,
+                                    self.model.omega,
+                                    self.model.Frxy[r][x][y],
+                                    self.model.Prxy[r][x][y],
+                                    self.model.phi,
+                                    self.model.kappa,
+                                    self.model.dQxy_dbeta[x][y],
+                                    self.model.dphi_dbeta,
+                                    self.model.dPrxy["beta"][r][x][y],
+                                    self.model.piAx_piAy_beta[r][x][y],
+                                ),
+                            )
+                        )
             # back to original value
             self.model.updateParams(self.params)
 
@@ -316,23 +352,21 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
         """Makes sure matrix exponentials are as expected."""
         for r in range(self.nsites):
             # fromdiag is recomputed Prxy after diagonalization
-            fromdiag = numpy.dot(self.model.A[r],
-                                 numpy.dot(numpy.diag(self.model.D[r]),
-                                           self.model.Ainv[r]))
-            self.assertTrue(numpy.allclose(self.model.Prxy[r],
-                                           fromdiag,
-                                           atol=1e-5),
-                            "Max diff {0}".format(
-                    (self.model.Prxy[r] - fromdiag).max()))
+            fromdiag = numpy.dot(
+                self.model.A[r],
+                numpy.dot(numpy.diag(self.model.D[r]), self.model.Ainv[r]),
+            )
+            self.assertTrue(
+                numpy.allclose(self.model.Prxy[r], fromdiag, atol=1e-5),
+                "Max diff {0}".format((self.model.Prxy[r] - fromdiag).max()),
+            )
 
             for t in [0.02, 0.2, 0.5]:
-                direct = scipy.linalg.expm(self.model.Prxy[r] *
-                                           self.model.mu * t)
-                self.assertTrue(numpy.allclose(self.model.M(t)[r],
-                                direct,
-                                atol=1e-6),
-                                "Max diff {0}".format((self.model.M(t)[r] -
-                                                       direct).max()))
+                direct = scipy.linalg.expm(self.model.Prxy[r] * self.model.mu * t)
+                self.assertTrue(
+                    numpy.allclose(self.model.M(t)[r], direct, atol=1e-6),
+                    "Max diff {0}".format((self.model.M(t)[r] - direct).max()),
+                )
         # check derivatives of M calculated by dM
         # implementation looks a bit complex because `check_grad` function
         # can only be used for single values at a time, so have to loop
@@ -340,7 +374,7 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
 
         def funcM(paramvalue, paramname, t, expcm, r, x, y, storedvalues):
             """Gets `M(t)[r][x][y]`."""
-            key = ('M', tuple(paramvalue), paramname, t)
+            key = ("M", tuple(paramvalue), paramname, t)
             if key not in storedvalues:
                 if len(paramvalue) == 1:
                     expcm.updateParams({paramname: paramvalue[0]})
@@ -354,7 +388,7 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
 
         def funcdM(paramvalue, paramname, t, expcm, r, x, y, storedvalues):
             """Gets `dM`."""
-            key = ('dM', tuple(paramvalue), paramname, t)
+            key = ("dM", tuple(paramvalue), paramname, t)
             if key not in storedvalues:
                 if len(paramvalue) == 1:
                     expcm.updateParams({paramname: paramvalue[0]})
@@ -365,6 +399,7 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
                 return storedvalues[key][r][x][y]
             else:
                 return storedvalues[key][:, r, x, y]
+
         for (pname, pvalue) in sorted(self.params.items()):
             storedvalues = {}  # used to hash values
             if isinstance(pvalue, float):
@@ -375,30 +410,47 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
                         for y in range(N_CODON):
                             if x == y:
                                 continue
-                            diff = (scipy.optimize
-                                    .check_grad(funcM, funcdM, pvalue, pname,
-                                                t, self.model, r,
-                                                x, y, storedvalues,
-                                                epsilon=1e-4))
-                            (self
-                             .assertTrue(diff < 1e-3,
-                                         "diff {0} for {1}: "
-                                         "computed derivative = {10}, "
-                                         "r = {2}, x = {3}, y = {4}, "
-                                         "beta = {5}, pirAx = {6}, "
-                                         "pirAy = {7}, t = {8}, mu = {9}"
-                                         .format(diff, pname, r, x, y,
-                                                 self.params['beta'],
-                                                 self.model.pi_codon[r][x],
-                                                 self.model.pi_codon[r][y],
-                                                 t, self.model.mu,
-                                                 funcdM(pvalue, pname, t,
-                                                        self.model, r, x, y,
-                                                        {}))))
+                            diff = scipy.optimize.check_grad(
+                                funcM,
+                                funcdM,
+                                pvalue,
+                                pname,
+                                t,
+                                self.model,
+                                r,
+                                x,
+                                y,
+                                storedvalues,
+                                epsilon=1e-4,
+                            )
+                            (
+                                self.assertTrue(
+                                    diff < 1e-3,
+                                    "diff {0} for {1}: "
+                                    "computed derivative = {10}, "
+                                    "r = {2}, x = {3}, y = {4}, "
+                                    "beta = {5}, pirAx = {6}, "
+                                    "pirAy = {7}, t = {8}, mu = {9}".format(
+                                        diff,
+                                        pname,
+                                        r,
+                                        x,
+                                        y,
+                                        self.params["beta"],
+                                        self.model.pi_codon[r][x],
+                                        self.model.pi_codon[r][y],
+                                        t,
+                                        self.model.mu,
+                                        funcdM(
+                                            pvalue, pname, t, self.model, r, x, y, {}
+                                        ),
+                                    ),
+                                )
+                            )
                 # back to original value
                 self.model.updateParams(self.params)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     runner = unittest.TextTestRunner()
     unittest.main(testRunner=runner)

--- a/tests/test_expcm_divpressure.py
+++ b/tests/test_expcm_divpressure.py
@@ -58,37 +58,28 @@ class test_compare_ExpCM_emp_phi_with_without_divpress(unittest.TestCase):
         self.assertTrue(numpy.allclose(expcm.Qxy, expcm_divpressure.Qxy),
                         "Qxy differs")
         self.assertTrue(
-            numpy.allclose(expcm.Frxy, expcm_divpressure.Frxy), "Frxy differs"
-        )
+            numpy.allclose(expcm.Frxy, expcm_divpressure.Frxy), "Frxy differs")
         self.assertTrue(
-            numpy.allclose(expcm.Prxy, expcm_divpressure.Prxy), "Prxy differs"
-        )
+            numpy.allclose(expcm.Prxy, expcm_divpressure.Prxy), "Prxy differs")
         t = 0.02
         self.assertTrue(
             numpy.allclose(expcm.M(t), expcm_divpressure.M(t)),
-            "M({0}) differs".format(t),
-        )
+            "M({0}) differs".format(t))
         for param in ["kappa", "omega", "beta"]:
             self.assertTrue(
                 numpy.allclose(
-                    getattr(expcm, param), getattr(expcm_divpressure, param)
-                ),
-                "param values differ for {0}".format(param),
-            )
+                    getattr(expcm, param), getattr(expcm_divpressure, param)),
+                "param values differ for {0}".format(param))
             self.assertTrue(
                 numpy.allclose(
                     expcm.dstationarystate(param),
-                    (expcm_divpressure.dstationarystate(param)),
-                ),
-                "dstationarystate differs for {0}".format(param),
-            )
+                    (expcm_divpressure.dstationarystate(param))),
+                "dstationarystate differs for {0}".format(param))
             self.assertTrue(
                 numpy.allclose(
                     expcm.dM(t, param, expcm.M(t)),
-                    (expcm_divpressure.dM(t, param, expcm_divpressure.M(t))),
-                ),
-                "dM({0}) differs for {1}".format(t, param),
-            )
+                    (expcm_divpressure.dM(t, param, expcm_divpressure.M(t)))),
+                "dM({0}) differs for {1}".format(t, param))
 
 
 class testExpCM_empirical_phi_divpressure(unittest.TestCase):
@@ -122,8 +113,7 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
             omega=omega,
             kappa=kappa,
             beta=beta,
-            omega2=omega2,
-        )
+            omega2=omega2)
         # now check ExpCM attributes / derivates, updating several times
         for _update in range(2):
             self.params = {
@@ -234,8 +224,7 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
                 self.assertTrue(
                     diff < 1e-4,
                     "dQxy_dbeta diff {0} for x = {1}, y = {2}"
-                    .format(diff, x, y),
-                )
+                    .format(diff, x, y))
         # back to original value
         self.model.updateParams(self.params)
 
@@ -309,39 +298,25 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
                             r,
                             x,
                             y,
-                            epsilon=1e-4,
-                        )
-                        (
-                            self.assertTrue(
-                                diff < 1e-3,
-                                "diff {0} for {1}: r = {2}, x = {3}, "
-                                "y = {4}, beta = {5} pirAx = {6}, "
-                                "pirAy = {7}, mu = {8}, omega = {9}, "
-                                "Frxy = {10}, Prxy = {11}, phi = {12}, "
-                                "kappa = {13}, dQxy_dbeta = {14}, "
-                                "dphi_dbeta = {15}, dPrxy_dbeta = {16}, "
-                                "piAx_piAy_beta[r][x][y] = {17}".format(
-                                    diff,
-                                    pname,
-                                    r,
-                                    x,
-                                    y,
-                                    self.params["beta"],
-                                    self.model.pi_codon[r][x],
-                                    self.model.pi_codon[r][y],
-                                    self.model.mu,
-                                    self.model.omega,
-                                    self.model.Frxy[r][x][y],
-                                    self.model.Prxy[r][x][y],
-                                    self.model.phi,
-                                    self.model.kappa,
-                                    self.model.dQxy_dbeta[x][y],
-                                    self.model.dphi_dbeta,
-                                    self.model.dPrxy["beta"][r][x][y],
-                                    self.model.piAx_piAy_beta[r][x][y],
-                                ),
-                            )
-                        )
+                            epsilon=1e-4,)
+                        (self.assertTrue(
+                            diff < 1e-3,
+                            f"diff {diff} for {pname}: r = {r}, x = {x}, "
+                            f"y = {y}, beta = {self.params['beta']} "
+                            f"pirAx = {self.model.pi_codon[r][x]}, "
+                            f"pirAy = {self.model.pi_codon[r][y]}, "
+                            f"mu = {self.model.mu}, "
+                            f"omega = {self.model.omega}, "
+                            f"Frxy = {self.model.Frxy[r][x][y]}, "
+                            f"Prxy = {self.model.Prxy[r][x][y]}, "
+                            f"phi = {self.model.phi}, "
+                            f"kappa = {self.model.kappa}, "
+                            f"dQxy_dbeta = {self.model.dQxy_dbeta[x][y]}, "
+                            f"dphi_dbeta = {self.model.dphi_dbeta}, "
+                            f"dPrxy_dbeta = "
+                            f"{self.model.dPrxy["beta"][r][x][y]}, "
+                            f"piAx_piAy_beta[r][x][y] = "
+                            f"{self.model.piAx_piAy_beta[r][x][y]}"))
             # back to original value
             self.model.updateParams(self.params)
 
@@ -351,20 +326,17 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
             # fromdiag is recomputed Prxy after diagonalization
             fromdiag = numpy.dot(
                 self.model.A[r],
-                numpy.dot(numpy.diag(self.model.D[r]), self.model.Ainv[r]),
-            )
+                numpy.dot(numpy.diag(self.model.D[r]), self.model.Ainv[r]))
             self.assertTrue(
                 numpy.allclose(self.model.Prxy[r], fromdiag, atol=1e-5),
-                "Max diff {0}".format((self.model.Prxy[r] - fromdiag).max()),
-            )
+                "Max diff {0}".format((self.model.Prxy[r] - fromdiag).max()))
 
             for t in [0.02, 0.2, 0.5]:
                 direct = scipy.linalg.expm(self.model.Prxy[r] *
                                            self.model.mu * t)
                 self.assertTrue(
                     numpy.allclose(self.model.M(t)[r], direct, atol=1e-6),
-                    "Max diff {0}".format((self.model.M(t)[r] - direct).max()),
-                )
+                    "Max diff {0}".format((self.model.M(t)[r] - direct).max()))
         # check derivatives of M calculated by dM
         # implementation looks a bit complex because `check_grad` function
         # can only be used for single values at a time, so have to loop
@@ -419,28 +391,17 @@ class testExpCM_empirical_phi_divpressure(unittest.TestCase):
                                 x,
                                 y,
                                 storedvalues,
-                                epsilon=1e-4,
-                            )
-                            (
-                                self.assertTrue(
-                                    diff < 1e-3,
-                                    "diff {0} for {1}: "
-                                    "computed derivative = {10}, "
-                                    "r = {2}, x = {3}, y = {4}, "
-                                    "beta = {5}, pirAx = {6}, "
-                                    "pirAy = {7}, t = {8}, mu = {9}".format(
-                                        diff,
-                                        pname,
-                                        r,
-                                        x,
-                                        y,
-                                        self.params["beta"],
-                                        self.model.pi_codon[r][x],
-                                        self.model.pi_codon[r][y],
-                                        t,
-                                        self.model.mu,
-                                        funcdM(pvalue, pname, t, self.model,
-                                               r, x, y, {}))))
+                                epsilon=1e-4,)
+                            (self.assertTrue(
+                                diff < 1e-3,
+                                f"diff {diff} for {pname}: computed "
+                                f"derivative = {funcdM(pvalue, pname, t,\
+                                                self.model,r, x, y, {})}, "
+                                f"r = {r}, x = {x}, y = {u}, beta = "
+                                f"{self.params['beta']}, pirAx = "
+                                f"{self.model.pi_codon[r][x]}, pirAy = "
+                                f"{self.model.pi_codon[r][y]}, t = {t}, "
+                                f"mu = {self.model.mu}"))
                 # back to original value
                 self.model.updateParams(self.params)
 

--- a/tests/test_expcm_empirical_phi.py
+++ b/tests/test_expcm_empirical_phi.py
@@ -9,15 +9,15 @@ import unittest
 import numpy
 import scipy.linalg
 import scipy.optimize
-import sympy
-from phydmslib.constants import *
+from phydmslib.constants import (N_CODON, N_NT, CODON_NT_COUNT,
+                                 AA_TO_INDEX, N_AA)
 import phydmslib.models
 
 
 class testExpCM_empirical_phi(unittest.TestCase):
 
     def test_ExpCM_empirical_phi(self):
-        """Initialize `ExpCM_empirical_phi`, test values, update, test again."""
+        """Initialize `ExpCM_empirical_phi`, test, update, test again."""
 
         # create preferences
         random.seed(1)
@@ -36,17 +36,18 @@ class testExpCM_empirical_phi(unittest.TestCase):
         omega = 0.7
         kappa = 2.5
         beta = 1.2
-        self.expcm = phydmslib.models.ExpCM_empirical_phi(self.prefs,
-                g=g, omega=omega, kappa=kappa, beta=beta)
+        self.expcm = (phydmslib.models
+                      .ExpCM_empirical_phi(self.prefs, g=g, omega=omega,
+                                           kappa=kappa, beta=beta))
         self.assertTrue(numpy.allclose(g, self.expcm.g))
 
         # now check ExpCM attributes / derivates, updating several times
         for update in range(2):
-            self.params = {'omega':random.uniform(0.1, 2),
-                      'kappa':random.uniform(0.5, 10),
-                      'beta':random.uniform(0.5, 5),
-                      'mu':random.uniform(0.05, 5.0),
-                     }
+            self.params = {'omega': random.uniform(0.1, 2),
+                           'kappa': random.uniform(0.5, 10),
+                           'beta': random.uniform(0.5, 5),
+                           'mu': random.uniform(0.05, 5.0),
+                           }
             self.expcm.updateParams(self.params)
             self.assertTrue(numpy.allclose(g, self.expcm.g))
             self.check_empirical_phi()
@@ -67,63 +68,66 @@ class testExpCM_empirical_phi(unittest.TestCase):
         nt_freqs = numpy.array(nt_freqs)
         nt_freqs /= nt_freqs.sum()
         self.assertTrue(numpy.allclose(nt_freqs, self.expcm.g, atol=1e-5),
-                "Actual nt_freqs: {0}\nExpected (g): {1}".format(
-                nt_freqs, self.expcm.g))
+                        "Actual nt_freqs: {0}\nExpected (g): {1}"
+                        .format(nt_freqs, self.expcm.g))
 
         def func_phi(beta, expcm, w):
-            expcm.updateParams({'beta':beta[0]})
+            expcm.updateParams({'beta': beta[0]})
             return expcm.phi[w]
 
         def func_dphi(beta, expcm, w):
-            expcm.updateParams({'beta':beta[0]})
+            expcm.updateParams({'beta': beta[0]})
             return expcm.dphi_dbeta[w]
 
         for w in range(N_NT):
             diff = scipy.optimize.check_grad(func_phi, func_dphi,
-                    [self.expcm.beta], self.expcm, w, epsilon=1e-4)
+                                             [self.expcm.beta],
+                                             self.expcm, w, epsilon=1e-4)
             self.assertTrue(diff < 1e-4,
-                    "dphi_dbeta diff {0} for w = {1}".format(diff, w))
-        self.expcm.updateParams(self.params) # back to original value
+                            "dphi_dbeta diff {0} for w = {1}".format(diff, w))
+        self.expcm.updateParams(self.params)  # back to original value
 
     def check_dprx_dbeta(self):
         """Checks derivatives of `prx` with respect to `beta`."""
 
         def func_prx(beta, expcm, r, x):
-            expcm.updateParams({'beta':beta[0]})
+            expcm.updateParams({'beta': beta[0]})
             return expcm.prx[r][x]
 
         def func_dprx(beta, expcm, r, x):
-            expcm.updateParams({'beta':beta[0]})
+            expcm.updateParams({'beta': beta[0]})
             return expcm.dprx['beta'][r][x]
 
         for r in range(self.nsites):
             for x in range(N_CODON):
                 diff = scipy.optimize.check_grad(func_prx, func_dprx,
-                        [self.expcm.beta], self.expcm, r, x, epsilon=1e-4)
+                                                 [self.expcm.beta], self.expcm,
+                                                 r, x, epsilon=1e-4)
                 self.assertTrue(diff < 1e-4,
-                        "dprx_dbeta diff {0} for r = {1}, x = {2}".format(
-                        diff, r, x))
-        self.expcm.updateParams(self.params) # back to original value
+                                "dprx_dbeta diff {0} for r = {1}, x = {2}"
+                                .format(diff, r, x))
+        self.expcm.updateParams(self.params)  # back to original value
 
     def check_dQxy_dbeta(self):
         """Checks derivatives of `Qxy` with respect to `beta`."""
 
         def func_Qxy(beta, expcm, x, y):
-            expcm.updateParams({'beta':beta[0]})
+            expcm.updateParams({'beta': beta[0]})
             return expcm.Qxy[x][y]
 
         def func_dQxy(beta, expcm, x, y):
-            expcm.updateParams({'beta':beta[0]})
+            expcm.updateParams({'beta': beta[0]})
             return expcm.dQxy_dbeta[x][y]
 
         for x in random.sample(range(N_CODON), 3):
             for y in range(N_CODON):
                 diff = scipy.optimize.check_grad(func_Qxy, func_dQxy,
-                        [self.expcm.beta], self.expcm, x, y, epsilon=1e-4)
+                                                 [self.expcm.beta], self.expcm,
+                                                 x, y, epsilon=1e-4)
                 self.assertTrue(diff < 1e-4,
-                        "dQxy_dbeta diff {0} for x = {1}, y = {2}".format(
-                        diff, x, y))
-        self.expcm.updateParams(self.params) # back to original value
+                                "dQxy_dbeta diff {0} for x = {1}, y = {2}"
+                                .format(diff, x, y))
+        self.expcm.updateParams(self.params)  # back to original value
 
     def check_ExpCM_attributes(self):
         """Make sure has the expected attribute values."""
@@ -135,7 +139,7 @@ class testExpCM_empirical_phi(unittest.TestCase):
         diag = numpy.eye(N_CODON, dtype='bool')
         for r in range(self.nsites):
             self.assertTrue(numpy.allclose(0, numpy.sum(self.expcm.Prxy[r],
-                    axis=1)))
+                            axis=1)))
             self.assertTrue(numpy.allclose(0, self.expcm.Prxy[r].sum()))
             self.assertTrue((self.expcm.Prxy[r][diag] <= 0).all())
             self.assertTrue((self.expcm.Prxy[r][~diag] >= 0).all())
@@ -148,10 +152,10 @@ class testExpCM_empirical_phi(unittest.TestCase):
         # prx is eigenvector or Prxy for the same r, but not different r
         for r in range(self.nsites):
             self.assertTrue(numpy.allclose(0, numpy.dot(self.expcm.prx[r],
-                    self.expcm.Prxy[r])))
+                                           self.expcm.Prxy[r])))
             if r > 0:
                 self.assertFalse(numpy.allclose(0, numpy.dot(self.expcm.prx[r],
-                        self.expcm.Prxy[r - 1])))
+                                                self.expcm.Prxy[r - 1])))
 
         # phi sums to one
         self.assertTrue(numpy.allclose(1, self.expcm.phi.sum()))
@@ -165,16 +169,16 @@ class testExpCM_empirical_phi(unittest.TestCase):
 
         def funcPrxy(paramvalue, paramname, expcm, r, x, y):
             if len(paramvalue) == 1:
-                expcm.updateParams({paramname:paramvalue[0]})
+                expcm.updateParams({paramname: paramvalue[0]})
             else:
-                expcm.updateParams({paramname:paramvalue})
+                expcm.updateParams({paramname: paramvalue})
             return expcm.Prxy[r][x][y]
 
         def funcdPrxy(paramvalue, paramname, expcm, r, x, y):
             if len(paramvalue) == 1:
-                expcm.updateParams({paramname:paramvalue[0]})
+                expcm.updateParams({paramname: paramvalue[0]})
             else:
-                expcm.updateParams({paramname:paramvalue})
+                expcm.updateParams({paramname: paramvalue})
             return expcm.dPrxy[paramname][r][x][y]
 
         for (pname, pvalue) in sorted(self.params.items()):
@@ -182,26 +186,36 @@ class testExpCM_empirical_phi(unittest.TestCase):
                 continue
             if isinstance(pvalue, float):
                 pvalue = [pvalue]
-            for r in random.sample(range(self.nsites), 2): # check a few sites
-                for x in random.sample(range(N_CODON), 3): # check a few codons
+            for r in random.sample(range(self.nsites), 2):  # check a few sites
+                for x in random.sample(range(N_CODON), 3):  # check a few codon
                     for y in range(N_CODON):
                         diff = scipy.optimize.check_grad(funcPrxy, funcdPrxy,
-                                pvalue, pname, self.expcm, r, x, y, epsilon=1e-4)
-                        self.assertTrue(diff < 1e-3, ("diff {0} for {1}:" +
-                                " r = {2}, x = {3}, y = {4}, beta = {5} " +
-                                "pirAx = {6}, pirAy = {7}, mu = {8}, " +
-                                "omega = {9}, Frxy = {10}, Prxy = {11}, " +
-                                "phi = {12}, kappa = {13}, dQxy_dbeta = {14}, " +
-                                "dphi_dbeta = {15}, dPrxy_dbeta = {16}"
-                                ).format(diff, pname, r, x, y,
-                                self.params['beta'], self.expcm.pi_codon[r][x],
-                                self.expcm.pi_codon[r][y], self.expcm.mu,
-                                self.expcm.omega, self.expcm.Frxy[r][x][y],
-                                self.expcm.Prxy[r][x][y], self.expcm.phi,
-                                self.expcm.kappa, self.expcm.dQxy_dbeta[x][y],
-                                self.expcm.dphi_dbeta,
-                                self.expcm.dPrxy['beta'][r][x][y]))
-            self.expcm.updateParams(self.params) # back to original value
+                                                         pvalue, pname,
+                                                         self.expcm, r, x, y,
+                                                         epsilon=1e-4)
+                        (self
+                         .assertTrue(diff < 1e-3,
+                                     "diff {0} for {1}: r = {2}, x = {3}, "
+                                     "y = {4}, beta = {5} pirAx = {6}, "
+                                     "pirAy = {7}, mu = {8}, omega = {9}, "
+                                     "Frxy = {10}, Prxy = {11}, phi = {12}, "
+                                     "kappa = {13}, dQxy_dbeta = {14}, "
+                                     "dphi_dbeta = {15}, dPrxy_dbeta = {16}"
+                                     .format(diff, pname, r, x, y,
+                                             self.params['beta'],
+                                             self.expcm.pi_codon[r][x],
+                                             self.expcm.pi_codon[r][y],
+                                             self.expcm.mu,
+                                             self.expcm.omega,
+                                             self.expcm.Frxy[r][x][y],
+                                             self.expcm.Prxy[r][x][y],
+                                             self.expcm.phi,
+                                             self.expcm.kappa,
+                                             self.expcm.dQxy_dbeta[x][y],
+                                             self.expcm.dphi_dbeta,
+                                             self.expcm.dPrxy['beta'][r][x][y])
+                                     ))
+            self.expcm.updateParams(self.params)  # back to original value
 
     def check_ExpCM_matrix_exponentials(self):
         """Makes sure matrix exponentials are as expected."""
@@ -209,14 +223,21 @@ class testExpCM_empirical_phi(unittest.TestCase):
             # fromdiag is recomputed Prxy after diagonalization
             fromdiag = numpy.dot(self.expcm.A[r], numpy.dot(numpy.diag(
                     self.expcm.D[r]), self.expcm.Ainv[r]))
-            self.assertTrue(numpy.allclose(self.expcm.Prxy[r], fromdiag,
-                    atol=1e-5), "Max diff {0}".format(
-                    (self.expcm.Prxy[r] - fromdiag).max()))
+            self.assertTrue(numpy.allclose(self.expcm.Prxy[r],
+                                           fromdiag,
+                                           atol=1e-5),
+                            "Max diff {0}"
+                            .format((self.expcm.Prxy[r] - fromdiag).max()))
 
             for t in [0.02, 0.2, 0.5]:
-                direct = scipy.linalg.expm(self.expcm.Prxy[r] * self.expcm.mu * t)
-                self.assertTrue(numpy.allclose(self.expcm.M(t)[r], direct, atol=1e-6),
-                        "Max diff {0}".format((self.expcm.M(t)[r] - direct).max()))
+                direct = scipy.linalg.expm(self.expcm.Prxy[r] *
+                                           self.expcm.mu * t)
+                self.assertTrue(numpy.allclose(self.expcm.M(t)[r],
+                                               direct,
+                                               atol=1e-6),
+                                "Max diff {0}"
+                                .format((self.expcm.M(t)[r] - direct).max()))
+
         # check derivatives of M calculated by dM
         # implementation looks a bit complex because `check_grad` function
         # can only be used for single values at a time, so have to loop
@@ -226,29 +247,30 @@ class testExpCM_empirical_phi(unittest.TestCase):
             key = ('M', tuple(paramvalue), paramname, t)
             if key not in storedvalues:
                 if len(paramvalue) == 1:
-                    expcm.updateParams({paramname:paramvalue[0]})
+                    expcm.updateParams({paramname: paramvalue[0]})
                 else:
-                    expcm.updateParams({paramname:paramvalue})
+                    expcm.updateParams({paramname: paramvalue})
                 storedvalues[key] = expcm.M(t)
             if len(storedvalues[key].shape) == 3:
                 return storedvalues[key][r][x][y]
             else:
-                return storedvalues[key][:,r,x,y]
+                return storedvalues[key][:, r, x, y]
+
         def funcdM(paramvalue, paramname, t, expcm, r, x, y, storedvalues):
             """Gets `dM`."""
             key = ('dM', tuple(paramvalue), paramname, t)
             if key not in storedvalues:
                 if len(paramvalue) == 1:
-                    expcm.updateParams({paramname:paramvalue[0]})
+                    expcm.updateParams({paramname: paramvalue[0]})
                 else:
-                    expcm.updateParams({paramname:paramvalue})
+                    expcm.updateParams({paramname: paramvalue})
                 storedvalues[key] = expcm.dM(t, paramname, expcm.M(t))
             if len(storedvalues[key].shape) == 3:
                 return storedvalues[key][r][x][y]
             else:
-                return storedvalues[key][:,r,x,y]
+                return storedvalues[key][:, r, x, y]
         for (pname, pvalue) in sorted(self.params.items()):
-            storedvalues = {} # used to hash values
+            storedvalues = {}  # used to hash values
             if isinstance(pvalue, float):
                 pvalue = [pvalue]
             for t in [0.01, 0.2]:
@@ -257,20 +279,28 @@ class testExpCM_empirical_phi(unittest.TestCase):
                         for y in range(N_CODON):
                             if x == y:
                                 continue
-                            diff = scipy.optimize.check_grad(funcM, funcdM, pvalue,
-                                    pname, t, self.expcm, r, x, y, storedvalues,
-                                    epsilon=1e-4)
-                            self.assertTrue(diff < 1e-3, ("diff {0} for {1}:" +
-                                " computed derivative = {10}, " +
-                                " r = {2}, x = {3}, y = {4}, beta = {5}, " +
-                                "pirAx = {6}, pirAy = {7}, t = {8}, mu = {9}"
-                                ).format(diff, pname, r, x, y,
-                                self.params['beta'], self.expcm.pi_codon[r][x],
-                                self.expcm.pi_codon[r][y], t, self.expcm.mu,
-                                funcdM(pvalue, pname, t, self.expcm,
-                                r, x, y, {})))
-                self.expcm.updateParams(self.params) # back to original value
-
+                            diff = scipy.optimize.check_grad(funcM, funcdM,
+                                                             pvalue, pname, t,
+                                                             self.expcm, r, x,
+                                                             y, storedvalues,
+                                                             epsilon=1e-4)
+                            (self
+                             .assertTrue(diff < 1e-3,
+                                         "diff {0} for {1}:"
+                                         " computed derivative = {10}, "
+                                         " r = {2}, x = {3}, y = {4}, "
+                                         "beta = {5}, pirAx = {6}, "
+                                         "pirAy = {7}, t = {8}, mu = {9}"
+                                         .format(diff, pname, r, x, y,
+                                                 self.params['beta'],
+                                                 self.expcm.pi_codon[r][x],
+                                                 self.expcm.pi_codon[r][y],
+                                                 t,
+                                                 self.expcm.mu,
+                                                 funcdM(pvalue, pname, t,
+                                                        self.expcm, r, x, y,
+                                                        {}))))
+                self.expcm.updateParams(self.params)  # back to original value
 
 
 if __name__ == '__main__':

--- a/tests/test_expcm_empirical_phi.py
+++ b/tests/test_expcm_empirical_phi.py
@@ -15,17 +15,17 @@ import phydmslib.models
 
 
 class testExpCM_empirical_phi(unittest.TestCase):
+    """Tests ``ExpCM`` with empirical phi."""
 
     def test_ExpCM_empirical_phi(self):
         """Initialize `ExpCM_empirical_phi`, test, update, test again."""
-
         # create preferences
         random.seed(1)
         numpy.random.seed(1)
         self.nsites = 7
         self.prefs = []
         minpref = 0.01
-        for r in range(self.nsites):
+        for _r in range(self.nsites):
             rprefs = numpy.random.dirichlet([0.5] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
@@ -42,7 +42,7 @@ class testExpCM_empirical_phi(unittest.TestCase):
         self.assertTrue(numpy.allclose(g, self.expcm.g))
 
         # now check ExpCM attributes / derivates, updating several times
-        for update in range(2):
+        for _update in range(2):
             self.params = {'omega': random.uniform(0.1, 2),
                            'kappa': random.uniform(0.5, 10),
                            'beta': random.uniform(0.5, 5),

--- a/tests/test_expcm_fitprefs.py
+++ b/tests/test_expcm_fitprefs.py
@@ -69,10 +69,9 @@ class test_ExpCM_fitprefs(unittest.TestCase):
                     # check Prxy values
                     if values[pirAx] == values[pirAy]:
                         if CODON_TO_AA[x] == CODON_TO_AA[y]:
-                            (self
-                             .assertTrue(numpy.allclose(Qxy,
-                                                        (expcm_fitprefs
-                                                         .Prxy[r][x][y]))))
+                            (self.assertTrue(numpy.allclose(Qxy,
+                                                            (expcm_fitprefs
+                                                             .Prxy[r][x][y]))))
                         else:
                             (self
                              .assertTrue(numpy.allclose(Qxy * values[omega],

--- a/tests/test_expcm_fitprefs.py
+++ b/tests/test_expcm_fitprefs.py
@@ -1,6 +1,7 @@
 """Tests `ExpCM` with fitting of preferences as free parameters.
 
-Written by Jesse Bloom."""
+Written by Jesse Bloom.
+"""
 
 
 import random
@@ -35,7 +36,7 @@ class test_ExpCM_fitprefs(unittest.TestCase):
                         ((1 - (pirAx / pirAy)**beta)**2))
         dFrxy_dpirAy_equal = omega * beta / (2 * pirAy)
         diffpref = 1.0e-5
-        for itest in range(5):
+        for _itest in range(5):
             values = [[beta, 1],
                       [pirAx, random.uniform(0.01, 0.5)],
                       [pirAy, random.uniform(0.01, 0.5)],
@@ -125,7 +126,7 @@ class test_ExpCM_fitprefs(unittest.TestCase):
         nsites = 1
         minpref = 0.001
         self.prefs = []
-        for r in range(nsites):
+        for _r in range(nsites):
             rprefs = numpy.random.dirichlet([0.7] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs[0] = rprefs[1] + 1.0e-8  # near equal prefs handled OK

--- a/tests/test_expcm_fitprefs.py
+++ b/tests/test_expcm_fitprefs.py
@@ -37,8 +37,7 @@ class test_ExpCM_fitprefs(unittest.TestCase):
         dFrxy_dpirAy_equal = omega * beta / (2 * pirAy)
         diffpref = 1.0e-5
         for _itest in range(5):
-            values = [[beta, 1],
-                      [pirAx, random.uniform(0.01, 0.5)],
+            values = [[beta, 1], [pirAx, random.uniform(0.01, 0.5)],
                       [pirAy, random.uniform(0.01, 0.5)],
                       [omega, random.uniform(0.1, 2.0)]]
             self.assertTrue(abs(values[1][1] - values[2][1]) > diffpref,

--- a/tests/test_expcm_fitprefs.py
+++ b/tests/test_expcm_fitprefs.py
@@ -197,8 +197,8 @@ class test_ExpCM_fitprefs(unittest.TestCase):
                                                 expcm_fitprefs.origpi))
                 if self.MODEL == phydmslib.models.ExpCM_fitprefs:
                     self.assertTrue(expcm_fitprefs.pi[r][i] > oldpi[r][i])
-                    self.assertTrue(all([expcm_fitprefs.pi[r][j] <
-                                    oldpi[r][j] for j in range(i + 1, N_AA)]))
+                    self.assertTrue(all((expcm_fitprefs.pi[r][j] <
+                                    oldpi[r][j] for j in range(i + 1, N_AA))))
                 elif self.MODEL == phydmslib.models.ExpCM_fitprefs2:
                     self.assertTrue(expcm_fitprefs.pi[r][i] < oldpi[r][i])
                     zeta[k] *= 2

--- a/tests/test_expcm_fitprefs.py
+++ b/tests/test_expcm_fitprefs.py
@@ -9,7 +9,7 @@ import copy
 import numpy
 import scipy.optimize
 import sympy
-from phydmslib.constants import *
+from phydmslib.constants import CODON_TO_AA, N_CODON, N_AA, AA_TO_INDEX, N_NT
 import phydmslib.models
 
 
@@ -23,16 +23,17 @@ class test_ExpCM_fitprefs(unittest.TestCase):
         random.seed(1)
         numpy.random.seed(1)
         omega, beta, pirAx, pirAy = sympy.symbols('omega beta pirAx pirAy')
-        Frxy = omega * -beta * sympy.ln(pirAx / pirAy) / (1 -
-                (pirAx / pirAy)**beta)
-        dFrxy_dpirAx = (-omega * beta / pirAx) * ((pirAx / pirAy)**beta * (
-                sympy.ln((pirAx / pirAy)**beta) - 1) + 1) / ((1 -
-                (pirAx / pirAy)**beta)**2)
-        dFrxy_dpirAx_prefsequal = -omega * beta / (2 * pirAx)
-        dFrxy_dpirAy = (omega * beta / pirAy) * ((pirAx / pirAy)**beta * (
-                sympy.ln((pirAx / pirAy)**beta) - 1) + 1) / ((1 -
-                (pirAx / pirAy)**beta)**2)
-        dFrxy_dpirAy_prefsequal = omega * beta / (2 * pirAy)
+        Frxy = (omega * -beta * sympy.ln(pirAx / pirAy) /
+                (1 - (pirAx / pirAy)**beta))
+        dFrxy_dpirAx = ((-omega * beta / pirAx) *
+                        ((pirAx / pirAy)**beta *
+                        (sympy.ln((pirAx / pirAy)**beta) - 1) + 1) /
+                        ((1 - (pirAx / pirAy)**beta)**2))
+        dFrxy_dpirAx_equal = -omega * beta / (2 * pirAx)
+        dFrxy_dpirAy = ((omega * beta / pirAy) * ((pirAx / pirAy)**beta *
+                        (sympy.ln((pirAx / pirAy)**beta) - 1) + 1) /
+                        ((1 - (pirAx / pirAy)**beta)**2))
+        dFrxy_dpirAy_equal = omega * beta / (2 * pirAy)
         diffpref = 1.0e-5
         for itest in range(5):
             values = [[beta, 1],
@@ -40,16 +41,16 @@ class test_ExpCM_fitprefs(unittest.TestCase):
                       [pirAy, random.uniform(0.01, 0.5)],
                       [omega, random.uniform(0.1, 2.0)]]
             self.assertTrue(abs(values[1][1] - values[2][1]) > diffpref,
-                    "choose another random number seed as pirAx and pirAy "
-                    "are too close.")
+                            "choose another random number seed as pirAx and "
+                            "pirAy are too close.")
             self.assertTrue(numpy.allclose(float(dFrxy_dpirAx.subs(values)),
-                    float(sympy.diff(Frxy, pirAx).subs(values))))
+                            float(sympy.diff(Frxy, pirAx).subs(values))))
             self.assertTrue(numpy.allclose(float(dFrxy_dpirAy.subs(values)),
-                    float(sympy.diff(Frxy, pirAy).subs(values))))
+                            float(sympy.diff(Frxy, pirAy).subs(values))))
             values[2][1] = values[1][1] * (1 + diffpref)
-            self.assertTrue(numpy.allclose(float(dFrxy_dpirAx_prefsequal.subs(
+            self.assertTrue(numpy.allclose(float(dFrxy_dpirAx_equal.subs(
                     values)), float(sympy.diff(Frxy, pirAx).subs(values))))
-            self.assertTrue(numpy.allclose(float(dFrxy_dpirAy_prefsequal.subs(
+            self.assertTrue(numpy.allclose(float(dFrxy_dpirAy_equal.subs(
                     values)), float(sympy.diff(Frxy, pirAy).subs(values))))
 
         expcm_fitprefs = copy.deepcopy(self.expcm_fitprefs)
@@ -68,11 +69,15 @@ class test_ExpCM_fitprefs(unittest.TestCase):
                     # check Prxy values
                     if values[pirAx] == values[pirAy]:
                         if CODON_TO_AA[x] == CODON_TO_AA[y]:
-                            self.assertTrue(numpy.allclose(Qxy,
-                                    expcm_fitprefs.Prxy[r][x][y]))
+                            (self
+                             .assertTrue(numpy.allclose(Qxy,
+                                                        (expcm_fitprefs
+                                                         .Prxy[r][x][y]))))
                         else:
-                            self.assertTrue(numpy.allclose(Qxy * values[omega],
-                                    expcm_fitprefs.Prxy[r][x][y]))
+                            (self
+                             .assertTrue(numpy.allclose(Qxy * values[omega],
+                                                        (expcm_fitprefs
+                                                        .Prxy[r][x][y]))))
                     else:
                         self.assertTrue(numpy.allclose(Qxy * float(Frxy.subs(
                             values.items())), expcm_fitprefs.Prxy[r][x][y]))
@@ -80,21 +85,27 @@ class test_ExpCM_fitprefs(unittest.TestCase):
                     # check dFrxy_dpi
                     if values[pirAx] == values[pirAy]:
                         if CODON_TO_AA[x] == CODON_TO_AA[y]:
-                            self.assertTrue(numpy.allclose(0,
-                                    -expcm_fitprefs.tildeFrxy[r][x][y] /
-                                    values[pirAx]))
-                            self.assertTrue(numpy.allclose(0,
-                                    -expcm_fitprefs.tildeFrxy[r][x][y] /
-                                    values[pirAy]))
+                            (self
+                             .assertTrue(numpy.allclose(0,
+                                                        (-expcm_fitprefs
+                                                         .tildeFrxy[r][x][y]) /
+                                                        values[pirAx])))
+                            (self
+                             .assertTrue(numpy.allclose(0,
+                                                        (-expcm_fitprefs
+                                                         .tildeFrxy[r][x][y]) /
+                                                        values[pirAy])))
                         else:
+                            (self
+                             .assertTrue((numpy
+                                          .allclose(float(dFrxy_dpirAx_equal
+                                                          .subs(values.items())
+                                                          ), (-expcm_fitprefs
+                                                    .tildeFrxy[r][x][y]) /
+                                                    values[pirAx]))))
                             self.assertTrue(numpy.allclose(
-                                    float(dFrxy_dpirAx_prefsequal.subs(
-                                    values.items())),
-                                    -expcm_fitprefs.tildeFrxy[r][x][y] /
-                                    values[pirAx]))
-                            self.assertTrue(numpy.allclose(
-                                    float(dFrxy_dpirAy_prefsequal.subs(
-                                    values.items())),
+                                    float(dFrxy_dpirAy_equal
+                                          .subs(values.items())),
                                     expcm_fitprefs.tildeFrxy[r][x][y] /
                                     values[pirAy]))
                     else:
@@ -117,26 +128,26 @@ class test_ExpCM_fitprefs(unittest.TestCase):
         for r in range(nsites):
             rprefs = numpy.random.dirichlet([0.7] * N_AA)
             rprefs[rprefs < minpref] = minpref
-            rprefs[0] = rprefs[1] + 1.0e-8 # ensure near equal prefs handled OK
+            rprefs[0] = rprefs[1] + 1.0e-8  # near equal prefs handled OK
             rprefs /= rprefs.sum()
             self.prefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))
         self.expcm_fitprefs = self.MODEL(self.prefs,
-                prior=None, kappa=3.0, omega=0.3,
-                phi=numpy.random.dirichlet([5] * N_NT))
+                                         prior=None, kappa=3.0, omega=0.3,
+                                         phi=numpy.random.dirichlet([5] * N_NT)
+                                         )
         assert len(self.expcm_fitprefs.zeta.flatten()) == nsites * (N_AA - 1)
         assert self.expcm_fitprefs.nsites == nsites
-
 
     def test_origbeta(self):
         """Test `origbeta` parameter."""
         for origbeta in [0.8, 1.0, 1.2]:
             expcm_fitprefs2 = self.MODEL(self.prefs,
-                    prior=None,
-                    kappa=self.expcm_fitprefs.kappa,
-                    omega=self.expcm_fitprefs.omega,
-                    mu=self.expcm_fitprefs.mu,
-                    phi=self.expcm_fitprefs.phi,
-                    origbeta=origbeta)
+                                         prior=None,
+                                         kappa=self.expcm_fitprefs.kappa,
+                                         omega=self.expcm_fitprefs.omega,
+                                         mu=self.expcm_fitprefs.mu,
+                                         phi=self.expcm_fitprefs.phi,
+                                         origbeta=origbeta)
             zeta = self.expcm_fitprefs.zeta
             zeta2 = expcm_fitprefs2.zeta
             pi = self.expcm_fitprefs.zeta
@@ -155,12 +166,11 @@ class test_ExpCM_fitprefs(unittest.TestCase):
                         elif origbeta == 1:
                             self.assertTrue((pix == pix2) and (piy == piy2))
                         elif piy > pix:
-                            self.assertTrue((origbeta > 1) == (piy2 / pix2 >
-                                    piy / pix))
+                            self.assertTrue((origbeta > 1) ==
+                                            (piy2 / pix2 > piy / pix))
                         else:
-                            self.assertTrue((origbeta > 1) == (piy2 / pix2 <
-                                    piy / pix))
-
+                            self.assertTrue((origbeta > 1) ==
+                                            (piy2 / pix2 < piy / pix))
 
     def test_zeta_updates(self):
         """Test updating `zeta`."""
@@ -169,7 +179,8 @@ class test_ExpCM_fitprefs(unittest.TestCase):
 
         expcm_fitprefs = copy.deepcopy(self.expcm_fitprefs)
 
-        self.assertTrue(numpy.allclose(expcm_fitprefs.pi, expcm_fitprefs.origpi))
+        self.assertTrue(numpy.allclose(expcm_fitprefs.pi,
+                                       expcm_fitprefs.origpi))
         k = 0
         for r in range(expcm_fitprefs.nsites):
             for i in range(N_AA - 1):
@@ -177,20 +188,20 @@ class test_ExpCM_fitprefs(unittest.TestCase):
                 oldpi = expcm_fitprefs.pi.copy()
                 zeta = oldzeta.copy()
                 zeta[k] *= 0.9
-                expcm_fitprefs.updateParams({'zeta':zeta})
+                expcm_fitprefs.updateParams({'zeta': zeta})
                 self.assertFalse(numpy.allclose(oldzeta, expcm_fitprefs.zeta))
                 self.assertFalse(numpy.allclose(oldpi[r],
-                        expcm_fitprefs.pi[r]))
+                                 expcm_fitprefs.pi[r]))
                 self.assertFalse(numpy.allclose(expcm_fitprefs.pi,
-                        expcm_fitprefs.origpi))
+                                                expcm_fitprefs.origpi))
                 if self.MODEL == phydmslib.models.ExpCM_fitprefs:
                     self.assertTrue(expcm_fitprefs.pi[r][i] > oldpi[r][i])
                     self.assertTrue(all([expcm_fitprefs.pi[r][j] <
-                            oldpi[r][j] for j in range(i + 1, N_AA)]))
+                                    oldpi[r][j] for j in range(i + 1, N_AA)]))
                 elif self.MODEL == phydmslib.models.ExpCM_fitprefs2:
                     self.assertTrue(expcm_fitprefs.pi[r][i] < oldpi[r][i])
                     zeta[k] *= 2
-                    expcm_fitprefs.updateParams({'zeta':zeta})
+                    expcm_fitprefs.updateParams({'zeta': zeta})
                     self.assertTrue(expcm_fitprefs.pi[r][i] > oldpi[r][i])
                 k += 1
 
@@ -204,13 +215,13 @@ class test_ExpCM_fitprefs(unittest.TestCase):
         def func(zetari, i, r, x):
             zeta = expcm_fitprefs.zeta.copy()
             zeta.reshape(nsites, N_AA - 1)[r][i] = zetari
-            expcm_fitprefs.updateParams({'zeta':zeta})
+            expcm_fitprefs.updateParams({'zeta': zeta})
             return expcm_fitprefs.prx[r][x]
 
         def dfunc(zetari, i, r, x):
             zeta = expcm_fitprefs.zeta.copy()
             zeta.reshape(nsites, N_AA - 1)[r][i] = zetari
-            expcm_fitprefs.updateParams({'zeta':zeta})
+            expcm_fitprefs.updateParams({'zeta': zeta})
             return expcm_fitprefs.dprx['zeta'][i + r * (N_AA - 1)][r][x]
 
         j = 0
@@ -220,13 +231,13 @@ class test_ExpCM_fitprefs(unittest.TestCase):
                         nsites, N_AA - 1)[r][i]])
                 for x in range(N_CODON):
                     diff = scipy.optimize.check_grad(func, dfunc,
-                            zetari, i, r, x)
+                                                     zetari, i, r, x)
                     deriv = dfunc(zetari, i, r, x)
                     self.assertTrue(diff < max(1e-4, 1e-5 * abs(deriv)),
-                            "{0}, {1}, {2}, {3}, {4}, {5}, {6}".format(
-                            diff, zetari, i, r, x, CODON_TO_AA[x], deriv))
+                                    "{0}, {1}, {2}, {3}, {4}, {5}, {6}"
+                                    .format(diff, zetari, i, r, x,
+                                            CODON_TO_AA[x], deriv))
                 j += 1
-
 
     def test_dPrxy_dzeta(self):
         """Test `dPrxy['zeta']`."""
@@ -238,13 +249,13 @@ class test_ExpCM_fitprefs(unittest.TestCase):
         def func(zetari, i, r, x, y):
             zeta = expcm_fitprefs.zeta.copy()
             zeta.reshape(nsites, N_AA - 1)[r][i] = zetari
-            expcm_fitprefs.updateParams({'zeta':zeta})
+            expcm_fitprefs.updateParams({'zeta': zeta})
             return expcm_fitprefs.Prxy[r][x][y]
 
         def dfunc(zetari, i, r, x, y):
             zeta = expcm_fitprefs.zeta.copy()
             zeta.reshape(nsites, N_AA - 1)[r][i] = zetari
-            expcm_fitprefs.updateParams({'zeta':zeta})
+            expcm_fitprefs.updateParams({'zeta': zeta})
             return expcm_fitprefs.dPrxy['zeta'][i + r * (N_AA - 1)][r][x][y]
 
         j = 0
@@ -257,12 +268,14 @@ class test_ExpCM_fitprefs(unittest.TestCase):
                         if x == y:
                             continue
                         diff = scipy.optimize.check_grad(func, dfunc,
-                                zetari, i, r, x, y)
+                                                         zetari, i, r, x, y)
                         deriv = expcm_fitprefs.dPrxy['zeta'][j][r][x][y]
                         self.assertTrue(diff < max(1e-4, 1e-5 * abs(deriv)),
-                                "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}".format(
-                                diff, zetari, i, r, x, y, CODON_TO_AA[x],
-                                CODON_TO_AA[y], deriv))
+                                        "{0}, {1}, {2}, {3}, {4}, {5}, {6}, "
+                                        "{7}, {8}"
+                                        .format(diff, zetari, i, r, x, y,
+                                                CODON_TO_AA[x], CODON_TO_AA[y],
+                                                deriv))
                 j += 1
 
     def test_dM_dzeta(self):
@@ -275,13 +288,13 @@ class test_ExpCM_fitprefs(unittest.TestCase):
         def func(zetari, i, r, x, y, t):
             zeta = expcm_fitprefs.zeta.copy()
             zeta.reshape(nsites, N_AA - 1)[r][i] = zetari
-            expcm_fitprefs.updateParams({'zeta':zeta})
+            expcm_fitprefs.updateParams({'zeta': zeta})
             return expcm_fitprefs.M(t)[r][x][y]
 
         def dfunc(zetari, i, r, x, y, t):
             zeta = expcm_fitprefs.zeta.copy()
             zeta.reshape(nsites, N_AA - 1)[r][i] = zetari
-            expcm_fitprefs.updateParams({'zeta':zeta})
+            expcm_fitprefs.updateParams({'zeta': zeta})
             j = i + r * (N_AA - 1)
             return expcm_fitprefs.dM(t, 'zeta', None)[j][r][x][y]
 
@@ -295,19 +308,23 @@ class test_ExpCM_fitprefs(unittest.TestCase):
                             continue
                         for t in [0.1, 0.5]:
                             diff = scipy.optimize.check_grad(func, dfunc,
-                                    zetari, i, r, x, y, t)
+                                                             zetari, i, r, x,
+                                                             y, t)
                             deriv = dfunc(zetari, i, r, x, y, t)
-                            self.assertTrue(diff < max(0.02, 1e-4 * abs(deriv)),
-                                    "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, "
-                                    "{8}, {9}".format(
-                                    diff, zetari, i, r, x, y, CODON_TO_AA[x],
-                                    CODON_TO_AA[y], deriv, t))
+                            self.assertTrue(diff < max(0.02,
+                                                       1e-4 * abs(deriv)),
+                                            "{0}, {1}, {2}, {3}, {4}, {5}, "
+                                            "{6}, {7}, {8}, {9}"
+                                            .format(diff, zetari, i, r, x, y,
+                                                    CODON_TO_AA[x],
+                                                    CODON_TO_AA[y], deriv, t))
 
 
 class test_ExpCM_fitprefs2(test_ExpCM_fitprefs):
     """Test `ExpCM_fitprefs2`."""
 
     MODEL = phydmslib.models.ExpCM_fitprefs2
+
 
 if __name__ == '__main__':
     runner = unittest.TextTestRunner()

--- a/tests/test_expcm_fitprefs_invquadraticprior.py
+++ b/tests/test_expcm_fitprefs_invquadraticprior.py
@@ -1,6 +1,7 @@
 """Tests invquadratic prior in `ExpCM_fitprefs`.
 
-Written by Jesse Bloom."""
+Written by Jesse Bloom.
+"""
 
 
 import random
@@ -25,7 +26,7 @@ class test_fitprefs_invquadraticprior(unittest.TestCase):
         nsites = 1
         minpref = 0.001
         self.prefs = []
-        for r in range(nsites):
+        for _r in range(nsites):
             rprefs = numpy.random.dirichlet([0.7] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs[0] = rprefs[1] + 1.0e-8  # near equal prefs handled OK

--- a/tests/test_expcm_fitprefs_invquadraticprior.py
+++ b/tests/test_expcm_fitprefs_invquadraticprior.py
@@ -9,11 +9,11 @@ import copy
 import numpy
 import scipy.optimize
 import sympy
-from phydmslib.constants import *
+from phydmslib.constants import N_AA, N_NT, AA_TO_INDEX
 import phydmslib.models
 
 
-class test_ExpCM_fitprefs_invquadraticprior(unittest.TestCase):
+class test_fitprefs_invquadraticprior(unittest.TestCase):
     """Test `ExpCM_fitprefs` with inverse quadratic prior."""
 
     MODEL = phydmslib.models.ExpCM_fitprefs
@@ -28,15 +28,16 @@ class test_ExpCM_fitprefs_invquadraticprior(unittest.TestCase):
         for r in range(nsites):
             rprefs = numpy.random.dirichlet([0.7] * N_AA)
             rprefs[rprefs < minpref] = minpref
-            rprefs[0] = rprefs[1] + 1.0e-8 # ensure near equal prefs handled OK
+            rprefs[0] = rprefs[1] + 1.0e-8  # near equal prefs handled OK
             rprefs /= rprefs.sum()
             self.prefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))
         self.expcm_fitprefs = self.MODEL(self.prefs,
-                prior=('invquadratic', 150.0, 0.5), kappa=3.0, omega=0.3,
-                phi=numpy.random.dirichlet([5] * N_NT))
+                                         prior=('invquadratic', 150.0, 0.5),
+                                         kappa=3.0, omega=0.3,
+                                         phi=numpy.random.dirichlet([5] * N_NT)
+                                         )
         assert len(self.expcm_fitprefs.zeta.flatten()) == nsites * (N_AA - 1)
         assert self.expcm_fitprefs.nsites == nsites
-
 
     def test_deriv(self):
         """Test analytical expression for derivative."""
@@ -44,38 +45,42 @@ class test_ExpCM_fitprefs_invquadraticprior(unittest.TestCase):
         lnpr = sympy.ln((1 / (1 + c1 * (pi - theta)**2))**c2)
         deriv = -2 * c1 * c2 * (pi - theta) / (1 + c1 * (pi - theta)**2)
         values = [(c1, 150), (c2, 0.5), (pi, 0.3), (theta, 0.421)]
-        self.assertTrue(numpy.allclose(
-                float(deriv.subs(values)), float(sympy.diff(lnpr, pi).subs(values))))
-
+        self.assertTrue(numpy.allclose(float(deriv.subs(values)),
+                                       float(sympy.diff(lnpr, pi).subs(values))
+                                       ))
 
     def test_dlogprior(self):
         """Test `dlogprior`."""
         numpy.random.seed(1)
 
         expcm_fitprefs = copy.deepcopy(self.expcm_fitprefs)
-        self.assertTrue(numpy.allclose(expcm_fitprefs.pi, expcm_fitprefs.origpi))
+        self.assertTrue(numpy.allclose(expcm_fitprefs.pi,
+                                       expcm_fitprefs.origpi))
         if self.MODEL == phydmslib.models.ExpCM_fitprefs:
-            newzeta = expcm_fitprefs.zeta.copy() * numpy.random.uniform(0.9, 1.0,
-                    expcm_fitprefs.zeta.shape)
+            newzeta = (expcm_fitprefs.zeta.copy() *
+                       numpy.random.uniform(0.9, 1.0,
+                                            expcm_fitprefs.zeta.shape))
         elif self.MODEL == phydmslib.models.ExpCM_fitprefs2:
-            newzeta = expcm_fitprefs.zeta.copy() * numpy.random.uniform(0.01, 10.0,
-                    expcm_fitprefs.zeta.shape)
+            newzeta = (expcm_fitprefs.zeta.copy() *
+                       numpy.random.uniform(0.01, 10.0,
+                                            expcm_fitprefs.zeta.shape))
         else:
             raise RuntimeError("invalid MODEL: {0}".format(self.MODEL))
-        expcm_fitprefs.updateParams({'zeta':newzeta})
-        self.assertFalse(numpy.allclose(expcm_fitprefs.pi, expcm_fitprefs.origpi))
+        expcm_fitprefs.updateParams({'zeta': newzeta})
+        self.assertFalse(numpy.allclose(expcm_fitprefs.pi,
+                                        expcm_fitprefs.origpi))
         nsites = expcm_fitprefs.nsites
 
         def func(zetari, i, r):
             zeta = expcm_fitprefs.zeta.copy()
             zeta.reshape(nsites, N_AA - 1)[r][i] = zetari
-            expcm_fitprefs.updateParams({'zeta':zeta})
+            expcm_fitprefs.updateParams({'zeta': zeta})
             return expcm_fitprefs.logprior
 
         def dfunc(zetari, i, r):
             zeta = expcm_fitprefs.zeta.copy()
             zeta.reshape(nsites, N_AA - 1)[r][i] = zetari
-            expcm_fitprefs.updateParams({'zeta':zeta})
+            expcm_fitprefs.updateParams({'zeta': zeta})
             return expcm_fitprefs.dlogprior('zeta')[i + r * (N_AA - 1)]
 
         j = 0
@@ -86,12 +91,12 @@ class test_ExpCM_fitprefs_invquadraticprior(unittest.TestCase):
                 diff = scipy.optimize.check_grad(func, dfunc, zetari, i, r)
                 deriv = dfunc(zetari, i, r)
                 self.assertTrue(diff < max(1e-5, 1e-5 * abs(deriv)),
-                        "{0}, {1}, {2}, {3}, {4}".format(
-                        diff, zetari, i, r, deriv))
+                                "{0}, {1}, {2}, {3}, {4}"
+                                .format(diff, zetari, i, r, deriv))
                 j += 1
 
 
-class test_ExpCM_fitprefs2_invquadraticprior(test_ExpCM_fitprefs_invquadraticprior):
+class test_fitprefs2_invquadraticprior(test_fitprefs_invquadraticprior):
     """Test `ExpCM_fitprefs2` with inverse quadratic prior."""
 
     MODEL = phydmslib.models.ExpCM_fitprefs2

--- a/tests/test_gammadistributedbeta_model.py
+++ b/tests/test_gammadistributedbeta_model.py
@@ -21,7 +21,6 @@ class test_GammaBeta_ExpCM(unittest.TestCase):
 
     def test_GammaDistributedBeta(self):
         """Initialize, test values, update, test again."""
-
         random.seed(1)
         numpy.random.seed(1)
         nsites = 10
@@ -29,7 +28,7 @@ class test_GammaBeta_ExpCM(unittest.TestCase):
         # create preference set
         prefs = []
         minpref = 0.01
-        for r in range(nsites):
+        for _r in range(nsites):
             rprefs = numpy.random.dirichlet([0.5] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()

--- a/tests/test_gammadistributedbeta_model.py
+++ b/tests/test_gammadistributedbeta_model.py
@@ -8,11 +8,11 @@ import random
 import unittest
 import numpy
 import scipy.optimize
-from phydmslib.constants import *
+from phydmslib.constants import N_AA, N_NT, AA_TO_INDEX
 import phydmslib.models
 
 
-class test_GammaDistributedBeta_ExpCM(unittest.TestCase):
+class test_GammaBeta_ExpCM(unittest.TestCase):
     """Test gamma distributed beta for `ExpCM`."""
 
     # use approach here to run multiple tests:
@@ -37,29 +37,31 @@ class test_GammaDistributedBeta_ExpCM(unittest.TestCase):
 
         if self.BASEMODEL == phydmslib.models.ExpCM:
             paramvalues = {
-                    'eta':numpy.random.dirichlet([5] * (N_NT - 1)),
-                    'omega':0.7,
-                    'kappa':2.5,
-                    'beta':1.2,
-                    'mu':0.5,
-                    }
+                "eta": numpy.random.dirichlet([5] * (N_NT - 1)),
+                "omega": 0.7,
+                "kappa": 2.5,
+                "beta": 1.2,
+                "mu": 0.5,
+            }
             basemodel = self.BASEMODEL(prefs)
-            assert set(paramvalues.keys()) == set(basemodel.freeparams), (
-                    "{0} vs {1}".format(set(paramvalues.keys()),
-                    set(basemodel.freeparams)))
+            assert set(paramvalues.keys()) == set(
+                basemodel.freeparams
+            ), "{0} vs {1}".format(set(paramvalues.keys()),
+                                   set(basemodel.freeparams))
             basemodel.updateParams(paramvalues)
         elif self.BASEMODEL == phydmslib.models.ExpCM_empirical_phi:
             g = numpy.random.dirichlet([3] * N_NT)
             paramvalues = {
-                    'omega':0.7,
-                    'kappa':2.5,
-                    'beta':1.2,
-                    'mu':0.5,
-                    }
+                "omega": 0.7,
+                "kappa": 2.5,
+                "beta": 1.2,
+                "mu": 0.5,
+            }
             basemodel = self.BASEMODEL(prefs, g)
-            assert set(paramvalues.keys()) == set(basemodel.freeparams), (
-                    "{0} vs {1}".format(set(paramvalues.keys()),
-                    set(basemodel.freeparams)))
+            assert set(paramvalues.keys()) == set(
+                basemodel.freeparams
+            ), "{0} vs {1}".format(set(paramvalues.keys()),
+                                   set(basemodel.freeparams))
             basemodel.updateParams(paramvalues)
         else:
             raise ValueError("Invalid BASEMODEL: {0}".format(self.BASEMODEL))
@@ -68,15 +70,21 @@ class test_GammaDistributedBeta_ExpCM(unittest.TestCase):
 
         ncats = 4
         gammamodel = phydmslib.models.GammaDistributedBetaModel(basemodel,
-                ncats)
-        self.assertTrue(numpy.allclose(numpy.array([m.beta for m in
-                gammamodel._models]), phydmslib.models.DiscreteGamma(
-                gammamodel.alpha_lambda, gammamodel.beta_lambda,
-                gammamodel.ncats)))
+                                                                ncats)
+        self.assertTrue(
+            numpy.allclose(
+                numpy.array([m.beta for m in gammamodel._models]),
+                phydmslib.models.DiscreteGamma(
+                    gammamodel.alpha_lambda,
+                    gammamodel.beta_lambda,
+                    gammamodel.ncats
+                ),
+            )
+        )
         for (param, pvalue) in paramvalues.items():
             if param != gammamodel.distributedparam:
                 self.assertTrue(numpy.allclose(getattr(gammamodel, param),
-                        pvalue))
+                                               pvalue))
 
         # try some updates and make sure everything remains OK
         for i in range(3):
@@ -87,26 +95,39 @@ class test_GammaDistributedBeta_ExpCM(unittest.TestCase):
                     newvalues[param] = random.uniform(low, high)
                 else:
                     paramlength = gammamodel.PARAMTYPES[param][1]
-                    newvalues[param] = numpy.random.uniform(
-                            low, high, paramlength)
+                    newvalues[param] = numpy.random.uniform(low, high,
+                                                            paramlength)
             gammamodel.updateParams(newvalues)
-            self.assertTrue(numpy.allclose(numpy.array([m.beta for m in
-                    gammamodel._models]), phydmslib.models.DiscreteGamma(
-                    gammamodel.alpha_lambda, gammamodel.beta_lambda,
-                    gammamodel.ncats)))
+            self.assertTrue(
+                numpy.allclose(
+                    numpy.array([m.beta for m in gammamodel._models]),
+                    phydmslib.models.DiscreteGamma(
+                        gammamodel.alpha_lambda,
+                        gammamodel.beta_lambda,
+                        gammamodel.ncats,
+                    ),
+                )
+            )
             for (param, pvalue) in newvalues.items():
                 if param != gammamodel.distributedparam:
                     self.assertTrue(numpy.allclose(pvalue,
-                            getattr(gammamodel, param)))
+                                                   getattr(gammamodel, param)))
                     if param not in gammamodel.distributionparams:
-                        self.assertTrue(all([numpy.allclose(pvalue,
-                                getattr(m, param)) for m in
-                                gammamodel._models]))
+                        self.assertTrue(
+                            all(
+                                [
+                                    numpy.allclose(pvalue, getattr(m, param))
+                                    for m in gammamodel._models
+                                ]
+                            )
+                        )
 
             # This is the opposite test of gammaomega
-            self.assertTrue(gammamodel._models[0].branchScale >
-                    gammamodel.branchScale >
-                    gammamodel._models[-1].branchScale)
+            self.assertTrue(
+                gammamodel._models[0].branchScale
+                > gammamodel.branchScale
+                > gammamodel._models[-1].branchScale
+            )
 
             t = 0.15
             for k in range(gammamodel.ncats):
@@ -115,54 +136,85 @@ class test_GammaDistributedBeta_ExpCM(unittest.TestCase):
                 for param in gammamodel.freeparams:
                     if param not in gammamodel.distributionparams:
                         dM = gammamodel.dM(k, t, param, M)
-                        self.assertTrue(numpy.allclose(dM,
-                                gammamodel._models[k].dM(t, param, Mt=None)))
+                        self.assertTrue(
+                            numpy.allclose(
+                                dM, gammamodel._models[k].dM(t, param, Mt=None)
+                            )
+                        )
 
             # Check derivatives with respect to distribution params
             d_distparams = gammamodel.d_distributionparams
-            self.assertTrue((d_distparams['alpha_lambda'] > 0).all())
-            self.assertTrue((d_distparams['beta_lambda'] < 0).all())
+            self.assertTrue((d_distparams["alpha_lambda"] > 0).all())
+            self.assertTrue((d_distparams["beta_lambda"] < 0).all())
             for param in gammamodel.distributionparams:
                 diffs = []
                 for k in range(gammamodel.ncats):
                     pvalue = getattr(gammamodel, param)
+
                     def func(x):
-                        gammamodel.updateParams({param:x[0]})
-                        return getattr(gammamodel._models[k],
-                                gammamodel.distributedparam)
+                        gammamodel.updateParams({param: x[0]})
+                        return getattr(
+                            gammamodel._models[k], gammamodel.distributedparam
+                        )
+
                     def dfunc(x):
-                        gammamodel.updateParams({param:x[0]})
+                        gammamodel.updateParams({param: x[0]})
                         return gammamodel.d_distributionparams[param][k]
+
                     diff = scipy.optimize.check_grad(func, dfunc,
-                            numpy.array([pvalue]))
-                    gammamodel.updateParams({param:pvalue})
+                                                     numpy.array([pvalue]))
+                    gammamodel.updateParams({param: pvalue})
                     diffs.append(diff)
                 diffs = numpy.array(diffs)
-                self.assertTrue((diffs < 1e-5).all(), ("Excessive diff "
+                self.assertTrue(
+                    (diffs < 1e-5).all(),
+                    (
+                        "Excessive diff "
                         "for d_distributionparams[{0}] when "
                         "distributionparams = {1}:\n{2}".format(
-                        param, gammamodel.distributionparams, diffs)))
+                            param, gammamodel.distributionparams, diffs
+                        )
+                    ),
+                )
 
-            # Check the stationary state and deriviative of the stationary state
+            # Check the stationary state & deriviative of the stationary state
             # Stationary states should be different for each `k`
-            self.assertFalse(all([numpy.allclose(gammamodel.stationarystate(i),
-                    gammamodel.stationarystate(j)) for i in
-                    range(gammamodel.ncats) for j in range(i+1, gammamodel.ncats)]))
+            self.assertFalse(
+                all(
+                    [
+                        numpy.allclose(
+                            gammamodel.stationarystate(i),
+                            gammamodel.stationarystate(j)
+                        )
+                        for i in range(gammamodel.ncats)
+                        for j in range(i + 1, gammamodel.ncats)
+                    ]
+                )
+            )
             # The derviative of the stationary states should be different with
             # respect to beta for each `k`
-            self.assertFalse(all([numpy.allclose(gammamodel.dstationarystate(i, "beta"),
-                    gammamodel.dstationarystate(j, "beta")) for i in
-                    range(gammamodel.ncats) for j in range(i+1, gammamodel.ncats)]))
+            self.assertFalse(
+                all(
+                    [
+                        numpy.allclose(
+                            gammamodel.dstationarystate(i, "beta"),
+                            gammamodel.dstationarystate(j, "beta"),
+                        )
+                        for i in range(gammamodel.ncats)
+                        for j in range(i + 1, gammamodel.ncats)
+                    ]
+                )
+            )
 
 
-
-class test_GammaDistributedBeta_ExpCM_empirical_phi(test_GammaDistributedBeta_ExpCM):
+class test_GammaBeta_ExpCM_empirical_phi(test_GammaBeta_ExpCM):
     """Test gamma distributed beta for `ExpCM_empirical_phi`."""
 
     # use approach here to run multiple tests:
     # http://stackoverflow.com/questions/17260469/instantiate-python-unittest-testcase-with-arguments
     BASEMODEL = phydmslib.models.ExpCM_empirical_phi
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     runner = unittest.TextTestRunner()
     unittest.main(testRunner=runner)

--- a/tests/test_gammadistributedbeta_model.py
+++ b/tests/test_gammadistributedbeta_model.py
@@ -114,10 +114,10 @@ class test_GammaBeta_ExpCM(unittest.TestCase):
                     if param not in gammamodel.distributionparams:
                         self.assertTrue(
                             all(
-                                [
+                                (
                                     numpy.allclose(pvalue, getattr(m, param))
                                     for m in gammamodel._models
-                                ]
+                                )
                             )
                         )
 
@@ -180,28 +180,28 @@ class test_GammaBeta_ExpCM(unittest.TestCase):
             # Stationary states should be different for each `k`
             self.assertFalse(
                 all(
-                    [
+                    (
                         numpy.allclose(
                             gammamodel.stationarystate(i),
                             gammamodel.stationarystate(j)
                         )
                         for i in range(gammamodel.ncats)
                         for j in range(i + 1, gammamodel.ncats)
-                    ]
+                    )
                 )
             )
             # The derviative of the stationary states should be different with
             # respect to beta for each `k`
             self.assertFalse(
                 all(
-                    [
+                    (
                         numpy.allclose(
                             gammamodel.dstationarystate(i, "beta"),
                             gammamodel.dstationarystate(j, "beta"),
                         )
                         for i in range(gammamodel.ncats)
                         for j in range(i + 1, gammamodel.ncats)
-                    ]
+                    )
                 )
             )
 

--- a/tests/test_gammadistributedbeta_model.py
+++ b/tests/test_gammadistributedbeta_model.py
@@ -35,13 +35,11 @@ class test_GammaBeta_ExpCM(unittest.TestCase):
             prefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))
 
         if self.BASEMODEL == phydmslib.models.ExpCM:
-            paramvalues = {
-                "eta": numpy.random.dirichlet([5] * (N_NT - 1)),
-                "omega": 0.7,
-                "kappa": 2.5,
-                "beta": 1.2,
-                "mu": 0.5,
-            }
+            paramvalues = {"eta": numpy.random.dirichlet([5] * (N_NT - 1)),
+                           "omega": 0.7,
+                           "kappa": 2.5,
+                           "beta": 1.2,
+                           "mu": 0.5}
             basemodel = self.BASEMODEL(prefs)
             assert set(paramvalues.keys()) == set(
                 basemodel.freeparams
@@ -50,12 +48,10 @@ class test_GammaBeta_ExpCM(unittest.TestCase):
             basemodel.updateParams(paramvalues)
         elif self.BASEMODEL == phydmslib.models.ExpCM_empirical_phi:
             g = numpy.random.dirichlet([3] * N_NT)
-            paramvalues = {
-                "omega": 0.7,
-                "kappa": 2.5,
-                "beta": 1.2,
-                "mu": 0.5,
-            }
+            paramvalues = {"omega": 0.7,
+                           "kappa": 2.5,
+                           "beta": 1.2,
+                           "mu": 0.5}
             basemodel = self.BASEMODEL(prefs, g)
             assert set(paramvalues.keys()) == set(
                 basemodel.freeparams
@@ -76,10 +72,7 @@ class test_GammaBeta_ExpCM(unittest.TestCase):
                 phydmslib.models.DiscreteGamma(
                     gammamodel.alpha_lambda,
                     gammamodel.beta_lambda,
-                    gammamodel.ncats
-                ),
-            )
-        )
+                    gammamodel.ncats)))
         for (param, pvalue) in paramvalues.items():
             if param != gammamodel.distributedparam:
                 self.assertTrue(numpy.allclose(getattr(gammamodel, param),
@@ -103,30 +96,21 @@ class test_GammaBeta_ExpCM(unittest.TestCase):
                     phydmslib.models.DiscreteGamma(
                         gammamodel.alpha_lambda,
                         gammamodel.beta_lambda,
-                        gammamodel.ncats,
-                    ),
-                )
-            )
+                        gammamodel.ncats)))
             for (param, pvalue) in newvalues.items():
                 if param != gammamodel.distributedparam:
                     self.assertTrue(numpy.allclose(pvalue,
                                                    getattr(gammamodel, param)))
                     if param not in gammamodel.distributionparams:
                         self.assertTrue(
-                            all(
-                                (
-                                    numpy.allclose(pvalue, getattr(m, param))
-                                    for m in gammamodel._models
-                                )
-                            )
-                        )
+                            all((numpy.allclose(pvalue, getattr(m, param))
+                                 for m in gammamodel._models)))
 
             # This is the opposite test of gammaomega
             self.assertTrue(
                 gammamodel._models[0].branchScale
                 > gammamodel.branchScale
-                > gammamodel._models[-1].branchScale
-            )
+                > gammamodel._models[-1].branchScale)
 
             t = 0.15
             for k in range(gammamodel.ncats):
@@ -137,9 +121,8 @@ class test_GammaBeta_ExpCM(unittest.TestCase):
                         dM = gammamodel.dM(k, t, param, M)
                         self.assertTrue(
                             numpy.allclose(
-                                dM, gammamodel._models[k].dM(t, param, Mt=None)
-                            )
-                        )
+                                dM,
+                                gammamodel._models[k].dM(t, param, Mt=None)))
 
             # Check derivatives with respect to distribution params
             d_distparams = gammamodel.d_distributionparams
@@ -152,9 +135,8 @@ class test_GammaBeta_ExpCM(unittest.TestCase):
 
                     def func(x):
                         gammamodel.updateParams({param: x[0]})
-                        return getattr(
-                            gammamodel._models[k], gammamodel.distributedparam
-                        )
+                        return getattr(gammamodel._models[k],
+                                       gammamodel.distributedparam)
 
                     def dfunc(x):
                         gammamodel.updateParams({param: x[0]})
@@ -167,43 +149,25 @@ class test_GammaBeta_ExpCM(unittest.TestCase):
                 diffs = numpy.array(diffs)
                 self.assertTrue(
                     (diffs < 1e-5).all(),
-                    (
-                        "Excessive diff "
-                        "for d_distributionparams[{0}] when "
-                        "distributionparams = {1}:\n{2}".format(
-                            param, gammamodel.distributionparams, diffs
-                        )
-                    ),
-                )
+                    ("Excessive diff for d_distributionparams[{0}] when "
+                     "distributionparams = {1}:\n{2}".format(
+                            param, gammamodel.distributionparams, diffs)))
 
             # Check the stationary state & deriviative of the stationary state
             # Stationary states should be different for each `k`
             self.assertFalse(
-                all(
-                    (
-                        numpy.allclose(
-                            gammamodel.stationarystate(i),
-                            gammamodel.stationarystate(j)
-                        )
-                        for i in range(gammamodel.ncats)
-                        for j in range(i + 1, gammamodel.ncats)
-                    )
-                )
-            )
+                all((numpy.allclose(gammamodel.stationarystate(i),
+                                    gammamodel.stationarystate(j))
+                    for i in range(gammamodel.ncats)
+                    for j in range(i + 1, gammamodel.ncats))))
             # The derviative of the stationary states should be different with
             # respect to beta for each `k`
             self.assertFalse(
                 all(
-                    (
-                        numpy.allclose(
-                            gammamodel.dstationarystate(i, "beta"),
-                            gammamodel.dstationarystate(j, "beta"),
-                        )
-                        for i in range(gammamodel.ncats)
-                        for j in range(i + 1, gammamodel.ncats)
-                    )
-                )
-            )
+                    (numpy.allclose(gammamodel.dstationarystate(i, "beta"),
+                                    gammamodel.dstationarystate(j, "beta"))
+                     for i in range(gammamodel.ncats)
+                     for j in range(i + 1, gammamodel.ncats))))
 
 
 class test_GammaBeta_ExpCM_empirical_phi(test_GammaBeta_ExpCM):

--- a/tests/test_gammadistributedomega_model.py
+++ b/tests/test_gammadistributedomega_model.py
@@ -8,7 +8,7 @@ import random
 import unittest
 import numpy
 import scipy.optimize
-from phydmslib.constants import *
+from phydmslib.constants import N_AA, AA_TO_INDEX, N_NT
 import phydmslib.models
 
 
@@ -35,26 +35,27 @@ class test_GammaDistributedOmega_ExpCM(unittest.TestCase):
                 rprefs /= rprefs.sum()
                 prefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))
             paramvalues = {
-                    'eta':numpy.random.dirichlet([5] * (N_NT - 1)),
-                    'omega':0.7,
-                    'kappa':2.5,
-                    'beta':1.2,
-                    'mu':0.5,
-                    }
+                "eta": numpy.random.dirichlet([5] * (N_NT - 1)),
+                "omega": 0.7,
+                "kappa": 2.5,
+                "beta": 1.2,
+                "mu": 0.5,
+            }
             basemodel = self.BASEMODEL(prefs)
-            assert set(paramvalues.keys()) == set(basemodel.freeparams), (
-                    "{0} vs {1}".format(set(paramvalues.keys()),
-                    set(basemodel.freeparams)))
+            assert set(paramvalues.keys()) == set(
+                basemodel.freeparams
+            ), "{0} vs {1}".format(set(paramvalues.keys()),
+                                   set(basemodel.freeparams))
             basemodel.updateParams(paramvalues)
         elif self.BASEMODEL == phydmslib.models.YNGKP_M0:
             e_pw = numpy.random.uniform(0.4, 0.6, size=(3, N_NT))
             e_pw = e_pw / e_pw.sum(axis=1, keepdims=True)
             basemodel = self.BASEMODEL(e_pw, nsites)
             paramvalues = {
-                        'kappa':2.5,
-                        'omega':0.7,
-                        'mu':0.5,
-                        }
+                "kappa": 2.5,
+                "omega": 0.7,
+                "mu": 0.5,
+            }
             assert set(paramvalues.keys()) == set(basemodel.freeparams)
             basemodel.updateParams(paramvalues)
         else:
@@ -64,15 +65,21 @@ class test_GammaDistributedOmega_ExpCM(unittest.TestCase):
 
         ncats = 4
         gammamodel = phydmslib.models.GammaDistributedOmegaModel(basemodel,
-                ncats)
-        self.assertTrue(numpy.allclose(numpy.array([m.omega for m in
-                gammamodel._models]), phydmslib.models.DiscreteGamma(
-                gammamodel.alpha_lambda, gammamodel.beta_lambda,
-                gammamodel.ncats)))
+                                                                 ncats)
+        self.assertTrue(
+            numpy.allclose(
+                numpy.array([m.omega for m in gammamodel._models]),
+                phydmslib.models.DiscreteGamma(
+                    gammamodel.alpha_lambda,
+                    gammamodel.beta_lambda,
+                    gammamodel.ncats
+                ),
+            )
+        )
         for (param, pvalue) in paramvalues.items():
             if param != gammamodel.distributedparam:
                 self.assertTrue(numpy.allclose(getattr(gammamodel, param),
-                        pvalue))
+                                pvalue))
 
         # try some updates and make sure everything remains OK
         for i in range(3):
@@ -83,25 +90,38 @@ class test_GammaDistributedOmega_ExpCM(unittest.TestCase):
                     newvalues[param] = random.uniform(low, high)
                 else:
                     paramlength = gammamodel.PARAMTYPES[param][1]
-                    newvalues[param] = numpy.random.uniform(
-                            low, high, paramlength)
+                    newvalues[param] = numpy.random.uniform(low, high,
+                                                            paramlength)
             gammamodel.updateParams(newvalues)
-            self.assertTrue(numpy.allclose(numpy.array([m.omega for m in
-                    gammamodel._models]), phydmslib.models.DiscreteGamma(
-                    gammamodel.alpha_lambda, gammamodel.beta_lambda,
-                    gammamodel.ncats)))
+            self.assertTrue(
+                numpy.allclose(
+                    numpy.array([m.omega for m in gammamodel._models]),
+                    phydmslib.models.DiscreteGamma(
+                        gammamodel.alpha_lambda,
+                        gammamodel.beta_lambda,
+                        gammamodel.ncats,
+                    ),
+                )
+            )
             for (param, pvalue) in newvalues.items():
                 if param != gammamodel.distributedparam:
                     self.assertTrue(numpy.allclose(pvalue,
-                            getattr(gammamodel, param)))
+                                                   getattr(gammamodel, param)))
                     if param not in gammamodel.distributionparams:
-                        self.assertTrue(all([numpy.allclose(pvalue,
-                                getattr(m, param)) for m in
-                                gammamodel._models]))
+                        self.assertTrue(
+                            all(
+                                [
+                                    numpy.allclose(pvalue, getattr(m, param))
+                                    for m in gammamodel._models
+                                ]
+                            )
+                        )
 
-            self.assertTrue(gammamodel._models[0].branchScale <
-                    gammamodel.branchScale <
-                    gammamodel._models[-1].branchScale)
+            self.assertTrue(
+                gammamodel._models[0].branchScale
+                < gammamodel.branchScale
+                < gammamodel._models[-1].branchScale
+            )
 
             t = 0.15
             for k in range(gammamodel.ncats):
@@ -110,34 +130,47 @@ class test_GammaDistributedOmega_ExpCM(unittest.TestCase):
                 for param in gammamodel.freeparams:
                     if param not in gammamodel.distributionparams:
                         dM = gammamodel.dM(k, t, param, M)
-                        self.assertTrue(numpy.allclose(dM,
-                                gammamodel._models[k].dM(t, param, Mt=None)))
+                        self.assertTrue(
+                            numpy.allclose(
+                                dM, gammamodel._models[k].dM(t, param, Mt=None)
+                            )
+                        )
 
             # Check derivatives with respect to distribution params
             d_distparams = gammamodel.d_distributionparams
-            self.assertTrue((d_distparams['alpha_lambda'] > 0).all())
-            self.assertTrue((d_distparams['beta_lambda'] < 0).all())
+            self.assertTrue((d_distparams["alpha_lambda"] > 0).all())
+            self.assertTrue((d_distparams["beta_lambda"] < 0).all())
             for param in gammamodel.distributionparams:
                 diffs = []
                 for k in range(gammamodel.ncats):
                     pvalue = getattr(gammamodel, param)
+
                     def func(x):
-                        gammamodel.updateParams({param:x[0]})
-                        return getattr(gammamodel._models[k],
-                                gammamodel.distributedparam)
+                        gammamodel.updateParams({param: x[0]})
+                        return getattr(
+                            gammamodel._models[k], gammamodel.distributedparam
+                        )
+
                     def dfunc(x):
-                        gammamodel.updateParams({param:x[0]})
+                        gammamodel.updateParams({param: x[0]})
                         return gammamodel.d_distributionparams[param][k]
-                    diff = scipy.optimize.check_grad(func, dfunc,
-                            numpy.array([pvalue]))
-                    gammamodel.updateParams({param:pvalue})
+
+                    diff = scipy.optimize.check_grad(func,
+                                                     dfunc,
+                                                     numpy.array([pvalue]))
+                    gammamodel.updateParams({param: pvalue})
                     diffs.append(diff)
                 diffs = numpy.array(diffs)
-                self.assertTrue((diffs < 1e-5).all(), ("Excessive diff "
+                self.assertTrue(
+                    (diffs < 1e-5).all(),
+                    (
+                        "Excessive diff "
                         "for d_distributionparams[{0}] when "
                         "distributionparams = {1}:\n{2}".format(
-                        param, gammamodel.distributionparams, diffs)))
-
+                            param, gammamodel.distributionparams, diffs
+                        )
+                    ),
+                )
 
 
 class test_GammaDistributedOmega_YNGKP_M0(test_GammaDistributedOmega_ExpCM):
@@ -147,6 +180,7 @@ class test_GammaDistributedOmega_YNGKP_M0(test_GammaDistributedOmega_ExpCM):
     # http://stackoverflow.com/questions/17260469/instantiate-python-unittest-testcase-with-arguments
     BASEMODEL = phydmslib.models.YNGKP_M0
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     runner = unittest.TextTestRunner()
     unittest.main(testRunner=runner)

--- a/tests/test_gammadistributedomega_model.py
+++ b/tests/test_gammadistributedomega_model.py
@@ -33,13 +33,11 @@ class test_GammaDistributedOmega_ExpCM(unittest.TestCase):
                 rprefs[rprefs < minpref] = minpref
                 rprefs /= rprefs.sum()
                 prefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))
-            paramvalues = {
-                "eta": numpy.random.dirichlet([5] * (N_NT - 1)),
-                "omega": 0.7,
-                "kappa": 2.5,
-                "beta": 1.2,
-                "mu": 0.5,
-            }
+            paramvalues = {"eta": numpy.random.dirichlet([5] * (N_NT - 1)),
+                           "omega": 0.7,
+                           "kappa": 2.5,
+                           "beta": 1.2,
+                           "mu": 0.5}
             basemodel = self.BASEMODEL(prefs)
             assert set(paramvalues.keys()) == set(
                 basemodel.freeparams
@@ -50,11 +48,7 @@ class test_GammaDistributedOmega_ExpCM(unittest.TestCase):
             e_pw = numpy.random.uniform(0.4, 0.6, size=(3, N_NT))
             e_pw = e_pw / e_pw.sum(axis=1, keepdims=True)
             basemodel = self.BASEMODEL(e_pw, nsites)
-            paramvalues = {
-                "kappa": 2.5,
-                "omega": 0.7,
-                "mu": 0.5,
-            }
+            paramvalues = {"kappa": 2.5, "omega": 0.7, "mu": 0.5}
             assert set(paramvalues.keys()) == set(basemodel.freeparams)
             basemodel.updateParams(paramvalues)
         else:
@@ -71,10 +65,7 @@ class test_GammaDistributedOmega_ExpCM(unittest.TestCase):
                 phydmslib.models.DiscreteGamma(
                     gammamodel.alpha_lambda,
                     gammamodel.beta_lambda,
-                    gammamodel.ncats
-                ),
-            )
-        )
+                    gammamodel.ncats)))
         for (param, pvalue) in paramvalues.items():
             if param != gammamodel.distributedparam:
                 self.assertTrue(numpy.allclose(getattr(gammamodel, param),
@@ -98,10 +89,7 @@ class test_GammaDistributedOmega_ExpCM(unittest.TestCase):
                     phydmslib.models.DiscreteGamma(
                         gammamodel.alpha_lambda,
                         gammamodel.beta_lambda,
-                        gammamodel.ncats,
-                    ),
-                )
-            )
+                        gammamodel.ncats)))
             for (param, pvalue) in newvalues.items():
                 if param != gammamodel.distributedparam:
                     self.assertTrue(numpy.allclose(pvalue,
@@ -115,8 +103,7 @@ class test_GammaDistributedOmega_ExpCM(unittest.TestCase):
             self.assertTrue(
                 gammamodel._models[0].branchScale
                 < gammamodel.branchScale
-                < gammamodel._models[-1].branchScale
-            )
+                < gammamodel._models[-1].branchScale)
 
             t = 0.15
             for k in range(gammamodel.ncats):
@@ -127,9 +114,8 @@ class test_GammaDistributedOmega_ExpCM(unittest.TestCase):
                         dM = gammamodel.dM(k, t, param, M)
                         self.assertTrue(
                             numpy.allclose(
-                                dM, gammamodel._models[k].dM(t, param, Mt=None)
-                            )
-                        )
+                                dM,
+                                gammamodel._models[k].dM(t, param, Mt=None)))
 
             # Check derivatives with respect to distribution params
             d_distparams = gammamodel.d_distributionparams
@@ -142,9 +128,8 @@ class test_GammaDistributedOmega_ExpCM(unittest.TestCase):
 
                     def func(x):
                         gammamodel.updateParams({param: x[0]})
-                        return getattr(
-                            gammamodel._models[k], gammamodel.distributedparam
-                        )
+                        return getattr(gammamodel._models[k],
+                                       gammamodel.distributedparam)
 
                     def dfunc(x):
                         gammamodel.updateParams({param: x[0]})
@@ -162,10 +147,7 @@ class test_GammaDistributedOmega_ExpCM(unittest.TestCase):
                         "Excessive diff "
                         "for d_distributionparams[{0}] when "
                         "distributionparams = {1}:\n{2}".format(
-                            param, gammamodel.distributionparams, diffs
-                        )
-                    ),
-                )
+                            param, gammamodel.distributionparams, diffs)))
 
 
 class test_GammaDistributedOmega_YNGKP_M0(test_GammaDistributedOmega_ExpCM):

--- a/tests/test_gammadistributedomega_model.py
+++ b/tests/test_gammadistributedomega_model.py
@@ -107,14 +107,10 @@ class test_GammaDistributedOmega_ExpCM(unittest.TestCase):
                     self.assertTrue(numpy.allclose(pvalue,
                                                    getattr(gammamodel, param)))
                     if param not in gammamodel.distributionparams:
-                        self.assertTrue(
-                            all(
-                                [
-                                    numpy.allclose(pvalue, getattr(m, param))
-                                    for m in gammamodel._models
-                                ]
-                            )
-                        )
+                        self.assertTrue(all(
+                                            (numpy.allclose(pvalue,
+                                                            getattr(m, param))
+                                             for m in gammamodel._models)))
 
             self.assertTrue(
                 gammamodel._models[0].branchScale

--- a/tests/test_gammadistributedomega_model.py
+++ b/tests/test_gammadistributedomega_model.py
@@ -143,10 +143,8 @@ class test_GammaDistributedOmega_ExpCM(unittest.TestCase):
                 diffs = numpy.array(diffs)
                 self.assertTrue(
                     (diffs < 1e-5).all(),
-                    (
-                        "Excessive diff "
-                        "for d_distributionparams[{0}] when "
-                        "distributionparams = {1}:\n{2}".format(
+                    ("Excessive diff for d_distributionparams[{0}] when "
+                     "distributionparams = {1}:\n{2}".format(
                             param, gammamodel.distributionparams, diffs)))
 
 

--- a/tests/test_gammadistributedomega_model.py
+++ b/tests/test_gammadistributedomega_model.py
@@ -21,7 +21,6 @@ class test_GammaDistributedOmega_ExpCM(unittest.TestCase):
 
     def test_GammaDistributedOmega(self):
         """Initialize, test values, update, test again."""
-
         random.seed(1)
         numpy.random.seed(1)
         nsites = 10
@@ -29,7 +28,7 @@ class test_GammaDistributedOmega_ExpCM(unittest.TestCase):
         if self.BASEMODEL == phydmslib.models.ExpCM:
             prefs = []
             minpref = 0.01
-            for r in range(nsites):
+            for _r in range(nsites):
                 rprefs = numpy.random.dirichlet([0.5] * N_AA)
                 rprefs[rprefs < minpref] = minpref
                 rprefs /= rprefs.sum()
@@ -82,7 +81,7 @@ class test_GammaDistributedOmega_ExpCM(unittest.TestCase):
                                 pvalue))
 
         # try some updates and make sure everything remains OK
-        for i in range(3):
+        for _i in range(3):
             newvalues = {}
             for param in gammamodel.freeparams:
                 (low, high) = gammamodel.PARAMLIMITS[param]

--- a/tests/test_omegabysite.py
+++ b/tests/test_omegabysite.py
@@ -4,7 +4,6 @@ Written by Jesse Bloom.
 """
 
 import os
-import shutil
 import unittest
 import subprocess
 import random
@@ -12,25 +11,37 @@ import pandas
 import phydmslib.file_io
 import phydmslib.models
 import phydmslib.simulate
-from phydmslib.constants import *
+from phydmslib.constants import N_NT
 import pyvolve
+import numpy
 
 
 class test_OmegaBySiteExpCM(unittest.TestCase):
     """Tests ``--omegabysite`` to ``phydms`` for `ExpCM`."""
 
     def setUp(self):
-        self.tree = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './NP_data/NP_tree_short.newick'))
-        self.alignment = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './NP_data/NP_alignment_short.fasta'))
-        self.prefs = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './NP_data/NP_prefs_short.csv'))
-        self.nsites = len(phydmslib.file_io.ReadCodonAlignment(self.alignment,
-                True)[0][1]) // 3
+        self.tree = os.path.abspath(
+            os.path.join(os.path.dirname(__file__),
+                         "./NP_data/NP_tree_short.newick")
+        )
+        self.alignment = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__), "./NP_data/NP_alignment_short.fasta"
+            )
+        )
+        self.prefs = os.path.abspath(
+            os.path.join(os.path.dirname(__file__),
+                         "./NP_data/NP_prefs_short.csv")
+        )
+        self.nsites = (
+            len(phydmslib.file_io.ReadCodonAlignment(self.alignment,
+                                                     True)[0][1]) // 3
+        )
         self.initializeModel()
-        self.outdir = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './omegabysite_test_results/'))
+        self.outdir = os.path.abspath(
+            os.path.join(os.path.dirname(__file__),
+                         "./omegabysite_test_results/")
+        )
         if not os.path.isdir(self.outdir):
             os.mkdir(self.outdir)
 
@@ -40,36 +51,56 @@ class test_OmegaBySiteExpCM(unittest.TestCase):
         # Using beta < 1 partially flattens prefs in simulation
         # Use mu < 1 to get branch lengths about right
         self.model = phydmslib.models.ExpCM(prefs, beta=0.5, mu=0.5)
-        self.modelname = 'ExpCM'
-        self.modelarg = 'ExpCM_{0}'.format(self.prefs)
+        self.modelname = "ExpCM"
+        self.modelarg = "ExpCM_{0}".format(self.prefs)
 
     def test_OnSimulatedData(self):
         random.seed(1)
         divpressuresites = random.sample(range(self.nsites), 5)
-        partitions = phydmslib.simulate.pyvolvePartitions(self.model,
-                (200.0, divpressuresites))
-        evolver = pyvolve.Evolver(partitions=partitions,
-                tree=pyvolve.read_tree(file=self.tree))
+        partitions = phydmslib.simulate.pyvolvePartitions(
+            self.model, (200.0, divpressuresites)
+        )
+        evolver = pyvolve.Evolver(
+            partitions=partitions, tree=pyvolve.read_tree(file=self.tree)
+        )
         simulateprefix = os.path.join(self.outdir, self.modelname)
-        simulatedalignment = simulateprefix + '_simulatedalignment.fasta'
-        info = simulateprefix + '_temp_info.txt'
-        rates = simulateprefix + '_temp_ratefile.txt'
+        simulatedalignment = simulateprefix + "_simulatedalignment.fasta"
+        info = simulateprefix + "_temp_info.txt"
+        rates = simulateprefix + "_temp_ratefile.txt"
         evolver(seqfile=simulatedalignment, infofile=info, ratefile=rates)
-        subprocess.check_call(['phydms', simulatedalignment, self.tree,
-                self.modelarg, simulateprefix, '--omegabysite',
-                '--brlen', 'scale'])
-        omegabysitefile = simulateprefix + '_omegabysite.txt'
-        omegas = pandas.read_csv(omegabysitefile, sep='\t', comment='#')
-        divpressureomegas = omegas[omegas['site'].isin(divpressuresites)]
+        subprocess.check_call(
+            [
+                "phydms",
+                simulatedalignment,
+                self.tree,
+                self.modelarg,
+                simulateprefix,
+                "--omegabysite",
+                "--brlen",
+                "scale",
+            ]
+        )
+        omegabysitefile = simulateprefix + "_omegabysite.txt"
+        omegas = pandas.read_csv(omegabysitefile, sep="\t", comment="#")
+        divpressureomegas = omegas[omegas["site"].isin(divpressuresites)]
         self.assertTrue(len(divpressureomegas) == len(divpressuresites))
-        self.assertTrue((divpressureomegas['omega'].values > 2).all(),
-                "Not all divpressure sites have omega > 2:\n{0}".format(
-                divpressureomegas))
-        self.assertTrue((divpressureomegas['P'].values < 0.08).all(),
-                "Not all divpressure sites have P < 0.08:\n{0}".format(
-                divpressureomegas))
-        nspurious = len(omegas[(omegas['omega'] > 2) & (omegas['P'] < 0.05)
-                & (~omegas['site'].isin(divpressuresites))])
+        self.assertTrue(
+            (divpressureomegas["omega"].values > 2).all(),
+            "Not all divpressure sites have omega > 2:\n{0}"
+            .format(divpressureomegas),
+        )
+        self.assertTrue(
+            (divpressureomegas["P"].values < 0.08).all(),
+            "Not all divpressure sites have P < 0.08:\n{0}"
+            .format(divpressureomegas),
+        )
+        nspurious = len(
+            omegas[
+                (omegas["omega"] > 2)
+                & (omegas["P"] < 0.05)
+                & (~omegas["site"].isin(divpressuresites))
+            ]
+        )
         self.assertTrue(nspurious <= 1, "{0} spurious sites".format(nspurious))
 
         for f in ["custom_matrix_frequencies.txt"]:
@@ -81,13 +112,13 @@ class test_OmegaBySiteYNGKP(test_OmegaBySiteExpCM):
     """Tests ``--omegabysite`` to ``phydms`` for `YNGKP_M0`."""
 
     def initializeModel(self):
-        e_pw = numpy.full((3, N_NT), 1.0 / N_NT, dtype='float')
+        e_pw = numpy.full((3, N_NT), 1.0 / N_NT, dtype="float")
         # mu > 1 leads to longer branches in simulation
         self.model = phydmslib.models.YNGKP_M0(e_pw, self.nsites, mu=4.0)
-        self.modelname = 'YNGKP'
-        self.modelarg = 'YNGKP_M0'
+        self.modelname = "YNGKP"
+        self.modelarg = "YNGKP_M0"
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     runner = unittest.TextTestRunner()
     unittest.main(testRunner=runner)

--- a/tests/test_omegabysite.py
+++ b/tests/test_omegabysite.py
@@ -20,6 +20,7 @@ class test_OmegaBySiteExpCM(unittest.TestCase):
     """Tests ``--omegabysite`` to ``phydms`` for `ExpCM`."""
 
     def setUp(self):
+        """Set up models."""
         self.tree = os.path.abspath(
             os.path.join(os.path.dirname(__file__),
                          "./NP_data/NP_tree_short.newick")
@@ -46,8 +47,9 @@ class test_OmegaBySiteExpCM(unittest.TestCase):
             os.mkdir(self.outdir)
 
     def initializeModel(self):
+        """Init models."""
         prefs = phydmslib.file_io.readPrefs(self.prefs, minpref=0.005)
-        prefs = [prefs[r] for r in sorted(list(prefs.keys()))]
+        prefs = [prefs[r] for r in sorted(prefs.keys())]
         # Using beta < 1 partially flattens prefs in simulation
         # Use mu < 1 to get branch lengths about right
         self.model = phydmslib.models.ExpCM(prefs, beta=0.5, mu=0.5)
@@ -55,6 +57,7 @@ class test_OmegaBySiteExpCM(unittest.TestCase):
         self.modelarg = "ExpCM_{0}".format(self.prefs)
 
     def test_OnSimulatedData(self):
+        """Test on Simulated Data."""
         random.seed(1)
         divpressuresites = random.sample(range(self.nsites), 5)
         partitions = phydmslib.simulate.pyvolvePartitions(
@@ -112,6 +115,7 @@ class test_OmegaBySiteYNGKP(test_OmegaBySiteExpCM):
     """Tests ``--omegabysite`` to ``phydms`` for `YNGKP_M0`."""
 
     def initializeModel(self):
+        """Init model."""
         e_pw = numpy.full((3, N_NT), 1.0 / N_NT, dtype="float")
         # mu > 1 leads to longer branches in simulation
         self.model = phydmslib.models.YNGKP_M0(e_pw, self.nsites, mu=4.0)

--- a/tests/test_omegabysite.py
+++ b/tests/test_omegabysite.py
@@ -23,26 +23,20 @@ class test_OmegaBySiteExpCM(unittest.TestCase):
         """Set up models."""
         self.tree = os.path.abspath(
             os.path.join(os.path.dirname(__file__),
-                         "./NP_data/NP_tree_short.newick")
-        )
+                         "./NP_data/NP_tree_short.newick"))
         self.alignment = os.path.abspath(
-            os.path.join(
-                os.path.dirname(__file__), "./NP_data/NP_alignment_short.fasta"
-            )
-        )
+            os.path.join(os.path.dirname(__file__),
+                         "./NP_data/NP_alignment_short.fasta"))
         self.prefs = os.path.abspath(
             os.path.join(os.path.dirname(__file__),
-                         "./NP_data/NP_prefs_short.csv")
-        )
+                         "./NP_data/NP_prefs_short.csv"))
         self.nsites = (
             len(phydmslib.file_io.ReadCodonAlignment(self.alignment,
-                                                     True)[0][1]) // 3
-        )
+                                                     True)[0][1]) // 3)
         self.initializeModel()
         self.outdir = os.path.abspath(
             os.path.join(os.path.dirname(__file__),
-                         "./omegabysite_test_results/")
-        )
+                         "./omegabysite_test_results/"))
         if not os.path.isdir(self.outdir):
             os.mkdir(self.outdir)
 
@@ -61,28 +55,17 @@ class test_OmegaBySiteExpCM(unittest.TestCase):
         random.seed(1)
         divpressuresites = random.sample(range(self.nsites), 5)
         partitions = phydmslib.simulate.pyvolvePartitions(
-            self.model, (200.0, divpressuresites)
-        )
+            self.model, (200.0, divpressuresites))
         evolver = pyvolve.Evolver(
-            partitions=partitions, tree=pyvolve.read_tree(file=self.tree)
-        )
+            partitions=partitions, tree=pyvolve.read_tree(file=self.tree))
         simulateprefix = os.path.join(self.outdir, self.modelname)
         simulatedalignment = simulateprefix + "_simulatedalignment.fasta"
         info = simulateprefix + "_temp_info.txt"
         rates = simulateprefix + "_temp_ratefile.txt"
         evolver(seqfile=simulatedalignment, infofile=info, ratefile=rates)
-        subprocess.check_call(
-            [
-                "phydms",
-                simulatedalignment,
-                self.tree,
-                self.modelarg,
-                simulateprefix,
-                "--omegabysite",
-                "--brlen",
-                "scale",
-            ]
-        )
+        subprocess.check_call(["phydms", simulatedalignment, self.tree,
+                               self.modelarg, simulateprefix, "--omegabysite",
+                               "--brlen", "scale"])
         omegabysitefile = simulateprefix + "_omegabysite.txt"
         omegas = pandas.read_csv(omegabysitefile, sep="\t", comment="#")
         divpressureomegas = omegas[omegas["site"].isin(divpressuresites)]
@@ -90,20 +73,16 @@ class test_OmegaBySiteExpCM(unittest.TestCase):
         self.assertTrue(
             (divpressureomegas["omega"].values > 2).all(),
             "Not all divpressure sites have omega > 2:\n{0}"
-            .format(divpressureomegas),
-        )
+            .format(divpressureomegas))
         self.assertTrue(
             (divpressureomegas["P"].values < 0.08).all(),
             "Not all divpressure sites have P < 0.08:\n{0}"
-            .format(divpressureomegas),
-        )
+            .format(divpressureomegas))
         nspurious = len(
             omegas[
                 (omegas["omega"] > 2)
                 & (omegas["P"] < 0.05)
-                & (~omegas["site"].isin(divpressuresites))
-            ]
-        )
+                & (~omegas["site"].isin(divpressuresites))])
         self.assertTrue(nspurious <= 1, "{0} spurious sites".format(nspurious))
 
         for f in ["custom_matrix_frequencies.txt"]:

--- a/tests/test_phydms_comprehensive.py
+++ b/tests/test_phydms_comprehensive.py
@@ -19,62 +19,111 @@ class test_phydms_comprehensive(unittest.TestCase):
 
     def test_NP(self):
         """Tests command-line ``phydms_comprehensive`` on NP data."""
-        tree = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './NP_data/NP_tree_short.newick'))
-        alignment = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './NP_data/NP_alignment_short.fasta'))
-        prefs = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './NP_data/NP_prefs_short.csv'))
+        tree = os.path.abspath(
+            os.path.join(os.path.dirname(__file__),
+                         "./NP_data/NP_tree_short.newick")
+        )
+        alignment = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__), "./NP_data/NP_alignment_short.fasta"
+            )
+        )
+        prefs = os.path.abspath(
+            os.path.join(os.path.dirname(__file__),
+                         "./NP_data/NP_prefs_short.csv")
+        )
         for f in [prefs, alignment]:
             self.assertTrue(os.path.isfile(f), "Can't find file {0}".format(f))
-        outprefix = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './NP_test_results/'))
+        outprefix = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "./NP_test_results/")
+        )
         if outprefix[-1] != "/":
             outprefix = "{0}/".format(outprefix)
 
         ncpus = min(20, multiprocessing.cpu_count())
 
-        subprocess.check_call(['phydms_comprehensive', outprefix, alignment,
-                prefs, "--tree", tree, "--omegabysite", '--brlen', 'scale',
-                '--ncpus', str(ncpus)])
+        subprocess.check_call(
+            [
+                "phydms_comprehensive",
+                outprefix,
+                alignment,
+                prefs,
+                "--tree",
+                tree,
+                "--omegabysite",
+                "--brlen",
+                "scale",
+                "--ncpus",
+                str(ncpus),
+            ]
+        )
 
-        expectedresults = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './expected_NP_test_results/'))
+        expectedresults = os.path.abspath(
+            os.path.join(os.path.dirname(__file__),
+                         "./expected_NP_test_results/")
+        )
 
-        models = ['ExpCM_NP_prefs_short', 'averaged_ExpCM_NP_prefs_short', 'YNGKP_M0',
-                'YNGKP_M5']
+        models = [
+            "ExpCM_NP_prefs_short",
+            "averaged_ExpCM_NP_prefs_short",
+            "YNGKP_M0",
+            "YNGKP_M5",
+        ]
 
         for model in models:
             values = {}
-            for (name, prefix) in [('expected', expectedresults), ('actual', outprefix)]:
+            for (name, prefix) in [
+                ("expected", expectedresults),
+                ("actual", outprefix),
+            ]:
                 values[name] = {}
-                for suffix in ['_loglikelihood.txt', '_modelparams.txt']:
-                    fname = os.path.abspath(os.path.join(prefix,
-                            './{0}{1}'.format(model, suffix)))
+                for suffix in ["_loglikelihood.txt", "_modelparams.txt"]:
+                    fname = os.path.abspath(
+                        os.path.join(prefix, "./{0}{1}".format(model, suffix))
+                    )
                     with open(fname) as f:
                         for line in f:
-                            (x, y) = line.split('=')
+                            (x, y) = line.split("=")
                             values[name][x.strip()] = float(y)
-            for param in values['actual'].keys():
-                self.assertTrue(numpy.allclose(values['actual'][param],
-                        values['expected'][param], atol=1e-2, rtol=1e-5))
+            for param in values["actual"].keys():
+                self.assertTrue(
+                    numpy.allclose(
+                        values["actual"][param],
+                        values["expected"][param],
+                        atol=1e-2,
+                        rtol=1e-5,
+                    )
+                )
 
             omegas = {}
-            for (name, prefix) in [('expected', expectedresults), ('actual', outprefix)]:
-                fname = os.path.abspath(os.path.join(prefix,
-                        './{0}{1}'.format(model, '_omegabysite.txt')))
-                omegas[name] = pandas.read_csv(fname,
-                        comment='#', sep='\t')
-                omegas[name] = omegas[name].sort_values(by='site', axis=0)
-            self.assertTrue(numpy.allclose(omegas['actual']['P'].values,
-                    omegas['expected']['P'].values, atol=0.01, rtol=0.03))
-            sigsites = omegas['expected'][omegas['expected']['P'] < 0.05]['site'].values
+            for (name, prefix) in [("expected", expectedresults),
+                                   ("actual", outprefix)]:
+                fname = os.path.abspath(
+                    os.path.join(prefix,
+                                 "./{0}{1}".format(model, "_omegabysite.txt"))
+                )
+                omegas[name] = pandas.read_csv(fname, comment="#", sep="\t")
+                omegas[name] = omegas[name].sort_values(by="site", axis=0)
+            self.assertTrue(
+                numpy.allclose(
+                    omegas["actual"]["P"].values,
+                    omegas["expected"]["P"].values,
+                    atol=0.01,
+                    rtol=0.03,
+                )
+            )
+            sigsites = (omegas["expected"]
+                        [omegas["expected"]["P"] < 0.05]["site"].values)
             sigomegas = {}
             for (name, df) in omegas.items():
-                sigomegas[name] = omegas[name][omegas[name]['site'].isin(sigsites)]['omega'].values
-            self.assertTrue(((sigomegas['actual'] > 1) == (sigomegas['expected'] > 1)).all())
+                sigomegas[name] = (omegas[name][omegas[name]["site"]
+                                   .isin(sigsites)]["omega"].values)
+            self.assertTrue(
+                ((sigomegas["actual"] > 1) == (sigomegas["expected"] > 1))
+                .all()
+            )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     runner = unittest.TextTestRunner()
     unittest.main(testRunner=runner)

--- a/tests/test_phydms_comprehensive.py
+++ b/tests/test_phydms_comprehensive.py
@@ -21,87 +21,59 @@ class test_phydms_comprehensive(unittest.TestCase):
         """Tests command-line ``phydms_comprehensive`` on NP data."""
         tree = os.path.abspath(
             os.path.join(os.path.dirname(__file__),
-                         "./NP_data/NP_tree_short.newick")
-        )
+                         "./NP_data/NP_tree_short.newick"))
         alignment = os.path.abspath(
-            os.path.join(
-                os.path.dirname(__file__), "./NP_data/NP_alignment_short.fasta"
-            )
-        )
-        prefs = os.path.abspath(
             os.path.join(os.path.dirname(__file__),
-                         "./NP_data/NP_prefs_short.csv")
-        )
+                         "./NP_data/NP_alignment_short.fasta"))
+        prefs = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                "./NP_data/NP_prefs_short.csv"))
         for f in [prefs, alignment]:
             self.assertTrue(os.path.isfile(f), "Can't find file {0}".format(f))
-        outprefix = os.path.abspath(
-            os.path.join(os.path.dirname(__file__), "./NP_test_results/")
-        )
+        outprefix = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                    "./NP_test_results/"))
         if outprefix[-1] != "/":
             outprefix = "{0}/".format(outprefix)
 
         ncpus = min(20, multiprocessing.cpu_count())
 
-        subprocess.check_call(
-            [
-                "phydms_comprehensive",
-                outprefix,
-                alignment,
-                prefs,
-                "--tree",
-                tree,
-                "--omegabysite",
-                "--brlen",
-                "scale",
-                "--ncpus",
-                str(ncpus),
-            ]
-        )
+        subprocess.check_call(["phydms_comprehensive", outprefix, alignment,
+                               prefs, "--tree", tree, "--omegabysite",
+                               "--brlen", "scale", "--ncpus", str(ncpus)])
 
         expectedresults = os.path.abspath(
             os.path.join(os.path.dirname(__file__),
-                         "./expected_NP_test_results/")
-        )
+                         "./expected_NP_test_results/"))
 
-        models = [
-            "ExpCM_NP_prefs_short",
-            "averaged_ExpCM_NP_prefs_short",
-            "YNGKP_M0",
-            "YNGKP_M5",
-        ]
+        models = ["ExpCM_NP_prefs_short",
+                  "averaged_ExpCM_NP_prefs_short",
+                  "YNGKP_M0",
+                  "YNGKP_M5"
+                  ]
 
         for model in models:
             values = {}
-            for (name, prefix) in [
-                ("expected", expectedresults),
-                ("actual", outprefix),
-            ]:
+            for (name, prefix) in [("expected", expectedresults),
+                                   ("actual", outprefix)]:
                 values[name] = {}
                 for suffix in ["_loglikelihood.txt", "_modelparams.txt"]:
-                    fname = os.path.abspath(
-                        os.path.join(prefix, "./{0}{1}".format(model, suffix))
-                    )
+                    fname = os.path.abspath(os.path.join(prefix,
+                                            "./{0}{1}".format(model, suffix)))
                     with open(fname) as f:
                         for line in f:
                             (x, y) = line.split("=")
                             values[name][x.strip()] = float(y)
             for param in values["actual"].keys():
-                self.assertTrue(
-                    numpy.allclose(
-                        values["actual"][param],
-                        values["expected"][param],
-                        atol=1e-2,
-                        rtol=1e-5,
-                    )
-                )
+                self.assertTrue(numpy.allclose(values["actual"][param],
+                                               values["expected"][param],
+                                               atol=1e-2,
+                                               rtol=1e-5))
 
             omegas = {}
             for (name, prefix) in [("expected", expectedresults),
                                    ("actual", outprefix)]:
                 fname = os.path.abspath(
-                    os.path.join(prefix,
-                                 "./{0}{1}".format(model, "_omegabysite.txt"))
-                )
+                    os.path.join(prefix, "./{0}{1}"
+                                 .format(model, "_omegabysite.txt")))
                 omegas[name] = pandas.read_csv(fname, comment="#", sep="\t")
                 omegas[name] = omegas[name].sort_values(by="site", axis=0)
             self.assertTrue(
@@ -109,9 +81,7 @@ class test_phydms_comprehensive(unittest.TestCase):
                     omegas["actual"]["P"].values,
                     omegas["expected"]["P"].values,
                     atol=0.01,
-                    rtol=0.03,
-                )
-            )
+                    rtol=0.03,))
             sigsites = (omegas["expected"]
                         [omegas["expected"]["P"] < 0.05]["site"].values)
             sigomegas = {}
@@ -120,8 +90,7 @@ class test_phydms_comprehensive(unittest.TestCase):
                                    .isin(sigsites)]["omega"].values)
             self.assertTrue(
                 ((sigomegas["actual"] > 1) == (sigomegas["expected"] > 1))
-                .all()
-            )
+                .all())
 
 
 if __name__ == "__main__":

--- a/tests/test_phydms_comprehensive.py
+++ b/tests/test_phydms_comprehensive.py
@@ -115,7 +115,7 @@ class test_phydms_comprehensive(unittest.TestCase):
             sigsites = (omegas["expected"]
                         [omegas["expected"]["P"] < 0.05]["site"].values)
             sigomegas = {}
-            for (name, df) in omegas.items():
+            for (name, _df) in omegas.items():
                 sigomegas[name] = (omegas[name][omegas[name]["site"]
                                    .isin(sigsites)]["omega"].values)
             self.assertTrue(

--- a/tests/test_phydms_divpressure.py
+++ b/tests/test_phydms_divpressure.py
@@ -25,9 +25,9 @@ class test_phydms_testdivpressure(unittest.TestCase):
         alignment = os.path.abspath(
             os.path.join(os.path.dirname(__file__),
                          "./divpressure_tests/simulated_NP.fasta"))
-        prefs = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                             "./divpressure_tests/NP_prefs.txt"
-                                             ))
+        prefs = os.path.abspath(
+            os.path.join(os.path.dirname(__file__),
+                         "./divpressure_tests/NP_prefs.txt"))
         divpressure = os.path.abspath(
             os.path.join(
                 os.path.dirname(__file__),
@@ -39,8 +39,8 @@ class test_phydms_testdivpressure(unittest.TestCase):
         for f in [prefs, alignment]:
             self.assertTrue(os.path.isfile(f), "Can't find file {0}".format(f))
         outprefix = os.path.abspath(
-            os.path.join(os.path.dirname(__file__),
-                         "./divpressure_test_results/"))
+            os.path.join(
+                os.path.dirname(__file__), "./divpressure_test_results/"))
         if outprefix[-1] != "/":
             outprefix = "{0}/".format(outprefix)
         if os.path.isdir(outprefix):
@@ -49,8 +49,8 @@ class test_phydms_testdivpressure(unittest.TestCase):
         subprocess.check_call(
             ["phydms_divpressure", outprefix, alignment, prefs, "--tree", tree,
              divpressure, divpressure2])
-        actual = os.path.abspath(os.path.join(outprefix,
-                                              "modelcomparison.csv"))
+        actual = os.path.abspath(
+            os.path.join(outprefix, "modelcomparison.csv"))
         actual = pd.read_csv(actual)
         expected = os.path.abspath(
             os.path.join(

--- a/tests/test_phydms_divpressure.py
+++ b/tests/test_phydms_divpressure.py
@@ -20,75 +20,52 @@ class test_phydms_testdivpressure(unittest.TestCase):
     def test_NP(self):
         """Tests command-line ``phydms_testdivpressure`` on NP data."""
         tree = os.path.abspath(
-            os.path.join(
-                os.path.dirname(__file__), "./divpressure_tests/NP_tree.newick"
-            )
-        )
-        alignment = os.path.abspath(
-            os.path.join(
-                os.path.dirname(__file__),
-                "./divpressure_tests/simulated_NP.fasta"
-            )
-        )
-        prefs = os.path.abspath(
             os.path.join(os.path.dirname(__file__),
-                         "./divpressure_tests/NP_prefs.txt")
-        )
+                         "./divpressure_tests/NP_tree.newick"))
+        alignment = os.path.abspath(
+            os.path.join(os.path.dirname(__file__),
+                         "./divpressure_tests/simulated_NP.fasta"))
+        prefs = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                             "./divpressure_tests/NP_prefs.txt"
+                                             ))
         divpressure = os.path.abspath(
             os.path.join(
                 os.path.dirname(__file__),
-                "./divpressure_tests/divpressure.txt"
-            )
-        )
+                "./divpressure_tests/divpressure.txt"))
         divpressure2 = os.path.abspath(
             os.path.join(
                 os.path.dirname(__file__),
-                "./divpressure_tests/divpressure2.csv"
-            )
-        )
+                "./divpressure_tests/divpressure2.csv"))
         for f in [prefs, alignment]:
             self.assertTrue(os.path.isfile(f), "Can't find file {0}".format(f))
         outprefix = os.path.abspath(
             os.path.join(os.path.dirname(__file__),
-                         "./divpressure_test_results/")
-        )
+                         "./divpressure_test_results/"))
         if outprefix[-1] != "/":
             outprefix = "{0}/".format(outprefix)
         if os.path.isdir(outprefix):
             shutil.rmtree(outprefix)
 
         subprocess.check_call(
-            [
-                "phydms_divpressure",
-                outprefix,
-                alignment,
-                prefs,
-                "--tree",
-                tree,
-                divpressure,
-                divpressure2,
-            ]
-        )
+            ["phydms_divpressure", outprefix, alignment, prefs, "--tree", tree,
+             divpressure, divpressure2])
         actual = os.path.abspath(os.path.join(outprefix,
                                               "modelcomparison.csv"))
         actual = pd.read_csv(actual)
         expected = os.path.abspath(
             os.path.join(
                 os.path.dirname(__file__),
-                "./expected_divpressure_test_results/modelcomparison.csv",
-            )
-        )
+                "./expected_divpressure_test_results/modelcomparison.csv"))
         expected = pd.read_csv(expected)
         assert (actual.columns.values == expected.columns.values).all()
         columns = [x for x in actual.columns.values if x != "value"]
         actual.sort_values(by=columns, inplace=True)
         expected.sort_values(by=columns, inplace=True)
-        self.assertTrue(
-            numpy.allclose(actual["value"],
-                           expected["value"],
-                           atol=5e-2, rtol=1e-5),
-            f"{actual.to_csv(index=False)}\n{expected.to_csv(index=False)}",
-        )
+        self.assertTrue(numpy.allclose(actual["value"],
+                                       expected["value"],
+                                       atol=5e-2, rtol=1e-5),
+                        f"{actual.to_csv(index=False)}\n"
+                        f"{expected.to_csv(index=False)}")
 
 
 if __name__ == "__main__":

--- a/tests/test_phydms_divpressure.py
+++ b/tests/test_phydms_divpressure.py
@@ -19,44 +19,78 @@ class test_phydms_testdivpressure(unittest.TestCase):
 
     def test_NP(self):
         """Tests command-line ``phydms_testdivpressure`` on NP data."""
-        tree = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './divpressure_tests/NP_tree.newick'))
-        alignment = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './divpressure_tests/simulated_NP.fasta'))
-        prefs = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './divpressure_tests/NP_prefs.txt'))
-        divpressure = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './divpressure_tests/divpressure.txt'))
-        divpressure2 = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './divpressure_tests/divpressure2.csv'))
+        tree = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__), "./divpressure_tests/NP_tree.newick"
+            )
+        )
+        alignment = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "./divpressure_tests/simulated_NP.fasta"
+            )
+        )
+        prefs = os.path.abspath(
+            os.path.join(os.path.dirname(__file__),
+                         "./divpressure_tests/NP_prefs.txt")
+        )
+        divpressure = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "./divpressure_tests/divpressure.txt"
+            )
+        )
+        divpressure2 = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "./divpressure_tests/divpressure2.csv"
+            )
+        )
         for f in [prefs, alignment]:
             self.assertTrue(os.path.isfile(f), "Can't find file {0}".format(f))
-        outprefix = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './divpressure_test_results/'))
+        outprefix = os.path.abspath(
+            os.path.join(os.path.dirname(__file__),
+                         "./divpressure_test_results/")
+        )
         if outprefix[-1] != "/":
             outprefix = "{0}/".format(outprefix)
         if os.path.isdir(outprefix):
             shutil.rmtree(outprefix)
 
-
-        subprocess.check_call(['phydms_divpressure', outprefix, alignment,
-                prefs, "--tree", tree, divpressure, divpressure2])
+        subprocess.check_call(
+            [
+                "phydms_divpressure",
+                outprefix,
+                alignment,
+                prefs,
+                "--tree",
+                tree,
+                divpressure,
+                divpressure2,
+            ]
+        )
         actual = os.path.abspath(os.path.join(outprefix,
-                "modelcomparison.csv"))
+                                              "modelcomparison.csv"))
         actual = pd.read_csv(actual)
-        expected = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                "./expected_divpressure_test_results/modelcomparison.csv"))
+        expected = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "./expected_divpressure_test_results/modelcomparison.csv",
+            )
+        )
         expected = pd.read_csv(expected)
-        assert((actual.columns.values == expected.columns.values).all())
+        assert (actual.columns.values == expected.columns.values).all()
         columns = [x for x in actual.columns.values if x != "value"]
         actual.sort_values(by=columns, inplace=True)
         expected.sort_values(by=columns, inplace=True)
-        self.assertTrue(numpy.allclose(actual["value"],
-                expected["value"], atol=5e-2, rtol=1e-5),
-                f"{actual.to_csv(index=False)}\n{expected.to_csv(index=False)}")
+        self.assertTrue(
+            numpy.allclose(actual["value"],
+                           expected["value"],
+                           atol=5e-2, rtol=1e-5),
+            f"{actual.to_csv(index=False)}\n{expected.to_csv(index=False)}",
+        )
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     runner = unittest.TextTestRunner()
     unittest.main(testRunner=runner)

--- a/tests/test_phydms_logoplot.py
+++ b/tests/test_phydms_logoplot.py
@@ -20,23 +20,18 @@ class test_phydms_logoplot(unittest.TestCase):
             os.path.join(
                 os.path.dirname(__file__),
                 "./expected_NP_test_results/ExpCM_NP_prefs_short_"
-                "diffprefsbysite.txt",
-            )
-        )
+                "diffprefsbysite.txt"))
         self.omega = os.path.abspath(
             os.path.join(
                 os.path.dirname(__file__),
                 "./expected_NP_test_results/ExpCM_NP_prefs_short_"
-                "omegabysite.txt",
-            )
-        )
+                "omegabysite.txt"))
         self.prefs = os.path.abspath(
             os.path.join(os.path.dirname(__file__),
-                         "./NP_data/NP_prefs_short.csv")
-        )
+                         "./NP_data/NP_prefs_short.csv"))
         self.outprefix = os.path.abspath(
-            os.path.join(os.path.dirname(__file__), "./logoplot_test_results/")
-        )
+            os.path.join(os.path.dirname(__file__),
+                         "./logoplot_test_results/"))
         self.stringency = "2.99"
         if not os.path.isdir(self.outprefix):
             os.mkdir(self.outprefix)
@@ -46,20 +41,9 @@ class test_phydms_logoplot(unittest.TestCase):
         plotfile = os.path.join(self.outprefix, "prefs_logoplot.pdf")
         if os.path.isfile(plotfile):
             os.remove(plotfile)
-        subprocess.call(
-            [
-                "phydms_logoplot",
-                "--prefs",
-                self.prefs,
-                plotfile,
-                "--stringency",
-                self.stringency,
-                "--nperline",
-                "72",
-                "--mapmetric",
-                "charge",
-            ]
-        )
+        subprocess.call(["phydms_logoplot", "--prefs", self.prefs, plotfile,
+                         "--stringency", self.stringency, "--nperline", "72",
+                         "--mapmetric", "charge"])
         self.assertTrue(os.path.isfile(plotfile))
 
     def test_diffprefs_logoplot(self):
@@ -67,16 +51,8 @@ class test_phydms_logoplot(unittest.TestCase):
         plotfile = os.path.join(self.outprefix, "diffprefs_logoplot.pdf")
         if os.path.isfile(plotfile):
             os.remove(plotfile)
-        subprocess.call(
-            [
-                "phydms_logoplot",
-                "--diffprefs",
-                self.diffprefs,
-                plotfile,
-                "--nperline",
-                "72",
-            ]
-        )
+        subprocess.call(["phydms_logoplot", "--diffprefs", self.diffprefs,
+                        plotfile, "--nperline", "72"])
         self.assertTrue(os.path.isfile(plotfile))
 
     def test_omegaoverlay(self):
@@ -84,22 +60,9 @@ class test_phydms_logoplot(unittest.TestCase):
         plotfile = os.path.join(self.outprefix, "omegaoverlay_logoplot.pdf")
         if os.path.isfile(plotfile):
             os.remove(plotfile)
-        subprocess.call(
-            [
-                "phydms_logoplot",
-                "--prefs",
-                self.prefs,
-                plotfile,
-                "--stringency",
-                self.stringency,
-                "--nperline",
-                "72",
-                "--omegabysite",
-                self.omega,
-                "--minP",
-                "0.001",
-            ]
-        )
+        subprocess.call(["phydms_logoplot", "--prefs", self.prefs, plotfile,
+                         "--stringency", self.stringency, "--nperline", "72",
+                         "--omegabysite", self.omega, "--minP", "0.001"])
         self.assertTrue(os.path.isfile(plotfile))
 
 

--- a/tests/test_phydms_logoplot.py
+++ b/tests/test_phydms_logoplot.py
@@ -16,54 +16,94 @@ class test_phydms_logoplot(unittest.TestCase):
 
     def setUp(self):
         """Define input data."""
-        self.diffprefs = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './expected_NP_test_results/ExpCM_NP_prefs_short_diffprefsbysite.txt'))
-        self.omega = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './expected_NP_test_results/ExpCM_NP_prefs_short_omegabysite.txt'))
-        self.prefs = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './NP_data/NP_prefs_short.csv'))
-        self.outprefix = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './logoplot_test_results/'))
-        self.stringency = '2.99'
+        self.diffprefs = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "./expected_NP_test_results/ExpCM_NP_prefs_short_"
+                "diffprefsbysite.txt",
+            )
+        )
+        self.omega = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "./expected_NP_test_results/ExpCM_NP_prefs_short_"
+                "omegabysite.txt",
+            )
+        )
+        self.prefs = os.path.abspath(
+            os.path.join(os.path.dirname(__file__),
+                         "./NP_data/NP_prefs_short.csv")
+        )
+        self.outprefix = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "./logoplot_test_results/")
+        )
+        self.stringency = "2.99"
         if not os.path.isdir(self.outprefix):
             os.mkdir(self.outprefix)
 
     def test_prefs_logoplot(self):
         """Tests ``--prefs`` option to ``phydms_logoplot``."""
-        plotfile = os.path.join(self.outprefix,
-                'prefs_logoplot.pdf')
+        plotfile = os.path.join(self.outprefix, "prefs_logoplot.pdf")
         if os.path.isfile(plotfile):
             os.remove(plotfile)
-        subprocess.call(['phydms_logoplot', '--prefs', self.prefs,
-                plotfile, '--stringency', self.stringency,
-                '--nperline', '72', '--mapmetric', 'charge'])
+        subprocess.call(
+            [
+                "phydms_logoplot",
+                "--prefs",
+                self.prefs,
+                plotfile,
+                "--stringency",
+                self.stringency,
+                "--nperline",
+                "72",
+                "--mapmetric",
+                "charge",
+            ]
+        )
         self.assertTrue(os.path.isfile(plotfile))
 
     def test_diffprefs_logoplot(self):
         """Tests ``--diffprefs`` option to ``phydms_logoplot``."""
-        plotfile = os.path.join(self.outprefix,
-                'diffprefs_logoplot.pdf')
+        plotfile = os.path.join(self.outprefix, "diffprefs_logoplot.pdf")
         if os.path.isfile(plotfile):
             os.remove(plotfile)
-        subprocess.call(['phydms_logoplot', '--diffprefs', self.diffprefs,
-                plotfile, '--nperline', '72'])
+        subprocess.call(
+            [
+                "phydms_logoplot",
+                "--diffprefs",
+                self.diffprefs,
+                plotfile,
+                "--nperline",
+                "72",
+            ]
+        )
         print(plotfile)
         self.assertTrue(os.path.isfile(plotfile))
 
     def test_omegaoverlay(self):
         """Tests ``--omegabysite`` option to ``phydms_logoplot``."""
-        plotfile = os.path.join(self.outprefix,
-                'omegaoverlay_logoplot.pdf')
+        plotfile = os.path.join(self.outprefix, "omegaoverlay_logoplot.pdf")
         if os.path.isfile(plotfile):
             os.remove(plotfile)
-        subprocess.call(['phydms_logoplot', '--prefs', self.prefs,
-                plotfile, '--stringency', self.stringency,
-                '--nperline', '72', '--omegabysite', self.omega,
-                '--minP', '0.001'])
+        subprocess.call(
+            [
+                "phydms_logoplot",
+                "--prefs",
+                self.prefs,
+                plotfile,
+                "--stringency",
+                self.stringency,
+                "--nperline",
+                "72",
+                "--omegabysite",
+                self.omega,
+                "--minP",
+                "0.001",
+            ]
+        )
         self.assertTrue(os.path.isfile(plotfile))
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     runner = unittest.TextTestRunner()
     unittest.main(testRunner=runner)

--- a/tests/test_phydms_logoplot.py
+++ b/tests/test_phydms_logoplot.py
@@ -77,7 +77,6 @@ class test_phydms_logoplot(unittest.TestCase):
                 "72",
             ]
         )
-        print(plotfile)
         self.assertTrue(os.path.isfile(plotfile))
 
     def test_omegaoverlay(self):

--- a/tests/test_prepalignment.py
+++ b/tests/test_prepalignment.py
@@ -11,7 +11,8 @@ import subprocess
 
 class TestPrepAlignment(unittest.TestCase):
     """
-    Runs ``phydms_prepalignment`` on test data, compares to known results.
+    Runs ``phydms_prepalignment`` on test data, compares to
+    known results.
     """
 
     def setUp(self):

--- a/tests/test_prepalignment.py
+++ b/tests/test_prepalignment.py
@@ -1,6 +1,7 @@
 """Tests ``phydms_prepalignment``.
 
-Written by Jesse Bloom."""
+Written by Jesse Bloom.
+"""
 
 
 import os

--- a/tests/test_prepalignment.py
+++ b/tests/test_prepalignment.py
@@ -3,7 +3,6 @@
 Written by Jesse Bloom."""
 
 
-import sys
 import os
 import unittest
 import subprocess
@@ -16,77 +15,124 @@ class TestPrepAlignment(unittest.TestCase):
 
     def setUp(self):
         """Gets files set up appropriately."""
-        self.testdir = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './prepalignment_tests/'))
-
+        self.testdir = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "./prepalignment_tests/")
+        )
 
     def test_unaligned(self):
         """Test on data set that needs aligning."""
-        inseqs = os.path.abspath(os.path.join(self.testdir,
-                'unaligned_SUMO1_orthologs.fasta'))
+        inseqs = os.path.abspath(
+            os.path.join(self.testdir, "unaligned_SUMO1_orthologs.fasta")
+        )
         for (minidentity, minuniqueness, purgeseqs, keepseqs) in [
-                ('0.7', '2', [''], [''])
-                ]:
-            alignmentSuffix = 'test_unaligned_SUMO1_alignment_minidentity{0}_minuniqueness{1}_purgeseqs{2}_keepseqs{3}.fasta'.format(minidentity, minuniqueness, os.path.splitext(os.path.basename(''.join(purgeseqs)))[0], os.path.splitext(os.path.basename(''.join(keepseqs)))[0])
-            alignment = os.path.abspath(os.path.join(self.testdir, alignmentSuffix))
-            subprocess.check_call([
-                    'phydms_prepalignment',
+            ("0.7", "2", [""], [""])
+        ]:
+            alignmentSuffix = ("test_unaligned_SUMO1_alignment_minidentity{0}"
+                               "_minuniqueness{1}_purgeseqs{2}_keepseqs{3}"
+                               ".fasta"
+                               .format(minidentity,
+                                       minuniqueness,
+                                       (os.path
+                                        .splitext(os.path
+                                                  .basename("".join(purgeseqs)
+                                                            ))[0]),
+                                       (os.path
+                                        .splitext(os.path
+                                                  .basename("".join(keepseqs)
+                                                            ))[0]),
+                                       ))
+            alignment = os.path.abspath(os.path.join(self.testdir,
+                                                     alignmentSuffix))
+            subprocess.check_call(
+                [
+                    "phydms_prepalignment",
                     inseqs,
                     alignment,
-                    'Hsap',
-                    '--minidentity', minidentity,
-                    '--minuniqueness', minuniqueness,
-                    '--purgeseqs'] + purgeseqs +
-                    ['--keepseqs'] + keepseqs
-                )
-            expected = alignment.replace('test_SUMO', 'expected_SUMO')
+                    "Hsap",
+                    "--minidentity",
+                    minidentity,
+                    "--minuniqueness",
+                    minuniqueness,
+                    "--purgeseqs",
+                ]
+                + purgeseqs
+                + ["--keepseqs"]
+                + keepseqs
+            )
+            expected = alignment.replace("test_SUMO", "expected_SUMO")
             with open(expected) as f_expected, open(alignment) as f_actual:
                 expectedtext = f_expected.read()
                 actualtext = f_actual.read()
-            self.assertTrue(expectedtext == actualtext, "Did not get expected results for {0}".format(alignment))
-
+            self.assertTrue(
+                expectedtext == actualtext,
+                "Did not get expected results for {0}".format(alignment),
+            )
 
     def test_prealigned(self):
         """Test on pre-aligned data set."""
-        inseqs = os.path.abspath(os.path.join(self.testdir,
-                'prealigned_SUMO1_orthologs.fasta'))
-        purgeseqsfile = os.path.abspath(os.path.join(self.testdir,
-                'test_purgeseqsfile.txt'))
-        with open(purgeseqsfile, 'w') as f:
-            f.write('Fcat\n\n')
-        keepseqsfile = os.path.abspath(os.path.join(self.testdir,
-                'test_keepseqsfile.txt'))
-        with open(keepseqsfile, 'w') as f:
-            f.write('Panu\nGgor\n')
+        inseqs = os.path.abspath(
+            os.path.join(self.testdir, "prealigned_SUMO1_orthologs.fasta")
+        )
+        purgeseqsfile = os.path.abspath(
+            os.path.join(self.testdir, "test_purgeseqsfile.txt")
+        )
+        with open(purgeseqsfile, "w") as f:
+            f.write("Fcat\n\n")
+        keepseqsfile = os.path.abspath(
+            os.path.join(self.testdir, "test_keepseqsfile.txt")
+        )
+        with open(keepseqsfile, "w") as f:
+            f.write("Panu\nGgor\n")
         for (minidentity, minuniqueness, purgeseqs, keepseqs) in [
-                ('0.7', '2', [''], ['']),
-                ('0.6', '2', [''], ['']),
-                ('0.7', '1', [''], ['']),
-                ('0.7', '2', [''], ['Panu', 'Ggor']),
-                ('0.7', '2', [''], [keepseqsfile]),
-                ('0.7', '2', [purgeseqsfile], ['Panu', 'Ggor']),
-                ('0.7', '2', ['Fcat'], [keepseqsfile]),
-                ]:
-            alignmentSuffix = 'test_SUMO1_alignment_minidentity{0}_minuniqueness{1}_purgeseqs{2}_keepseqs{3}.fasta'.format(minidentity, minuniqueness, os.path.splitext(os.path.basename(''.join(purgeseqs)))[0], os.path.splitext(os.path.basename(''.join(keepseqs)))[0])
-            alignment = os.path.abspath(os.path.join(self.testdir, alignmentSuffix))
-            subprocess.check_call([
-                    'phydms_prepalignment',
+            ("0.7", "2", [""], [""]),
+            ("0.6", "2", [""], [""]),
+            ("0.7", "1", [""], [""]),
+            ("0.7", "2", [""], ["Panu", "Ggor"]),
+            ("0.7", "2", [""], [keepseqsfile]),
+            ("0.7", "2", [purgeseqsfile], ["Panu", "Ggor"]),
+            ("0.7", "2", ["Fcat"], [keepseqsfile]),
+        ]:
+            alignmentSuffix = ("test_SUMO1_alignment_minidentity{0}_"
+                               "minuniqueness{1}_purgeseqs{2}_keepseqs{3}"
+                               ".fasta"
+                               .format(minidentity, minuniqueness,
+                                       (os.path
+                                        .splitext(os.path
+                                                  .basename("".join(purgeseqs)
+                                                            ))[0]),
+                                       (os.path
+                                        .splitext(os.path
+                                                  .basename("".join(keepseqs)
+                                                            ))[0])))
+            alignment = os.path.abspath(os.path.join(self.testdir,
+                                        alignmentSuffix))
+            subprocess.check_call(
+                [
+                    "phydms_prepalignment",
                     inseqs,
                     alignment,
-                    'Hsap',
-                    '--prealigned',
-                    '--minidentity', minidentity,
-                    '--minuniqueness', minuniqueness,
-                    '--purgeseqs'] + purgeseqs +
-                    ['--keepseqs'] + keepseqs
-                )
-            expected = alignment.replace('test_SUMO', 'expected_SUMO')
+                    "Hsap",
+                    "--prealigned",
+                    "--minidentity",
+                    minidentity,
+                    "--minuniqueness",
+                    minuniqueness,
+                    "--purgeseqs",
+                ]
+                + purgeseqs
+                + ["--keepseqs"]
+                + keepseqs
+            )
+            expected = alignment.replace("test_SUMO", "expected_SUMO")
             with open(expected) as f_expected, open(alignment) as f_actual:
                 expectedtext = f_expected.read()
                 actualtext = f_actual.read()
-            self.assertTrue(expectedtext == actualtext, "Did not get expected results for {0}".format(alignment))
+            self.assertTrue(
+                expectedtext == actualtext,
+                "Did not get expected results for {0}".format(alignment),
+            )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     runner = unittest.TextTestRunner()
     unittest.main(testRunner=runner)

--- a/tests/test_prepalignment.py
+++ b/tests/test_prepalignment.py
@@ -18,17 +18,14 @@ class TestPrepAlignment(unittest.TestCase):
     def setUp(self):
         """Gets files set up appropriately."""
         self.testdir = os.path.abspath(
-            os.path.join(os.path.dirname(__file__), "./prepalignment_tests/")
-        )
+            os.path.join(os.path.dirname(__file__), "./prepalignment_tests/"))
 
     def test_unaligned(self):
         """Test on data set that needs aligning."""
         inseqs = os.path.abspath(
-            os.path.join(self.testdir, "unaligned_SUMO1_orthologs.fasta")
-        )
-        for (minidentity, minuniqueness, purgeseqs, keepseqs) in [
-            ("0.7", "2", [""], [""])
-        ]:
+            os.path.join(self.testdir, "unaligned_SUMO1_orthologs.fasta"))
+        for (minidentity, minuniqueness, purgeseqs,
+             keepseqs) in [("0.7", "2", [""], [""])]:
             alignmentSuffix = ("test_unaligned_SUMO1_alignment_minidentity{0}"
                                "_minuniqueness{1}_purgeseqs{2}_keepseqs{3}"
                                ".fasta"
@@ -45,55 +42,40 @@ class TestPrepAlignment(unittest.TestCase):
                                        ))
             alignment = os.path.abspath(os.path.join(self.testdir,
                                                      alignmentSuffix))
-            subprocess.check_call(
-                [
-                    "phydms_prepalignment",
-                    inseqs,
-                    alignment,
-                    "Hsap",
-                    "--minidentity",
-                    minidentity,
-                    "--minuniqueness",
-                    minuniqueness,
-                    "--purgeseqs",
-                ]
-                + purgeseqs
-                + ["--keepseqs"]
-                + keepseqs
-            )
+            subprocess.check_call(["phydms_prepalignment", inseqs, alignment,
+                                   "Hsap", "--minidentity", minidentity,
+                                   "--minuniqueness", minuniqueness,
+                                   "--purgeseqs"]
+                                  + purgeseqs
+                                  + ["--keepseqs"]
+                                  + keepseqs)
             expected = alignment.replace("test_SUMO", "expected_SUMO")
             with open(expected) as f_expected, open(alignment) as f_actual:
                 expectedtext = f_expected.read()
                 actualtext = f_actual.read()
-            self.assertTrue(
-                expectedtext == actualtext,
-                "Did not get expected results for {0}".format(alignment),
-            )
+            self.assertTrue(expectedtext == actualtext,
+                            "Did not get expected results for {0}"
+                            .format(alignment))
 
     def test_prealigned(self):
         """Test on pre-aligned data set."""
         inseqs = os.path.abspath(
-            os.path.join(self.testdir, "prealigned_SUMO1_orthologs.fasta")
-        )
+            os.path.join(self.testdir, "prealigned_SUMO1_orthologs.fasta"))
         purgeseqsfile = os.path.abspath(
-            os.path.join(self.testdir, "test_purgeseqsfile.txt")
-        )
+            os.path.join(self.testdir, "test_purgeseqsfile.txt"))
         with open(purgeseqsfile, "w") as f:
             f.write("Fcat\n\n")
         keepseqsfile = os.path.abspath(
-            os.path.join(self.testdir, "test_keepseqsfile.txt")
-        )
+            os.path.join(self.testdir, "test_keepseqsfile.txt"))
         with open(keepseqsfile, "w") as f:
             f.write("Panu\nGgor\n")
-        for (minidentity, minuniqueness, purgeseqs, keepseqs) in [
-            ("0.7", "2", [""], [""]),
-            ("0.6", "2", [""], [""]),
-            ("0.7", "1", [""], [""]),
-            ("0.7", "2", [""], ["Panu", "Ggor"]),
-            ("0.7", "2", [""], [keepseqsfile]),
-            ("0.7", "2", [purgeseqsfile], ["Panu", "Ggor"]),
-            ("0.7", "2", ["Fcat"], [keepseqsfile]),
-        ]:
+        for (minidentity, minuniqueness, purgeseqs,
+             keepseqs) in [("0.7", "2", [""], [""]), ("0.6", "2", [""], [""]),
+                           ("0.7", "1", [""], [""]),
+                           ("0.7", "2", [""], ["Panu", "Ggor"]),
+                           ("0.7", "2", [""], [keepseqsfile]),
+                           ("0.7", "2", [purgeseqsfile], ["Panu", "Ggor"]),
+                           ("0.7", "2", ["Fcat"], [keepseqsfile])]:
             alignmentSuffix = ("test_SUMO1_alignment_minidentity{0}_"
                                "minuniqueness{1}_purgeseqs{2}_keepseqs{3}"
                                ".fasta"
@@ -108,31 +90,18 @@ class TestPrepAlignment(unittest.TestCase):
                                                             ))[0])))
             alignment = os.path.abspath(os.path.join(self.testdir,
                                         alignmentSuffix))
-            subprocess.check_call(
-                [
-                    "phydms_prepalignment",
-                    inseqs,
-                    alignment,
-                    "Hsap",
-                    "--prealigned",
-                    "--minidentity",
-                    minidentity,
-                    "--minuniqueness",
-                    minuniqueness,
-                    "--purgeseqs",
-                ]
-                + purgeseqs
-                + ["--keepseqs"]
-                + keepseqs
-            )
+            subprocess.check_call(["phydms_prepalignment", inseqs, alignment,
+                                   "Hsap", "--prealigned", "--minidentity",
+                                   minidentity, "--minuniqueness",
+                                   minuniqueness, "--purgeseqs"]
+                                  + purgeseqs + ["--keepseqs"] + keepseqs)
             expected = alignment.replace("test_SUMO", "expected_SUMO")
             with open(expected) as f_expected, open(alignment) as f_actual:
                 expectedtext = f_expected.read()
                 actualtext = f_actual.read()
             self.assertTrue(
                 expectedtext == actualtext,
-                "Did not get expected results for {0}".format(alignment),
-            )
+                "Did not get expected results for {0}".format(alignment))
 
 
 if __name__ == "__main__":

--- a/tests/test_prepalignment.py
+++ b/tests/test_prepalignment.py
@@ -26,20 +26,14 @@ class TestPrepAlignment(unittest.TestCase):
             os.path.join(self.testdir, "unaligned_SUMO1_orthologs.fasta"))
         for (minidentity, minuniqueness, purgeseqs,
              keepseqs) in [("0.7", "2", [""], [""])]:
-            alignmentSuffix = ("test_unaligned_SUMO1_alignment_minidentity{0}"
-                               "_minuniqueness{1}_purgeseqs{2}_keepseqs{3}"
-                               ".fasta"
-                               .format(minidentity,
-                                       minuniqueness,
-                                       (os.path
-                                        .splitext(os.path
-                                                  .basename("".join(purgeseqs)
-                                                            ))[0]),
-                                       (os.path
-                                        .splitext(os.path
-                                                  .basename("".join(keepseqs)
-                                                            ))[0]),
-                                       ))
+            alignmentSuffix = (
+                "test_unaligned_SUMO1_alignment_minidentity{0}_"
+                "minuniqueness{1}_purgeseqs{2}_keepseqs{3}."
+                "fasta".format(minidentity, minuniqueness,
+                               (os.path.splitext(
+                                os.path.basename("".join(purgeseqs)))[0]),
+                               (os.path.splitext(
+                                os.path.basename("".join(keepseqs)))[0])))
             alignment = os.path.abspath(os.path.join(self.testdir,
                                                      alignmentSuffix))
             subprocess.check_call(["phydms_prepalignment", inseqs, alignment,
@@ -76,18 +70,14 @@ class TestPrepAlignment(unittest.TestCase):
                            ("0.7", "2", [""], [keepseqsfile]),
                            ("0.7", "2", [purgeseqsfile], ["Panu", "Ggor"]),
                            ("0.7", "2", ["Fcat"], [keepseqsfile])]:
-            alignmentSuffix = ("test_SUMO1_alignment_minidentity{0}_"
-                               "minuniqueness{1}_purgeseqs{2}_keepseqs{3}"
-                               ".fasta"
-                               .format(minidentity, minuniqueness,
-                                       (os.path
-                                        .splitext(os.path
-                                                  .basename("".join(purgeseqs)
-                                                            ))[0]),
-                                       (os.path
-                                        .splitext(os.path
-                                                  .basename("".join(keepseqs)
-                                                            ))[0])))
+            alignmentSuffix = (
+                "test_SUMO1_alignment_minidentity{0}_minuniqueness{1}_"
+                "purgeseqs{2}_keepseqs{3}"
+                ".fasta".format(minidentity, minuniqueness,
+                                (os.path.splitext(
+                                 os.path.basename("".join(purgeseqs)))[0]),
+                                (os.path.splitext(
+                                 os.path.basename("".join(keepseqs)))[0])))
             alignment = os.path.abspath(os.path.join(self.testdir,
                                         alignmentSuffix))
             subprocess.check_call(["phydms_prepalignment", inseqs, alignment,

--- a/tests/test_prepalignment_prealigned.py
+++ b/tests/test_prepalignment_prealigned.py
@@ -16,50 +16,77 @@ class TestPrepAlignment(unittest.TestCase):
 
     def setUp(self):
         """Gets files set up appropriately."""
-        self.testdir = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './prepalignment_tests/'))
+        self.testdir = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "./prepalignment_tests/")
+        )
 
     def test_prealigned(self):
         """Test on pre-aligned data set."""
-        inseqs = os.path.abspath(os.path.join(self.testdir,
-                'prealigned_SUMO1_orthologs.fasta'))
-        purgeseqsfile = os.path.abspath(os.path.join(self.testdir,
-                'test_purgeseqsfile.txt'))
-        with open(purgeseqsfile, 'w') as f:
-            f.write('Fcat\n\n')
-        keepseqsfile = os.path.abspath(os.path.join(self.testdir,
-                'test_keepseqsfile.txt'))
-        with open(keepseqsfile, 'w') as f:
-            f.write('Panu\nGgor\n')
+        inseqs = os.path.abspath(
+            os.path.join(self.testdir, "prealigned_SUMO1_orthologs.fasta")
+        )
+        purgeseqsfile = os.path.abspath(
+            os.path.join(self.testdir, "test_purgeseqsfile.txt")
+        )
+        with open(purgeseqsfile, "w") as f:
+            f.write("Fcat\n\n")
+        keepseqsfile = os.path.abspath(
+            os.path.join(self.testdir, "test_keepseqsfile.txt")
+        )
+        with open(keepseqsfile, "w") as f:
+            f.write("Panu\nGgor\n")
         for (minidentity, minuniqueness, purgeseqs, keepseqs) in [
-                ('0.7', '2', [''], ['']),
-                ('0.6', '2', [''], ['']),
-                ('0.7', '1', [''], ['']),
-                ('0.7', '2', [''], ['Panu', 'Ggor']),
-                ('0.7', '2', [''], [keepseqsfile]),
-                ('0.7', '2', [purgeseqsfile], ['Panu', 'Ggor']),
-                ('0.7', '2', ['Fcat'], [keepseqsfile]),
-                ]:
-            alignmentSuffix = 'test_SUMO1_alignment_minidentity{0}_minuniqueness{1}_purgeseqs{2}_keepseqs{3}.fasta'.format(minidentity, minuniqueness, os.path.splitext(os.path.basename(''.join(purgeseqs)))[0], os.path.splitext(os.path.basename(''.join(keepseqs)))[0])
-            alignment = os.path.abspath(os.path.join(self.testdir, alignmentSuffix))
-            subprocess.check_call([
-                    'phydms_prepalignment',
+            ("0.7", "2", [""], [""]),
+            ("0.6", "2", [""], [""]),
+            ("0.7", "1", [""], [""]),
+            ("0.7", "2", [""], ["Panu", "Ggor"]),
+            ("0.7", "2", [""], [keepseqsfile]),
+            ("0.7", "2", [purgeseqsfile], ["Panu", "Ggor"]),
+            ("0.7", "2", ["Fcat"], [keepseqsfile]),
+        ]:
+            alignmentSuffix = ("test_SUMO1_alignment_minidentity{0}_"
+                               "minuniqueness{1}_purgeseqs{2}_keepseqs{3}"
+                               ".fasta"
+                               .format(minidentity,
+                                       minuniqueness,
+                                       (os.path
+                                        .splitext(os.path
+                                                  .basename("".join(purgeseqs
+                                                                    )))[0]),
+                                       (os.path
+                                        .splitext(os.path
+                                                  .basename("".join(keepseqs
+                                                                    )))[0])
+                                       ))
+            alignment = os.path.abspath(os.path.join(self.testdir,
+                                                     alignmentSuffix))
+            subprocess.check_call(
+                [
+                    "phydms_prepalignment",
                     inseqs,
                     alignment,
-                    'Hsap',
-                    '--prealigned',
-                    '--minidentity', minidentity,
-                    '--minuniqueness', minuniqueness,
-                    '--purgeseqs'] + purgeseqs +
-                    ['--keepseqs'] + keepseqs
-                )
-            expected = alignment.replace('test_SUMO', 'expected_SUMO')
+                    "Hsap",
+                    "--prealigned",
+                    "--minidentity",
+                    minidentity,
+                    "--minuniqueness",
+                    minuniqueness,
+                    "--purgeseqs",
+                ]
+                + purgeseqs
+                + ["--keepseqs"]
+                + keepseqs
+            )
+            expected = alignment.replace("test_SUMO", "expected_SUMO")
             with open(expected) as f_expected, open(alignment) as f_actual:
                 expectedtext = f_expected.read()
                 actualtext = f_actual.read()
-            self.assertTrue(expectedtext == actualtext, "Did not get expected results for {0}".format(alignment))
+            self.assertTrue(
+                expectedtext == actualtext,
+                "Did not get expected results for {0}".format(alignment),
+            )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     runner = unittest.TextTestRunner()
     unittest.main(testRunner=runner)

--- a/tests/test_prepalignment_prealigned.py
+++ b/tests/test_prepalignment_prealigned.py
@@ -11,7 +11,8 @@ import subprocess
 
 class TestPrepAlignment(unittest.TestCase):
     """
-    Runs ``phydms_prepalignment`` on test data, compares to known results.
+    Runs ``phydms_prepalignment`` on test data, compares to
+    known results.
     """
 
     def setUp(self):

--- a/tests/test_prepalignment_prealigned.py
+++ b/tests/test_prepalignment_prealigned.py
@@ -1,9 +1,9 @@
 """Tests ``phydms_prepalignment``.
 
-Written by Jesse Bloom."""
+Written by Jesse Bloom.
+"""
 
 
-import sys
 import os
 import unittest
 import subprocess

--- a/tests/test_prepalignment_prealigned.py
+++ b/tests/test_prepalignment_prealigned.py
@@ -18,33 +18,27 @@ class TestPrepAlignment(unittest.TestCase):
     def setUp(self):
         """Gets files set up appropriately."""
         self.testdir = os.path.abspath(
-            os.path.join(os.path.dirname(__file__), "./prepalignment_tests/")
-        )
+            os.path.join(os.path.dirname(__file__), "./prepalignment_tests/"))
 
     def test_prealigned(self):
         """Test on pre-aligned data set."""
         inseqs = os.path.abspath(
-            os.path.join(self.testdir, "prealigned_SUMO1_orthologs.fasta")
-        )
+            os.path.join(self.testdir, "prealigned_SUMO1_orthologs.fasta"))
         purgeseqsfile = os.path.abspath(
-            os.path.join(self.testdir, "test_purgeseqsfile.txt")
-        )
+            os.path.join(self.testdir, "test_purgeseqsfile.txt"))
         with open(purgeseqsfile, "w") as f:
             f.write("Fcat\n\n")
         keepseqsfile = os.path.abspath(
-            os.path.join(self.testdir, "test_keepseqsfile.txt")
-        )
+            os.path.join(self.testdir, "test_keepseqsfile.txt"))
         with open(keepseqsfile, "w") as f:
             f.write("Panu\nGgor\n")
-        for (minidentity, minuniqueness, purgeseqs, keepseqs) in [
-            ("0.7", "2", [""], [""]),
-            ("0.6", "2", [""], [""]),
-            ("0.7", "1", [""], [""]),
-            ("0.7", "2", [""], ["Panu", "Ggor"]),
-            ("0.7", "2", [""], [keepseqsfile]),
-            ("0.7", "2", [purgeseqsfile], ["Panu", "Ggor"]),
-            ("0.7", "2", ["Fcat"], [keepseqsfile]),
-        ]:
+        for (minidentity, minuniqueness, purgeseqs,
+             keepseqs) in [("0.7", "2", [""], [""]), ("0.6", "2", [""], [""]),
+                           ("0.7", "1", [""], [""]),
+                           ("0.7", "2", [""], ["Panu", "Ggor"]),
+                           ("0.7", "2", [""], [keepseqsfile]),
+                           ("0.7", "2", [purgeseqsfile], ["Panu", "Ggor"]),
+                           ("0.7", "2", ["Fcat"], [keepseqsfile])]:
             alignmentSuffix = ("test_SUMO1_alignment_minidentity{0}_"
                                "minuniqueness{1}_purgeseqs{2}_keepseqs{3}"
                                ".fasta"
@@ -61,31 +55,18 @@ class TestPrepAlignment(unittest.TestCase):
                                        ))
             alignment = os.path.abspath(os.path.join(self.testdir,
                                                      alignmentSuffix))
-            subprocess.check_call(
-                [
-                    "phydms_prepalignment",
-                    inseqs,
-                    alignment,
-                    "Hsap",
-                    "--prealigned",
-                    "--minidentity",
-                    minidentity,
-                    "--minuniqueness",
-                    minuniqueness,
-                    "--purgeseqs",
-                ]
-                + purgeseqs
-                + ["--keepseqs"]
-                + keepseqs
-            )
+            subprocess.check_call(["phydms_prepalignment", inseqs, alignment,
+                                   "Hsap", "--prealigned", "--minidentity",
+                                   minidentity, "--minuniqueness",
+                                   minuniqueness, "--purgeseqs"]
+                                  + purgeseqs + ["--keepseqs"] + keepseqs)
             expected = alignment.replace("test_SUMO", "expected_SUMO")
             with open(expected) as f_expected, open(alignment) as f_actual:
                 expectedtext = f_expected.read()
                 actualtext = f_actual.read()
             self.assertTrue(
                 expectedtext == actualtext,
-                "Did not get expected results for {0}".format(alignment),
-            )
+                "Did not get expected results for {0}".format(alignment))
 
 
 if __name__ == "__main__":

--- a/tests/test_prepalignment_prealigned.py
+++ b/tests/test_prepalignment_prealigned.py
@@ -39,20 +39,14 @@ class TestPrepAlignment(unittest.TestCase):
                            ("0.7", "2", [""], [keepseqsfile]),
                            ("0.7", "2", [purgeseqsfile], ["Panu", "Ggor"]),
                            ("0.7", "2", ["Fcat"], [keepseqsfile])]:
-            alignmentSuffix = ("test_SUMO1_alignment_minidentity{0}_"
-                               "minuniqueness{1}_purgeseqs{2}_keepseqs{3}"
-                               ".fasta"
-                               .format(minidentity,
-                                       minuniqueness,
-                                       (os.path
-                                        .splitext(os.path
-                                                  .basename("".join(purgeseqs
-                                                                    )))[0]),
-                                       (os.path
-                                        .splitext(os.path
-                                                  .basename("".join(keepseqs
-                                                                    )))[0])
-                                       ))
+            alignmentSuffix = (
+                "test_SUMO1_alignment_minidentity{0}_minuniqueness{1}_"
+                "purgeseqs{2}_keepseqs{3}."
+                "fasta".format(minidentity, minuniqueness,
+                               (os.path.splitext(
+                                os.path.basename("".join(purgeseqs)))[0]),
+                               (os.path.splitext(
+                                os.path.basename("".join(keepseqs)))[0])))
             alignment = os.path.abspath(os.path.join(self.testdir,
                                                      alignmentSuffix))
             subprocess.check_call(["phydms_prepalignment", inseqs, alignment,

--- a/tests/test_readDivPressure.py
+++ b/tests/test_readDivPressure.py
@@ -11,38 +11,46 @@ import phydmslib.file_io
 
 
 class test_readPrefs(unittest.TestCase):
-
     def setUp(self):
-        self.divPressurefiles = [os.path.abspath(os.path.join(os.path.dirname
-                (__file__), './divpressure_tests/divpressure{0}'.format(suffix)))
-                for suffix in ['.csv', '.tsv', '.txt']]
-        self.assertTrue(all(map(os.path.isfile, self.divPressurefiles)), "Cannot "
-                "find divpressure needed for test.")
+        self.divPressurefiles = [
+            os.path.abspath(
+                os.path.join(
+                    os.path.dirname(__file__),
+                    "./divpressure_tests/divpressure{0}".format(suffix),
+                )
+            )
+            for suffix in [".csv", ".tsv", ".txt"]
+        ]
+        self.assertTrue(
+            all(map(os.path.isfile, self.divPressurefiles)),
+            "Cannot " "find divpressure needed for test.",
+        )
 
     def test_readDivPressure(self):
         """Read divPresures in three different formats."""
-        divPressure_as_array = {} # convert to numpy.array so we can use allclose
+        divPressure_array = {}
         for divPressureFile in self.divPressurefiles:
             divPressure = phydmslib.file_io.readDivPressure(divPressureFile)
             sites = sorted(divPressure.keys())
             divPressureList = []
             for r in sites:
-            	divPressureList.append(divPressure[r])
-            divPressure_as_array[divPressureFile] = numpy.array(divPressureList)
+                divPressureList.append(divPressure[r])
+            divPressure_array[divPressureFile] = numpy.array(divPressureList)
         for (i, f1) in enumerate(self.divPressurefiles):
-            divPressure1 = divPressure_as_array[f1]
-            for f2 in self.divPressurefiles[i + 1: ]:
-                divPressure2 = divPressure_as_array[f2]
-                self.assertTrue(divPressure1.shape == divPressure2.shape, "Did not read "
-                        "same number of diversifying pressure values from {0} and {1}".format(f1, f2))
-                self.assertTrue(numpy.allclose(divPressure1, divPressure2), "Did not get "
-                        "same diversifying pressure values from {0} and {1}".format(f1, f2))
+            divPressure1 = divPressure_array[f1]
+            for f2 in self.divPressurefiles[i + 1:]:
+                divPressure2 = divPressure_array[f2]
+                self.assertTrue(
+                    divPressure1.shape == divPressure2.shape,
+                    "Did not read same number of diversifying pressure "
+                    "values from {0} and {1}".format(f1, f2))
+                self.assertTrue(
+                    numpy.allclose(divPressure1, divPressure2),
+                    "Did not get "
+                    "same diversifying pressure values from {0} and {1}"
+                    .format(f1, f2))
 
 
-
-
-
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     runner = unittest.TextTestRunner()
     unittest.main(testRunner=runner)

--- a/tests/test_readDivPressure.py
+++ b/tests/test_readDivPressure.py
@@ -12,7 +12,9 @@ import phydmslib.file_io
 
 class test_readPrefs(unittest.TestCase):
     """Test reading preferences."""
+
     def setUp(self):
+        """Set up."""
         self.divPressurefiles = [
             os.path.abspath(
                 os.path.join(

--- a/tests/test_readDivPressure.py
+++ b/tests/test_readDivPressure.py
@@ -19,15 +19,11 @@ class test_readPrefs(unittest.TestCase):
             os.path.abspath(
                 os.path.join(
                     os.path.dirname(__file__),
-                    "./divpressure_tests/divpressure{0}".format(suffix),
-                )
-            )
-            for suffix in [".csv", ".tsv", ".txt"]
-        ]
+                    "./divpressure_tests/divpressure{0}".format(suffix)))
+            for suffix in [".csv", ".tsv", ".txt"]]
         self.assertTrue(
             all(map(os.path.isfile, self.divPressurefiles)),
-            "Cannot " "find divpressure needed for test.",
-        )
+            "Cannot " "find divpressure needed for test.")
 
     def test_readDivPressure(self):
         """Read divPresures in three different formats."""

--- a/tests/test_readDivPressure.py
+++ b/tests/test_readDivPressure.py
@@ -11,6 +11,7 @@ import phydmslib.file_io
 
 
 class test_readPrefs(unittest.TestCase):
+    """Test reading preferences."""
     def setUp(self):
         self.divPressurefiles = [
             os.path.abspath(

--- a/tests/test_readDivPressure.py
+++ b/tests/test_readDivPressure.py
@@ -17,9 +17,9 @@ class test_readPrefs(unittest.TestCase):
         """Set up."""
         self.divPressurefiles = [
             os.path.abspath(
-                os.path.join(
-                    os.path.dirname(__file__),
-                    "./divpressure_tests/divpressure{0}".format(suffix)))
+                os.path.join(os.path.dirname(__file__),
+                             "./divpressure_tests/divpressure{0}"
+                             .format(suffix)))
             for suffix in [".csv", ".tsv", ".txt"]]
         self.assertTrue(
             all(map(os.path.isfile, self.divPressurefiles)),

--- a/tests/test_readprefs.py
+++ b/tests/test_readprefs.py
@@ -10,17 +10,24 @@ import phydmslib.file_io
 
 
 class test_readPrefs(unittest.TestCase):
-
     def setUp(self):
-        self.prefsfiles = [os.path.abspath(os.path.join(os.path.dirname
-                (__file__), './NP_data/NP_prefs{0}'.format(suffix)))
-                for suffix in ['.csv', '.tsv', '-dms_tools_format.txt']]
-        self.assertTrue(all(map(os.path.isfile, self.prefsfiles)), "Cannot "
-                "find prefsfiles needed for test.")
+        self.prefsfiles = [
+            os.path.abspath(
+                os.path.join(
+                    os.path.dirname(__file__),
+                    "./NP_data/NP_prefs{0}".format(suffix)
+                )
+            )
+            for suffix in [".csv", ".tsv", "-dms_tools_format.txt"]
+        ]
+        self.assertTrue(
+            all(map(os.path.isfile, self.prefsfiles)),
+            "Cannot " "find prefsfiles needed for test.",
+        )
 
     def test_readPrefs(self):
         """Read preferences in three different formats."""
-        prefs_as_array = {} # convert to numpy.array so we can use allclose
+        prefs_as_array = {}  # convert to numpy.array so we can use allclose
         for prefsfile in self.prefsfiles:
             prefs = phydmslib.file_io.readPrefs(prefsfile)
             sites = sorted(prefs.keys())
@@ -32,12 +39,17 @@ class test_readPrefs(unittest.TestCase):
             prefs_as_array[prefsfile] = numpy.array(preflist)
         for (i, f1) in enumerate(self.prefsfiles):
             prefs1 = prefs_as_array[f1]
-            for f2 in self.prefsfiles[i + 1: ]:
+            for f2 in self.prefsfiles[i + 1:]:
                 prefs2 = prefs_as_array[f2]
-                self.assertTrue(prefs1.shape == prefs2.shape, "Did not read "
-                        "same number of prefs from {0} and {1}".format(f1, f2))
-                self.assertTrue(numpy.allclose(prefs1, prefs2), "Did not get "
-                        "same prefs from {0} and {1}".format(f1, f2))
+                self.assertTrue(
+                    prefs1.shape == prefs2.shape,
+                    "Did not read "
+                    "same number of prefs from {0} and {1}".format(f1, f2),
+                )
+                self.assertTrue(
+                    numpy.allclose(prefs1, prefs2),
+                    "Did not get " "same prefs from {0} and {1}"
+                    .format(f1, f2))
 
     def test_avgPrefs(self):
         """Tests that the `avgprefs` option works."""
@@ -50,14 +62,17 @@ class test_readPrefs(unittest.TestCase):
                 firstsiteprefs = numpy.array([prefs[r][aa] for aa in aas])
             else:
                 siteprefs = numpy.array([prefs[r][aa] for aa in aas])
-                self.assertTrue(numpy.allclose(firstsiteprefs, siteprefs),
-                        "Prefs not same for all sites wth avgprefs")
+                self.assertTrue(
+                    numpy.allclose(firstsiteprefs, siteprefs),
+                    "Prefs not same for all sites wth avgprefs",
+                )
 
     def test_minPrefs(self):
         """Tests that the `minprefs` option works."""
         minpref = 0.01
         prefs = phydmslib.file_io.readPrefs(self.prefsfiles[0], minpref=0)
-        prefsmin = phydmslib.file_io.readPrefs(self.prefsfiles[0], minpref=minpref)
+        prefsmin = phydmslib.file_io.readPrefs(self.prefsfiles[0],
+                                               minpref=minpref)
         sites = sorted(prefs.keys())
         aas = sorted(prefs[sites[0]].keys())
         prefslist = []
@@ -68,13 +83,15 @@ class test_readPrefs(unittest.TestCase):
                 prefsminlist.append(prefsmin[r][aa])
         prefsarray = numpy.array(prefslist)
         prefsminarray = numpy.array(prefsminlist)
-        self.assertTrue((prefsarray < minpref).any(), "Not a good test "
-                "as all prefs already >= minpref")
-        self.assertFalse((prefsminarray < minpref).any(), "Still found "
-                "prefs < minpref")
+        self.assertTrue(
+            (prefsarray < minpref).any(),
+            "Not a good test " "as all prefs already >= minpref",
+        )
+        self.assertFalse(
+            (prefsminarray < minpref).any(), "Still found " "prefs < minpref"
+        )
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     runner = unittest.TextTestRunner()
     unittest.main(testRunner=runner)

--- a/tests/test_readprefs.py
+++ b/tests/test_readprefs.py
@@ -10,7 +10,10 @@ import phydmslib.file_io
 
 
 class test_readPrefs(unittest.TestCase):
+    """Tests reading in prefs."""
+
     def setUp(self):
+        """Set up models."""
         self.prefsfiles = [
             os.path.abspath(
                 os.path.join(

--- a/tests/test_readprefs.py
+++ b/tests/test_readprefs.py
@@ -18,15 +18,11 @@ class test_readPrefs(unittest.TestCase):
             os.path.abspath(
                 os.path.join(
                     os.path.dirname(__file__),
-                    "./NP_data/NP_prefs{0}".format(suffix)
-                )
-            )
-            for suffix in [".csv", ".tsv", "-dms_tools_format.txt"]
-        ]
+                    "./NP_data/NP_prefs{0}".format(suffix)))
+            for suffix in [".csv", ".tsv", "-dms_tools_format.txt"]]
         self.assertTrue(
             all(map(os.path.isfile, self.prefsfiles)),
-            "Cannot " "find prefsfiles needed for test.",
-        )
+            "Cannot " "find prefsfiles needed for test.")
 
     def test_readPrefs(self):
         """Read preferences in three different formats."""
@@ -47,12 +43,11 @@ class test_readPrefs(unittest.TestCase):
                 self.assertTrue(
                     prefs1.shape == prefs2.shape,
                     "Did not read "
-                    "same number of prefs from {0} and {1}".format(f1, f2),
-                )
+                    "same number of prefs from {0} and {1}".format(f1, f2),)
                 self.assertTrue(
                     numpy.allclose(prefs1, prefs2),
-                    "Did not get " "same prefs from {0} and {1}"
-                    .format(f1, f2))
+                    "Did not get " "same prefs from {0} and {1}".format(f1, f2)
+                    )
 
     def test_avgPrefs(self):
         """Tests that the `avgprefs` option works."""
@@ -67,8 +62,7 @@ class test_readPrefs(unittest.TestCase):
                 siteprefs = numpy.array([prefs[r][aa] for aa in aas])
                 self.assertTrue(
                     numpy.allclose(firstsiteprefs, siteprefs),
-                    "Prefs not same for all sites wth avgprefs",
-                )
+                    "Prefs not same for all sites wth avgprefs")
 
     def test_minPrefs(self):
         """Tests that the `minprefs` option works."""
@@ -88,11 +82,9 @@ class test_readPrefs(unittest.TestCase):
         prefsminarray = numpy.array(prefsminlist)
         self.assertTrue(
             (prefsarray < minpref).any(),
-            "Not a good test " "as all prefs already >= minpref",
-        )
+            "Not a good test " "as all prefs already >= minpref")
         self.assertFalse(
-            (prefsminarray < minpref).any(), "Still found " "prefs < minpref"
-        )
+            (prefsminarray < minpref).any(), "Still found " "prefs < minpref")
 
 
 if __name__ == "__main__":

--- a/tests/test_readprefs.py
+++ b/tests/test_readprefs.py
@@ -15,10 +15,9 @@ class test_readPrefs(unittest.TestCase):
     def setUp(self):
         """Set up models."""
         self.prefsfiles = [
-            os.path.abspath(
-                os.path.join(
-                    os.path.dirname(__file__),
-                    "./NP_data/NP_prefs{0}".format(suffix)))
+            os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                         "./NP_data/NP_prefs{0}"
+                                         .format(suffix)))
             for suffix in [".csv", ".tsv", "-dms_tools_format.txt"]]
         self.assertTrue(
             all(map(os.path.isfile, self.prefsfiles)),
@@ -46,8 +45,8 @@ class test_readPrefs(unittest.TestCase):
                     "same number of prefs from {0} and {1}".format(f1, f2),)
                 self.assertTrue(
                     numpy.allclose(prefs1, prefs2),
-                    "Did not get " "same prefs from {0} and {1}".format(f1, f2)
-                    )
+                    "Did not get " "same prefs from {0} and {1}"
+                    .format(f1, f2))
 
     def test_avgPrefs(self):
         """Tests that the `avgprefs` option works."""

--- a/tests/test_spielmanwr.py
+++ b/tests/test_spielmanwr.py
@@ -1,12 +1,14 @@
 """Tests the calculation of spielmanwr, following Spielman and Wilke, 2015.
 
-Written by Jesse Bloom and Sarah Hilton."""
+Written by Jesse Bloom and Sarah Hilton.
+"""
 
 
 import random
 import unittest
 import numpy
-from phydmslib.constants import *
+from phydmslib.constants import (N_NT, N_AA, AA_TO_INDEX, N_CODON,
+                                 CODON_SINGLEMUT, CODON_NONSYN)
 import phydmslib.models
 
 
@@ -19,7 +21,6 @@ class testExpCM_spielmanwr(unittest.TestCase):
 
     def testExpCM_spielmanwr(self):
         """Test the `ExpCM` function `_spielman_wr`."""
-
         # create models
         random.seed(1)
         numpy.random.seed(1)
@@ -27,7 +28,7 @@ class testExpCM_spielmanwr(unittest.TestCase):
         g = numpy.random.dirichlet([5] * N_NT)
         prefs = []
         minpref = 0.01
-        for r in range(nsites):
+        for _r in range(nsites):
             rprefs = numpy.random.dirichlet([0.5] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
@@ -55,7 +56,6 @@ class testExpCM_spielmanwr(unittest.TestCase):
                         denominator += prx * Qxy
             wr.append(numerator / denominator)
         wr = numpy.array(wr)
-        print(wr, self.model.spielman_wr(norm=False))
         self.assertTrue(
             numpy.allclose(wr, self.model.spielman_wr(norm=False), rtol=0.01)
         )

--- a/tests/test_spielmanwr.py
+++ b/tests/test_spielmanwr.py
@@ -57,13 +57,10 @@ class testExpCM_spielmanwr(unittest.TestCase):
             wr.append(numerator / denominator)
         wr = numpy.array(wr)
         self.assertTrue(
-            numpy.allclose(wr, self.model.spielman_wr(norm=False), rtol=0.01)
-        )
+            numpy.allclose(wr, self.model.spielman_wr(norm=False), rtol=0.01))
         self.assertTrue(
-            numpy.allclose(wr / self.model.omega,
-                           self.model.spielman_wr(),
-                           rtol=0.01)
-        )
+            numpy.allclose(wr / self.model.omega, self.model.spielman_wr(),
+                           rtol=0.01))
 
 
 class test_empirical_phi_spielmanwr(testExpCM_spielmanwr):

--- a/tests/test_spielmanwr.py
+++ b/tests/test_spielmanwr.py
@@ -54,8 +54,9 @@ class testExpCM_spielmanwr(unittest.TestCase):
                         denominator += prx * Qxy
             wr.append(numerator/denominator)
         wr = numpy.array(wr)
-        self.assertTrue(numpy.allclose(wr, numpy.array(self.model.spielman_wr(norm=False)), atol=1e-15))
-        self.assertTrue(numpy.allclose(wr/self.model.omega, numpy.array(self.model.spielman_wr()), atol=1e-15))
+        print(wr, numpy.array(self.model.spielman_wr(norm=False)), wr - numpy.array(self.model.spielman_wr(norm=False)))
+        self.assertTrue(numpy.allclose(wr, numpy.array(self.model.spielman_wr(norm=False)), atol=1e-10))
+        self.assertTrue(numpy.allclose(wr/self.model.omega, numpy.array(self.model.spielman_wr()), atol=1e-10))
 
 
 class test_empirical_phi_spielmanwr(testExpCM_spielmanwr):

--- a/tests/test_spielmanwr.py
+++ b/tests/test_spielmanwr.py
@@ -9,6 +9,7 @@ import numpy
 from phydmslib.constants import *
 import phydmslib.models
 
+
 class testExpCM_spielmanwr(unittest.TestCase):
     """Test the calculation of `spielmanwr` using the model `ExpCM`."""
 
@@ -48,25 +49,31 @@ class testExpCM_spielmanwr(unittest.TestCase):
                 for y in range(N_CODON):
                     if CODON_SINGLEMUT[x][y] and CODON_NONSYN[x][y]:
                         prx = self.model.stationarystate[n][x]
-                        Prxy = (self.model.Prxy[n][x][y])
+                        Prxy = self.model.Prxy[n][x][y]
                         Qxy = self.model.Qxy[x][y]
                         numerator += prx * Prxy
                         denominator += prx * Qxy
-            wr.append(numerator/denominator)
+            wr.append(numerator / denominator)
         wr = numpy.array(wr)
         print(wr, self.model.spielman_wr(norm=False))
-        self.assertTrue(numpy.allclose(wr, self.model.spielman_wr(norm=False), rtol=0.01))
-        self.assertTrue(numpy.allclose(wr/self.model.omega, self.model.spielman_wr(), rtol=0.01))
+        self.assertTrue(
+            numpy.allclose(wr, self.model.spielman_wr(norm=False), rtol=0.01)
+        )
+        self.assertTrue(
+            numpy.allclose(wr / self.model.omega,
+                           self.model.spielman_wr(),
+                           rtol=0.01)
+        )
 
 
 class test_empirical_phi_spielmanwr(testExpCM_spielmanwr):
-    """Test the calculation of `spielmanwr` using the model `ExpCM_empirical_phi`"""
+    """Test the calc of `spielmanwr` using the model `ExpCM_empirical_phi`"""
 
     # use approach here to run multiple tests:
     # http://stackoverflow.com/questions/17260469/instantiate-python-unittest-testcase-with-arguments
     MODEL = phydmslib.models.ExpCM_empirical_phi
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     runner = unittest.TextTestRunner()
     unittest.main(testRunner=runner)

--- a/tests/test_spielmanwr.py
+++ b/tests/test_spielmanwr.py
@@ -54,9 +54,8 @@ class testExpCM_spielmanwr(unittest.TestCase):
                         denominator += prx * Qxy
             wr.append(numerator/denominator)
         wr = numpy.array(wr)
-        print(wr, numpy.array(self.model.spielman_wr(norm=False)), wr - numpy.array(self.model.spielman_wr(norm=False)))
-        self.assertTrue(numpy.allclose(wr, numpy.array(self.model.spielman_wr(norm=False)), atol=1e-10))
-        self.assertTrue(numpy.allclose(wr/self.model.omega, numpy.array(self.model.spielman_wr()), atol=1e-10))
+        self.assertTrue(numpy.allclose(wr, numpy.array(self.model.spielman_wr(norm=False)), rtol=0.01))
+        self.assertTrue(numpy.allclose(wr/self.model.omega, numpy.array(self.model.spielman_wr()), atol=0.01))
 
 
 class test_empirical_phi_spielmanwr(testExpCM_spielmanwr):

--- a/tests/test_spielmanwr.py
+++ b/tests/test_spielmanwr.py
@@ -54,8 +54,8 @@ class testExpCM_spielmanwr(unittest.TestCase):
                         denominator += prx * Qxy
             wr.append(numerator/denominator)
         wr = numpy.array(wr)
-        self.assertTrue(numpy.allclose(wr, numpy.array(self.model.spielman_wr(norm=False)), rtol=0.01))
-        self.assertTrue(numpy.allclose(wr/self.model.omega, numpy.array(self.model.spielman_wr()), rtol=0.01))
+        self.assertTrue(numpy.allclose(wr, numpy.array(self.model.spielman_wr(norm=False)), atol=1e-15))
+        self.assertTrue(numpy.allclose(wr/self.model.omega, numpy.array(self.model.spielman_wr()), atol=1e-15))
 
 
 class test_empirical_phi_spielmanwr(testExpCM_spielmanwr):

--- a/tests/test_spielmanwr.py
+++ b/tests/test_spielmanwr.py
@@ -54,8 +54,9 @@ class testExpCM_spielmanwr(unittest.TestCase):
                         denominator += prx * Qxy
             wr.append(numerator/denominator)
         wr = numpy.array(wr)
-        self.assertTrue(numpy.allclose(wr, numpy.array(self.model.spielman_wr(norm=False)), rtol=0.01))
-        self.assertTrue(numpy.allclose(wr/self.model.omega, numpy.array(self.model.spielman_wr()), atol=0.01))
+        print(wr, self.model.spielman_wr(norm=False))
+        self.assertTrue(numpy.allclose(wr, self.model.spielman_wr(norm=False), rtol=0.01))
+        self.assertTrue(numpy.allclose(wr/self.model.omega, self.model.spielman_wr(), rtol=0.01))
 
 
 class test_empirical_phi_spielmanwr(testExpCM_spielmanwr):

--- a/tests/test_treelikelihood.py
+++ b/tests/test_treelikelihood.py
@@ -61,9 +61,8 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
         rates = "_temp_ratefile.txt"
         evolver = pyvolve.Evolver(partitions=partitions, tree=pyvolvetree)
         evolver(seqfile=alignment, infofile=info, ratefile=rates)
-        self.alignment = [
-            (s.description, str(s.seq)) for s in Bio.SeqIO.parse(alignment,
-                                                                 "fasta")]
+        self.alignment = [(s.description, str(s.seq))
+                          for s in Bio.SeqIO.parse(alignment, "fasta")]
         for f in [alignment, info, rates]:
             os.remove(f)
         assert len(self.alignment[0][1]) == self.nsites * 3
@@ -97,8 +96,7 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
             divpressure = numpy.random.uniform(-1, 5, self.nsites)
             divpressure /= max(abs(divpressure))
             self.model = phydmslib.models.ExpCM_empirical_phi_divpressure(
-                prefs, g, divpressure
-            )
+                prefs, g, divpressure)
         elif self.MODEL == phydmslib.models.YNGKP_M0:
             e_pw = numpy.random.uniform(0.2, 0.8, size=(3, N_NT))
             e_pw = e_pw / e_pw.sum(axis=1, keepdims=True)
@@ -115,9 +113,8 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
                                         .GammaDistributedBetaModel):
             self.model = self.DISTRIBUTIONMODEL(self.model, ncats=4)
         else:
-            raise ValueError(
-                "Invalid DISTRIBUTIONMODEL: {0}".format(self.DISTRIBUTIONMODEL)
-            )
+            raise ValueError("Invalid DISTRIBUTIONMODEL: {0}"
+                             .format(self.DISTRIBUTIONMODEL))
 
     def test_Initialize(self):
         """Test that initializes properly."""
@@ -125,8 +122,7 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
         numpy.random.seed(1)
 
         tl = phydmslib.treelikelihood.TreeLikelihood(
-            self.tree, self.alignment, self.model
-        )
+            self.tree, self.alignment, self.model)
         self.assertTrue(tl.nsites == self.nsites)
         self.assertTrue(tl.nseqs == self.nseqs)
         self.assertTrue(tl.nnodes == tl.ninternal + tl.ntips)

--- a/tests/test_treelikelihood.py
+++ b/tests/test_treelikelihood.py
@@ -84,7 +84,7 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
         g = numpy.random.dirichlet([5] * N_NT)
         g[g < 0.1] = 0.1
         g /= g.sum()
-        for r in range(self.nsites):
+        for _r in range(self.nsites):
             rprefs = numpy.random.dirichlet([0.5] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
@@ -220,7 +220,7 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
                                     "expected": siteloglik}
             loglik_by_mu[mu] = {"actual": tl.loglik, "expected": loglik}
 
-        for (i, mu1) in enumerate(mus):
+        for (_i, mu1) in enumerate(mus):
             for (name, d) in [
                 ("partials", partials_by_mu),
                 ("siteloglik", siteloglik_by_mu),
@@ -273,7 +273,8 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
     def test_MaximizeLikelihood(self):
         """Tests maximization likelihood.
 
-        Make sure it gives the same value for several starting points."""
+        Make sure it gives the same value for several starting points.
+        """
         random.seed(1)
         numpy.random.seed(1)
 

--- a/tests/test_treelikelihood.py
+++ b/tests/test_treelikelihood.py
@@ -152,15 +152,9 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
         logl = tl.loglik
         paramsarray = tl.paramsarray
         nparams = len(paramsarray)
-        self.assertTrue(
-            nparams
-            == sum(
-                map(
-                    lambda x: (1 if isinstance(x, float) else len(x)),
-                    modelparams.values(),
-                )
-            )
-        )
+        self.assertTrue(nparams == sum(map(lambda x: (1 if isinstance(x, float)
+                                                      else len(x)),
+                                           modelparams.values(),)))
         # set to new value, make sure have changed
         tl.paramsarray = numpy.array([random.uniform(0.7, 0.8)
                                       for i in range(nparams)])
@@ -187,9 +181,9 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
         for mu in mus:
             model = copy.deepcopy(self.model)
             model.updateParams({"mu": mu})
-            tl = phydmslib.treelikelihood.TreeLikelihood(
-                self.tree, self.alignment, model
-            )
+            tl = phydmslib.treelikelihood.TreeLikelihood(self.tree,
+                                                         self.alignment,
+                                                         model)
             # Here we are doing the multiplication hand-coded for the
             # tree defined in `setUp`. This calculation would be wrong
             # if the tree in `setUp` were to be changed.
@@ -207,8 +201,7 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
                             M[3][r][y][self.codons[3][r]]
                             * M[4][r][y][x]
                             * M[1][r][x][self.codons[1][r]]
-                            * M[2][r][x][self.codons[2][r]]
-                        )
+                            * M[2][r][x][self.codons[2][r]])
                     siteloglik[r] += partials[r][y] * model.stationarystate[r,
                                                                             y]
                 siteloglik[r] = math.log(siteloglik[r])
@@ -221,15 +214,12 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
             loglik_by_mu[mu] = {"actual": tl.loglik, "expected": loglik}
 
         for (_i, mu1) in enumerate(mus):
-            for (name, d) in [
-                ("partials", partials_by_mu),
-                ("siteloglik", siteloglik_by_mu),
-                ("loglik", loglik_by_mu),
-            ]:
+            for (name, d) in [("partials", partials_by_mu),
+                              ("siteloglik", siteloglik_by_mu),
+                              ("loglik", loglik_by_mu)]:
                 self.assertTrue(
                     numpy.allclose(d[mu1]["actual"], d[mu1]["expected"]),
-                    "Mismatch: {0}".format(name),
-                )
+                    "Mismatch: {0}".format(name))
 
     def test_LikelihoodDerivativesModelParams(self):
         """Test derivatives of with respect to model params."""
@@ -237,8 +227,7 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
         numpy.random.seed(1)
 
         tl = phydmslib.treelikelihood.TreeLikelihood(
-            self.tree, self.alignment, self.model
-        )
+            self.tree, self.alignment, self.model)
 
         for itest in range(2):
             modelparams = self.getModelParams(seed=itest)
@@ -258,17 +247,14 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
 
             for iparam in range(len(tl.paramsarray)):
                 diff = scipy.optimize.check_grad(
-                    func, dfunc, numpy.array([tl.paramsarray[iparam]]), iparam
-                )
+                    func, dfunc, numpy.array([tl.paramsarray[iparam]]), iparam)
                 self.assertTrue(
                     diff < 1e-1,
                     ("{0}: diff {1}, value " "{2}, deriv {3}").format(
                         tl._index_to_param[iparam],
                         diff,
                         tl.paramsarray[iparam],
-                        dfunc([tl.paramsarray[iparam]], iparam),
-                    ),
-                )
+                        dfunc([tl.paramsarray[iparam]], iparam)))
 
     def test_MaximizeLikelihood(self):
         """Tests maximization likelihood.
@@ -278,9 +264,8 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
         random.seed(1)
         numpy.random.seed(1)
 
-        tl = phydmslib.treelikelihood.TreeLikelihood(
-            self.tree, self.alignment, self.model
-        )
+        tl = phydmslib.treelikelihood.TreeLikelihood(self.tree, self.alignment,
+                                                     self.model)
 
         logliks = []
         paramsarrays = []
@@ -292,23 +277,18 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
             self.assertTrue(
                 tl.loglik > startloglik,
                 "no loglik increase: "
-                "start = {0}, end = {1}".format(startloglik, tl.loglik),
-            )
+                "start = {0}, end = {1}".format(startloglik, tl.loglik))
             for (otherloglik, otherparams) in zip(logliks, paramsarrays):
                 self.assertTrue(
                     numpy.allclose(tl.loglik, otherloglik,
                                    atol=1e-3, rtol=1e-3),
                     "Large difference in loglik: {0} vs {1}".format(
-                        otherloglik, tl.loglik
-                    ),
-                )
+                        otherloglik, tl.loglik))
                 self.assertTrue(
                     numpy.allclose(tl.paramsarray, otherparams,
                                    atol=1e-2, rtol=1e-1),
                     "Large difference in paramsarray: {0} vs {1}, {2}".format(
-                        otherparams, tl.paramsarray, self.model
-                    ),
-                )
+                        otherparams, tl.paramsarray, self.model))
             logliks.append(tl.loglik)
             paramsarrays.append(tl.paramsarray)
 

--- a/tests/test_treelikelihood.py
+++ b/tests/test_treelikelihood.py
@@ -131,7 +131,7 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
         self.assertTrue(tl.nseqs == self.nseqs)
         self.assertTrue(tl.nnodes == tl.ninternal + tl.ntips)
         self.assertTrue(tl.ntips == self.nseqs)
-        self.assertTrue(all([t > 0 for t in tl.t]))
+        self.assertTrue(all((t > 0 for t in tl.t)))
         for n in range(tl.ntips, tl.nnodes):
             for descend in [tl.rdescend, tl.ldescend]:
                 i = n - tl.ntips

--- a/tests/test_treelikelihood.py
+++ b/tests/test_treelikelihood.py
@@ -4,7 +4,6 @@ Written by Jesse Bloom and Sarah Hilton.
 """
 
 import os
-import sys
 import re
 import math
 import unittest
@@ -16,7 +15,8 @@ import Bio.Phylo
 import phydmslib.models
 import phydmslib.treelikelihood
 import phydmslib.simulate
-from phydmslib.constants import *
+from phydmslib.constants import (N_CODON, N_NT, AA_TO_INDEX,
+                                 N_AA, CODON_TO_INDEX)
 import pyvolve
 
 
@@ -34,46 +34,48 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
         numpy.random.seed(1)
 
         # define tree
-        self.newick = ('((node1:0.2,node2:0.3)node4:0.3,node3:0.5)node5:0.04;')
-        tempfile = '_temp.tree'
-        with open(tempfile, 'w') as f:
+        self.newick = "((node1:0.2,node2:0.3)node4:0.3,node3:0.5)node5:0.04;"
+        tempfile = "_temp.tree"
+        with open(tempfile, "w") as f:
             f.write(self.newick)
-        self.tree = Bio.Phylo.read(tempfile, 'newick')
+        self.tree = Bio.Phylo.read(tempfile, "newick")
         os.remove(tempfile)
         self.brlen = {}
         for (name, brlen) in re.findall(
-                r'(?P<name>node\d):(?P<brlen>\d+\.\d+)', self.newick):
+            r"(?P<name>node\d):(?P<brlen>\d+\.\d+)", self.newick
+        ):
             if name != self.tree.root.name:
-                i = name[-1] # node number
+                i = name[-1]  # node number
                 self.brlen[int(i)] = float(brlen)
 
         # simulate alignment with pyvolve
         pyvolvetree = pyvolve.read_tree(tree=self.newick)
         self.nsites = 60
         self.nseqs = self.tree.count_terminals()
-        e_pw = numpy.ndarray((3, N_NT), dtype='float')
+        e_pw = numpy.ndarray((3, N_NT), dtype="float")
         e_pw.fill(0.25)
         yngkp_m0 = phydmslib.models.YNGKP_M0(e_pw, self.nsites)
         partitions = phydmslib.simulate.pyvolvePartitions(yngkp_m0)
-        alignment = '_temp_simulatedalignment.fasta'
-        info = '_temp_info.txt'
-        rates = '_temp_ratefile.txt'
+        alignment = "_temp_simulatedalignment.fasta"
+        info = "_temp_info.txt"
+        rates = "_temp_ratefile.txt"
         evolver = pyvolve.Evolver(partitions=partitions, tree=pyvolvetree)
         evolver(seqfile=alignment, infofile=info, ratefile=rates)
-        self.alignment = [(s.description, str(s.seq)) for s in Bio.SeqIO.parse(
-                alignment, 'fasta')]
+        self.alignment = [
+            (s.description, str(s.seq)) for s in Bio.SeqIO.parse(alignment,
+                                                                 "fasta")]
         for f in [alignment, info, rates]:
             os.remove(f)
         assert len(self.alignment[0][1]) == self.nsites * 3
         assert len(self.alignment) == self.nseqs
-        self.codons = {} # indexed by node, site, gives codon index
+        self.codons = {}  # indexed by node, site, gives codon index
         for node in self.tree.get_terminals():
             node = node.name
             i = int(node[-1])
             self.codons[i] = {}
             seq = [seq for (head, seq) in self.alignment if node == head][0]
             for r in range(self.nsites):
-                codon = seq[3 * r : 3 * r + 3]
+                codon = seq[3 * r: 3 * r + 3]
                 self.codons[i][r] = CODON_TO_INDEX[codon]
 
         # define model
@@ -95,7 +97,8 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
             divpressure = numpy.random.uniform(-1, 5, self.nsites)
             divpressure /= max(abs(divpressure))
             self.model = phydmslib.models.ExpCM_empirical_phi_divpressure(
-                    prefs, g, divpressure)
+                prefs, g, divpressure
+            )
         elif self.MODEL == phydmslib.models.YNGKP_M0:
             e_pw = numpy.random.uniform(0.2, 0.8, size=(3, N_NT))
             e_pw = e_pw / e_pw.sum(axis=1, keepdims=True)
@@ -105,23 +108,25 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
 
         if self.DISTRIBUTIONMODEL is None:
             pass
-        elif (self.DISTRIBUTIONMODEL ==
-                phydmslib.models.GammaDistributedOmegaModel):
+        elif self.DISTRIBUTIONMODEL == (phydmslib.models
+                                        .GammaDistributedOmegaModel):
             self.model = self.DISTRIBUTIONMODEL(self.model, ncats=4)
-        elif (self.DISTRIBUTIONMODEL ==
-                phydmslib.models.GammaDistributedBetaModel):
+        elif self.DISTRIBUTIONMODEL == (phydmslib.models
+                                        .GammaDistributedBetaModel):
             self.model = self.DISTRIBUTIONMODEL(self.model, ncats=4)
         else:
-            raise ValueError("Invalid DISTRIBUTIONMODEL: {0}".format(
-                    self.DISTRIBUTIONMODEL))
+            raise ValueError(
+                "Invalid DISTRIBUTIONMODEL: {0}".format(self.DISTRIBUTIONMODEL)
+            )
 
     def test_Initialize(self):
         """Test that initializes properly."""
         random.seed(1)
         numpy.random.seed(1)
 
-        tl = phydmslib.treelikelihood.TreeLikelihood(self.tree,
-                self.alignment, self.model)
+        tl = phydmslib.treelikelihood.TreeLikelihood(
+            self.tree, self.alignment, self.model
+        )
         self.assertTrue(tl.nsites == self.nsites)
         self.assertTrue(tl.nseqs == self.nseqs)
         self.assertTrue(tl.nnodes == tl.ninternal + tl.ntips)
@@ -131,7 +136,7 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
             for descend in [tl.rdescend, tl.ldescend]:
                 i = n - tl.ntips
                 self.assertTrue(0 <= descend[i] < n,
-                        "{0}, {1}".format(n, descend[i]))
+                                "{0}, {1}".format(n, descend[i]))
         self.assertTrue(tl.nsites == len(tl.siteloglik))
 
     def test_paramsarray(self):
@@ -143,15 +148,22 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
         model = copy.deepcopy(self.model)
         model.updateParams(modelparams)
         tl = phydmslib.treelikelihood.TreeLikelihood(self.tree,
-                self.alignment, model)
+                                                     self.alignment, model)
         logl = tl.loglik
         paramsarray = tl.paramsarray
         nparams = len(paramsarray)
-        self.assertTrue(nparams == sum(map(lambda x: (1 if isinstance(x, float)
-                else len(x)), modelparams.values())))
+        self.assertTrue(
+            nparams
+            == sum(
+                map(
+                    lambda x: (1 if isinstance(x, float) else len(x)),
+                    modelparams.values(),
+                )
+            )
+        )
         # set to new value, make sure have changed
-        tl.paramsarray = numpy.array([random.uniform(0.7, 0.8) for i in
-                range(nparams)])
+        tl.paramsarray = numpy.array([random.uniform(0.7, 0.8)
+                                      for i in range(nparams)])
         for (param, value) in modelparams.items():
             self.assertFalse(numpy.allclose(value, getattr(tl.model, param)))
         self.assertFalse(numpy.allclose(logl, tl.loglik))
@@ -167,16 +179,17 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
         numpy.random.seed(1)
 
         if self.DISTRIBUTIONMODEL:
-            return # test doesn't work for DistributionModel
+            return  # test doesn't work for DistributionModel
         mus = [0.5, 1.5]
         partials_by_mu = {}
         siteloglik_by_mu = {}
         loglik_by_mu = {}
         for mu in mus:
             model = copy.deepcopy(self.model)
-            model.updateParams({'mu':mu})
-            tl = phydmslib.treelikelihood.TreeLikelihood(self.tree,
-                    self.alignment, model)
+            model.updateParams({"mu": mu})
+            tl = phydmslib.treelikelihood.TreeLikelihood(
+                self.tree, self.alignment, model
+            )
             # Here we are doing the multiplication hand-coded for the
             # tree defined in `setUp`. This calculation would be wrong
             # if the tree in `setUp` were to be changed.
@@ -190,31 +203,42 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
             for r in range(self.nsites):
                 for y in range(N_CODON):
                     for x in range(N_CODON):
-                        partials[r][y] += (M[3][r][y][self.codons[3][r]] *
-                                M[4][r][y][x] * M[1][r][x][self.codons[1][r]]
-                                * M[2][r][x][self.codons[2][r]])
-                    siteloglik[r] += partials[r][y] * model.stationarystate[r, y]
+                        partials[r][y] += (
+                            M[3][r][y][self.codons[3][r]]
+                            * M[4][r][y][x]
+                            * M[1][r][x][self.codons[1][r]]
+                            * M[2][r][x][self.codons[2][r]]
+                        )
+                    siteloglik[r] += partials[r][y] * model.stationarystate[r,
+                                                                            y]
                 siteloglik[r] = math.log(siteloglik[r])
                 loglik += siteloglik[r]
             rootnode = tl.nnodes - 1
-            partials_by_mu[mu] = {'actual':tl.L[rootnode], 'expected':partials}
-            siteloglik_by_mu[mu] = {'actual':tl.siteloglik, 'expected':siteloglik}
-            loglik_by_mu[mu] = {'actual':tl.loglik, 'expected':loglik}
+            partials_by_mu[mu] = {"actual": tl.L[rootnode],
+                                  "expected": partials}
+            siteloglik_by_mu[mu] = {"actual": tl.siteloglik,
+                                    "expected": siteloglik}
+            loglik_by_mu[mu] = {"actual": tl.loglik, "expected": loglik}
 
         for (i, mu1) in enumerate(mus):
-            for (name, d) in [('partials', partials_by_mu),
-                                      ('siteloglik', siteloglik_by_mu),
-                                      ('loglik', loglik_by_mu)]:
-                self.assertTrue(numpy.allclose(d[mu1]['actual'],
-                        d[mu1]['expected']), "Mismatch: {0}".format(name))
+            for (name, d) in [
+                ("partials", partials_by_mu),
+                ("siteloglik", siteloglik_by_mu),
+                ("loglik", loglik_by_mu),
+            ]:
+                self.assertTrue(
+                    numpy.allclose(d[mu1]["actual"], d[mu1]["expected"]),
+                    "Mismatch: {0}".format(name),
+                )
 
     def test_LikelihoodDerivativesModelParams(self):
         """Test derivatives of with respect to model params."""
         random.seed(1)
         numpy.random.seed(1)
 
-        tl = phydmslib.treelikelihood.TreeLikelihood(self.tree,
-                self.alignment, self.model)
+        tl = phydmslib.treelikelihood.TreeLikelihood(
+            self.tree, self.alignment, self.model
+        )
 
         for itest in range(2):
             modelparams = self.getModelParams(seed=itest)
@@ -225,18 +249,26 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
                 y[i] = x[0]
                 tl.paramsarray = y
                 return tl.loglik
+
             def dfunc(x, i):
                 y = tl.paramsarray
                 y[i] = x[0]
                 tl.paramsarray = y
                 return tl.dloglikarray[i]
+
             for iparam in range(len(tl.paramsarray)):
-                diff = scipy.optimize.check_grad(func, dfunc,
-                        numpy.array([tl.paramsarray[iparam]]), iparam)
-                self.assertTrue(diff < 1e-1, ("{0}: diff {1}, value "
-                        "{2}, deriv {3}").format(tl._index_to_param[iparam],
-                        diff, tl.paramsarray[iparam],
-                        dfunc([tl.paramsarray[iparam]], iparam)))
+                diff = scipy.optimize.check_grad(
+                    func, dfunc, numpy.array([tl.paramsarray[iparam]]), iparam
+                )
+                self.assertTrue(
+                    diff < 1e-1,
+                    ("{0}: diff {1}, value " "{2}, deriv {3}").format(
+                        tl._index_to_param[iparam],
+                        diff,
+                        tl.paramsarray[iparam],
+                        dfunc([tl.paramsarray[iparam]], iparam),
+                    ),
+                )
 
     def test_MaximizeLikelihood(self):
         """Tests maximization likelihood.
@@ -245,8 +277,9 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
         random.seed(1)
         numpy.random.seed(1)
 
-        tl = phydmslib.treelikelihood.TreeLikelihood(self.tree,
-                self.alignment, self.model)
+        tl = phydmslib.treelikelihood.TreeLikelihood(
+            self.tree, self.alignment, self.model
+        )
 
         logliks = []
         paramsarrays = []
@@ -254,18 +287,27 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
             modelparams = self.getModelParams(itest)
             tl.updateParams(modelparams)
             startloglik = tl.loglik
-            result = tl.maximizeLikelihood()
-            self.assertTrue(tl.loglik > startloglik, "no loglik increase: "
-                    "start = {0}, end = {1}".format(startloglik, tl.loglik))
+            tl.maximizeLikelihood()
+            self.assertTrue(
+                tl.loglik > startloglik,
+                "no loglik increase: "
+                "start = {0}, end = {1}".format(startloglik, tl.loglik),
+            )
             for (otherloglik, otherparams) in zip(logliks, paramsarrays):
-                self.assertTrue(numpy.allclose(tl.loglik, otherloglik,
-                        atol=1e-3, rtol=1e-3),
-                        "Large difference in loglik: {0} vs {1}".format(
-                        otherloglik, tl.loglik))
-                self.assertTrue(numpy.allclose(tl.paramsarray, otherparams,
-                        atol=1e-2, rtol=1e-1),
-                        "Large difference in paramsarray: {0} vs {1}, {2}".format(
-                        otherparams, tl.paramsarray, self.model))
+                self.assertTrue(
+                    numpy.allclose(tl.loglik, otherloglik,
+                                   atol=1e-3, rtol=1e-3),
+                    "Large difference in loglik: {0} vs {1}".format(
+                        otherloglik, tl.loglik
+                    ),
+                )
+                self.assertTrue(
+                    numpy.allclose(tl.paramsarray, otherparams,
+                                   atol=1e-2, rtol=1e-1),
+                    "Large difference in paramsarray: {0} vs {1}, {2}".format(
+                        otherparams, tl.paramsarray, self.model
+                    ),
+                )
             logliks.append(tl.loglik)
             paramsarrays.append(tl.paramsarray)
 
@@ -288,14 +330,16 @@ class test_TreeLikelihood_ExpCM(unittest.TestCase):
 
 class test_TreeLikelihood_ExpCM_empirical_phi(test_TreeLikelihood_ExpCM):
     """Tests `TreeLikelihood` for `ExpCM_empirical_phi`."""
+
     MODEL = phydmslib.models.ExpCM_empirical_phi
 
 
 class test_TreeLikelihood_YNGKP_M0(test_TreeLikelihood_ExpCM):
     """Tests `TreeLikelihood` for `YNGKP_M0`."""
+
     MODEL = phydmslib.models.YNGKP_M0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     runner = unittest.TextTestRunner()
     unittest.main(testRunner=runner)

--- a/tests/test_treelikelihood_fitprefs.py
+++ b/tests/test_treelikelihood_fitprefs.py
@@ -89,40 +89,29 @@ class test_TreeLikelihood_ExpCM_fitprefs(unittest.TestCase):
     def test_fitprefs_invquadratic_prior(self):
         """Tests fitting of preferences with invquadratic prior."""
         tls = {"no prior": copy.deepcopy(self.tl)}
-        for (name, c1, c2) in [
-            ("weak prior", 100, 0.25),
-            ("strong C1 prior", 200, 0.25),
-            ("strong C2 prior", 100, 0.75),
-        ]:
-            model = self.MODEL(
-                self.prefs,
-                prior=("invquadratic", c1, c2),
-                kappa=self.kappa,
-                omega=self.omega,
-                phi=self.phi,
-            )
-            tls[name] = phydmslib.treelikelihood.TreeLikelihood(
-                self.tree, self.alignment, model
-            )
+        for (name, c1, c2) in [("weak prior", 100, 0.25),
+                               ("strong C1 prior", 200, 0.25),
+                               ("strong C2 prior", 100, 0.75)]:
+            model = self.MODEL(self.prefs, prior=("invquadratic", c1, c2),
+                               kappa=self.kappa, omega=self.omega,
+                               phi=self.phi)
+            tls[name] = phydmslib.treelikelihood.TreeLikelihood(self.tree,
+                                                                self.alignment,
+                                                                model)
 
         logliks = [tl.loglik for tl in tls.values()]
         self.assertTrue(
             all((numpy.allclose(logliks[0], logliki) for logliki in logliks)),
             "All loglik should be equal prior to optimization as pi "
-            "starts at initial origpi values.",
-        )
+            "starts at initial origpi values.")
 
         for (_name, tl) in tls.items():
             tl.maximizeLikelihood()
 
-        self.assertTrue(
-            [
-                tls["no prior"].loglik > tl.loglik
-                for (name, tl) in tls.items()
-                if name != "no prior"
-            ],
-            "Unconstrained model does not have the highest loglik.",
-        )
+        (self
+         .assertTrue([tls["no prior"].loglik > tl.loglik
+                      for (name, tl) in tls.items() if name != "no prior"],
+                     "Unconstrained model does not have the highest loglik."))
 
         self.assertTrue(
             [
@@ -133,22 +122,12 @@ class test_TreeLikelihood_ExpCM_fitprefs(unittest.TestCase):
             "Weak prior does not have higher loglik than strong prior.",
         )
 
-        pidiff2 = {name: ((tl.model.pi - tl.model.origpi) ** 2).sum()
-                   for (_name, tl) in tls.items()}
-        self.assertTrue(
-            [
-                pidiff2["no prior"] > x
-                for (name, x) in pidiff2.items()
-                if name != "no prior"
-            ]
-        )
-        self.assertTrue(
-            [
-                pidiff2["weak prior"] > x
-                for (name, x) in pidiff2.items()
-                if "strong" in name
-            ]
-        )
+        pidiff2 = {name: (((tl.model.pi - tl.model.origpi)**2).sum()) for
+                   (name, tl) in tls.items()}
+        self.assertTrue([pidiff2["no prior"] > x for (name, x)
+                         in pidiff2.items() if name != "no prior"])
+        self.assertTrue([pidiff2["weak prior"] > x for (name, x)
+                         in pidiff2.items() if "strong" in name])
 
     def test_fitprefs_noprior(self):
         """Tests fitting of preferences with no prior."""

--- a/tests/test_treelikelihood_fitprefs.py
+++ b/tests/test_treelikelihood_fitprefs.py
@@ -7,12 +7,15 @@ import random
 import unittest
 import copy
 import os
-from phydmslib.constants import *
+from phydmslib.constants import (CODON_TO_INDEX, CODON_TO_AA, N_NT, N_AA,
+                                 INDEX_TO_CODON, AA_TO_INDEX, N_CODON)
 import phydmslib.models
 import phydmslib.file_io
 import phydmslib.simulate
 import phydmslib.treelikelihood
 import pyvolve
+import numpy
+import Bio
 
 
 class test_TreeLikelihood_ExpCM_fitprefs(unittest.TestCase):
@@ -35,79 +38,126 @@ class test_TreeLikelihood_ExpCM_fitprefs(unittest.TestCase):
             rprefs /= rprefs.sum()
             self.prefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))
             numpy.random.shuffle(rprefs)
-            self.realprefs.append(dict(zip(sorted(AA_TO_INDEX.keys()), rprefs)))
+            self.realprefs.append(dict(zip(sorted(AA_TO_INDEX.keys()),
+                                           rprefs)))
         self.kappa = 3.0
         self.omega = 3.0
         self.phi = numpy.random.dirichlet([5] * N_NT)
         self.model = self.MODEL(self.prefs,
-                prior=None, kappa=self.kappa, omega=self.omega, phi=self.phi)
+                                prior=None,
+                                kappa=self.kappa,
+                                omega=self.omega,
+                                phi=self.phi)
         self.realmodel = phydmslib.models.ExpCM(self.realprefs,
-                kappa=self.kappa, omega=self.omega, mu=10.0, phi=self.phi)
+                                                kappa=self.kappa,
+                                                omega=self.omega,
+                                                mu=10.0,
+                                                phi=self.phi)
 
-        treefile = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './NP_data/NP_tree.newick'))
-        self.tree = Bio.Phylo.read(treefile, 'newick')
+        treefile = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "./NP_data/NP_tree.newick")
+        )
+        self.tree = Bio.Phylo.read(treefile, "newick")
         self.tree.root_at_midpoint()
 
         # simulate alignment using realmodel
         evolver = pyvolve.Evolver(
-                partitions=phydmslib.simulate.pyvolvePartitions(self.realmodel),
-                tree=pyvolve.read_tree(file=treefile))
-        alignmentfile = '_temp_fitprefs_simulatedalignment.fasta'
-        info = '_temp_info.txt'
-        rates = '_temp_ratefile.txt'
+            partitions=phydmslib.simulate.pyvolvePartitions(self.realmodel),
+            tree=pyvolve.read_tree(file=treefile),
+        )
+        alignmentfile = "_temp_fitprefs_simulatedalignment.fasta"
+        info = "_temp_info.txt"
+        rates = "_temp_ratefile.txt"
         evolver(seqfile=alignmentfile, infofile=info, ratefile=rates)
-        self.alignment = phydmslib.file_io.ReadCodonAlignment(alignmentfile, True)
+        self.alignment = phydmslib.file_io.ReadCodonAlignment(alignmentfile,
+                                                              True)
         assert len(self.alignment[0][1]) == nsites * 3
         for f in [alignmentfile, info, rates]:
             os.remove(f)
-        self.codoncounts = dict([(r, dict([(INDEX_TO_CODON[c], 0)
-                for c in range(N_CODON)])) for r in range(nsites)])
-        self.aacounts = dict([(r, dict([(a, 0) for a in range(N_AA)]))
-                for r in range(nsites)])
+        self.codoncounts = dict(
+            [
+                (r, dict([(INDEX_TO_CODON[c], 0) for c in range(N_CODON)]))
+                for r in range(nsites)
+            ]
+        )
+        self.aacounts = dict(
+            [(r, dict([(a, 0) for a in range(N_AA)])) for r in range(nsites)]
+        )
         for (head, seq) in self.alignment:
             self.codoncounts[r][seq] += 1
             self.aacounts[r][CODON_TO_AA[CODON_TO_INDEX[seq]]] += 1
 
-        self.tl = phydmslib.treelikelihood.TreeLikelihood(self.tree,
-                self.alignment, self.model)
+        self.tl = phydmslib.treelikelihood.TreeLikelihood(
+            self.tree, self.alignment, self.model
+        )
 
     def test_fitprefs_invquadratic_prior(self):
         """Tests fitting of preferences with invquadratic prior."""
-        tls = {'no prior':copy.deepcopy(self.tl)}
-        for (name, c1, c2) in [('weak prior', 100, 0.25),
-                               ('strong C1 prior', 200, 0.25),
-                               ('strong C2 prior', 100, 0.75)]:
-            model = self.MODEL(self.prefs,
-                    prior=('invquadratic', c1, c2), kappa=self.kappa,
-                    omega=self.omega, phi=self.phi)
-            tls[name] = phydmslib.treelikelihood.TreeLikelihood(self.tree,
-                    self.alignment, model)
+        tls = {"no prior": copy.deepcopy(self.tl)}
+        for (name, c1, c2) in [
+            ("weak prior", 100, 0.25),
+            ("strong C1 prior", 200, 0.25),
+            ("strong C2 prior", 100, 0.75),
+        ]:
+            model = self.MODEL(
+                self.prefs,
+                prior=("invquadratic", c1, c2),
+                kappa=self.kappa,
+                omega=self.omega,
+                phi=self.phi,
+            )
+            tls[name] = phydmslib.treelikelihood.TreeLikelihood(
+                self.tree, self.alignment, model
+            )
 
         logliks = [tl.loglik for tl in tls.values()]
-        self.assertTrue(all([numpy.allclose(logliks[0], logliki)
-                for logliki in logliks]),
-                "All loglik should be equal prior to optimization as pi "
-                "starts at initial origpi values.")
+        self.assertTrue(
+            all([numpy.allclose(logliks[0], logliki) for logliki in logliks]),
+            "All loglik should be equal prior to optimization as pi "
+            "starts at initial origpi values.",
+        )
 
         for (name, tl) in tls.items():
-            maxresult = tl.maximizeLikelihood()
+            tl.maximizeLikelihood()
 
-        self.assertTrue([tls['no prior'].loglik > tl.loglik for
-                (name, tl) in tls.items() if name != 'no prior'],
-                "Unconstrained model does not have the highest loglik.")
+        self.assertTrue(
+            [
+                tls["no prior"].loglik > tl.loglik
+                for (name, tl) in tls.items()
+                if name != "no prior"
+            ],
+            "Unconstrained model does not have the highest loglik.",
+        )
 
-        self.assertTrue([tls['weak prior'].loglik > tl.loglik for
-                (name, tl) in tls.items() if 'strong' in name],
-                "Weak prior does not have higher loglik than strong prior.")
+        self.assertTrue(
+            [
+                tls["weak prior"].loglik > tl.loglik
+                for (name, tl) in tls.items()
+                if "strong" in name
+            ],
+            "Weak prior does not have higher loglik than strong prior.",
+        )
 
-        pidiff2 = dict([(name, ((tl.model.pi - tl.model.origpi)**2).sum()) for
-                (name, tl) in tls.items()])
-        self.assertTrue([pidiff2['no prior'] > x for (name, x) in
-                pidiff2.items() if name != 'no prior'])
-        self.assertTrue([pidiff2['weak prior'] > x for (name, x) in
-                pidiff2.items() if 'strong' in name])
-
+        pidiff2 = dict(
+            [
+                (name, ((tl.model.pi - tl.model.origpi) ** 2).sum())
+                for (name, tl) in tls.items()
+            ]
+        )
+        self.assertTrue(
+            [
+                pidiff2["no prior"] > x
+                for (name, x) in pidiff2.items()
+                if name != "no prior"
+            ]
+        )
+        self.assertTrue(
+            [
+                pidiff2["weak prior"] > x
+                for (name, x) in pidiff2.items()
+                if "strong" in name
+            ]
+        )
 
     def test_fitprefs_noprior(self):
         """Tests fitting of preferences with no prior."""
@@ -117,20 +167,24 @@ class test_TreeLikelihood_ExpCM_fitprefs(unittest.TestCase):
             numpy.random.seed(seed)
             if self.MODEL == phydmslib.models.ExpCM_fitprefs:
                 tl.paramsarray = numpy.random.uniform(0.1, 0.99,
-                        len(tl.paramsarray))
+                                                      len(tl.paramsarray))
             elif self.MODEL == phydmslib.models.ExpCM_fitprefs2:
                 tl.paramsarray = numpy.random.uniform(0.5, 5.0,
-                        len(tl.paramsarray))
+                                                      len(tl.paramsarray))
             else:
                 raise ValueError("Unrecognized MODEL: {0}".format(self.MODEL))
             if firstloglik:
-                self.assertFalse(numpy.allclose(firstloglik, tl.loglik,
-                        atol=0.02), "loglik matches even with random pi")
-            maxresult = tl.maximizeLikelihood()
+                self.assertFalse(
+                    numpy.allclose(firstloglik, tl.loglik, atol=0.02),
+                    "loglik matches even with random pi",
+                )
+            tl.maximizeLikelihood()
             if firstloglik:
-                self.assertTrue(numpy.allclose(firstloglik, tl.loglik,
-                        atol=0.4), "loglik not the same for different starts:"
-                        " {0} versus {1}".format(firstloglik, tl.loglik))
+                self.assertTrue(
+                    numpy.allclose(firstloglik, tl.loglik, atol=0.4),
+                    "loglik not the same for different starts:"
+                    " {0} versus {1}".format(firstloglik, tl.loglik),
+                )
             else:
                 firstloglik = tl.loglik
             self.assertTrue(numpy.allclose(tl.model.origpi, self.model.pi))
@@ -139,8 +193,8 @@ class test_TreeLikelihood_ExpCM_fitprefs(unittest.TestCase):
                 for (c, nc) in self.codoncounts[r].items():
                     if nc > 0:
                         for (c2, nc2) in self.codoncounts[r].items():
-                            ndiffs = len([i for (i, ci) in enumerate(c)
-                                    if ci != c2[i]])
+                            ndiffs = len([i for (i, ci) in
+                                          enumerate(c) if ci != c2[i]])
                             a = CODON_TO_AA[CODON_TO_INDEX[c]]
                             a2 = CODON_TO_AA[CODON_TO_INDEX[c2]]
                             na2 = self.aacounts[r][a2]
@@ -157,7 +211,6 @@ class test_TreeLikelihood_ExpCM_fitprefs2(test_TreeLikelihood_ExpCM_fitprefs):
     MODEL = phydmslib.models.ExpCM_fitprefs2
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     runner = unittest.TextTestRunner()
     unittest.main(testRunner=runner)

--- a/tests/test_treelikelihood_fitprefs.py
+++ b/tests/test_treelikelihood_fitprefs.py
@@ -56,16 +56,15 @@ class test_TreeLikelihood_ExpCM_fitprefs(unittest.TestCase):
                                                 phi=self.phi)
 
         treefile = os.path.abspath(
-            os.path.join(os.path.dirname(__file__), "./NP_data/NP_tree.newick")
-        )
+            os.path.join(os.path.dirname(__file__),
+                         "./NP_data/NP_tree.newick"))
         self.tree = Bio.Phylo.read(treefile, "newick")
         self.tree.root_at_midpoint()
 
         # simulate alignment using realmodel
         evolver = pyvolve.Evolver(
             partitions=phydmslib.simulate.pyvolvePartitions(self.realmodel),
-            tree=pyvolve.read_tree(file=treefile),
-        )
+            tree=pyvolve.read_tree(file=treefile))
         alignmentfile = "_temp_fitprefs_simulatedalignment.fasta"
         info = "_temp_info.txt"
         rates = "_temp_ratefile.txt"
@@ -84,8 +83,7 @@ class test_TreeLikelihood_ExpCM_fitprefs(unittest.TestCase):
                 self.aacounts[r][CODON_TO_AA[CODON_TO_INDEX[seq[i: i+3]]]] += 1
 
         self.tl = phydmslib.treelikelihood.TreeLikelihood(
-            self.tree, self.alignment, self.model
-        )
+            self.tree, self.alignment, self.model)
 
     def test_fitprefs_invquadratic_prior(self):
         """Tests fitting of preferences with invquadratic prior."""
@@ -114,14 +112,10 @@ class test_TreeLikelihood_ExpCM_fitprefs(unittest.TestCase):
                       for (name, tl) in tls.items() if name != "no prior"],
                      "Unconstrained model does not have the highest loglik."))
 
-        self.assertTrue(
-            [
-                tls["weak prior"].loglik > tl.loglik
-                for (name, tl) in tls.items()
-                if "strong" in name
-            ],
-            "Weak prior does not have higher loglik than strong prior.",
-        )
+        self.assertTrue([tls["weak prior"].loglik > tl.loglik
+                        for (name, tl) in tls.items() if "strong" in name],
+                        "Weak prior does not have higher loglik than "
+                        "strong prior.")
 
         pidiff2 = {name: (((tl.model.pi - tl.model.origpi)**2).sum()) for
                    (name, tl) in tls.items()}
@@ -147,15 +141,13 @@ class test_TreeLikelihood_ExpCM_fitprefs(unittest.TestCase):
             if firstloglik:
                 self.assertFalse(
                     numpy.allclose(firstloglik, tl.loglik, atol=0.02),
-                    "loglik matches even with random pi",
-                )
+                    "loglik matches even with random pi")
             tl.maximizeLikelihood()
             if firstloglik:
                 self.assertTrue(
                     numpy.allclose(firstloglik, tl.loglik, atol=0.4),
                     "loglik not the same for different starts:"
-                    " {0} versus {1}".format(firstloglik, tl.loglik),
-                )
+                    " {0} versus {1}".format(firstloglik, tl.loglik))
             else:
                 firstloglik = tl.loglik
             self.assertTrue(numpy.allclose(tl.model.origpi, self.model.pi))

--- a/tests/test_treelikelihood_fitprefs.py
+++ b/tests/test_treelikelihood_fitprefs.py
@@ -1,6 +1,7 @@
 """Tests `TreeLikelihood` with `ExpCM_fitprefs` and `ExpCM_fitprefs2`.
 
-Written by Jesse Bloom."""
+Written by Jesse Bloom.
+"""
 
 
 import random
@@ -32,7 +33,7 @@ class test_TreeLikelihood_ExpCM_fitprefs(unittest.TestCase):
         minpref = 0.001
         self.prefs = []
         self.realprefs = []
-        for r in range(nsites):
+        for _r in range(nsites):
             rprefs = numpy.random.dirichlet([0.5] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
@@ -74,16 +75,10 @@ class test_TreeLikelihood_ExpCM_fitprefs(unittest.TestCase):
         assert len(self.alignment[0][1]) == nsites * 3
         for f in [alignmentfile, info, rates]:
             os.remove(f)
-        self.codoncounts = dict(
-            [
-                (r, dict([(INDEX_TO_CODON[c], 0) for c in range(N_CODON)]))
-                for r in range(nsites)
-            ]
-        )
-        self.aacounts = dict(
-            [(r, dict([(a, 0) for a in range(N_AA)])) for r in range(nsites)]
-        )
-        for (head, seq) in self.alignment:
+        self.codoncounts = {r: {INDEX_TO_CODON[c]: 0 for c in range(N_CODON)}
+                            for r in range(nsites)}
+        self.aacounts = {r: {a: 0 for a in range(N_AA)} for r in range(nsites)}
+        for (_head, seq) in self.alignment:
             self.codoncounts[r][seq] += 1
             self.aacounts[r][CODON_TO_AA[CODON_TO_INDEX[seq]]] += 1
 
@@ -117,7 +112,7 @@ class test_TreeLikelihood_ExpCM_fitprefs(unittest.TestCase):
             "starts at initial origpi values.",
         )
 
-        for (name, tl) in tls.items():
+        for (_name, tl) in tls.items():
             tl.maximizeLikelihood()
 
         self.assertTrue(
@@ -138,12 +133,8 @@ class test_TreeLikelihood_ExpCM_fitprefs(unittest.TestCase):
             "Weak prior does not have higher loglik than strong prior.",
         )
 
-        pidiff2 = dict(
-            [
-                (name, ((tl.model.pi - tl.model.origpi) ** 2).sum())
-                for (name, tl) in tls.items()
-            ]
-        )
+        pidiff2 = {name: ((tl.model.pi - tl.model.origpi) ** 2).sum()
+                   for (_name, tl) in tls.items()}
         self.assertTrue(
             [
                 pidiff2["no prior"] > x
@@ -192,7 +183,7 @@ class test_TreeLikelihood_ExpCM_fitprefs(unittest.TestCase):
             for r in range(tl.nsites):
                 for (c, nc) in self.codoncounts[r].items():
                     if nc > 0:
-                        for (c2, nc2) in self.codoncounts[r].items():
+                        for (c2, _nc2) in self.codoncounts[r].items():
                             ndiffs = len([i for (i, ci) in
                                           enumerate(c) if ci != c2[i]])
                             a = CODON_TO_AA[CODON_TO_INDEX[c]]

--- a/tests/test_treelikelihood_fitprefs.py
+++ b/tests/test_treelikelihood_fitprefs.py
@@ -33,7 +33,7 @@ class test_TreeLikelihood_ExpCM_fitprefs(unittest.TestCase):
         minpref = 0.001
         self.prefs = []
         self.realprefs = []
-        for r in range(nsites):
+        for _r in range(nsites):
             rprefs = numpy.random.dirichlet([0.5] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()

--- a/tests/test_treelikelihood_fitprefs.py
+++ b/tests/test_treelikelihood_fitprefs.py
@@ -33,7 +33,7 @@ class test_TreeLikelihood_ExpCM_fitprefs(unittest.TestCase):
         minpref = 0.001
         self.prefs = []
         self.realprefs = []
-        for _r in range(nsites):
+        for r in range(nsites):
             rprefs = numpy.random.dirichlet([0.5] * N_AA)
             rprefs[rprefs < minpref] = minpref
             rprefs /= rprefs.sum()
@@ -107,7 +107,7 @@ class test_TreeLikelihood_ExpCM_fitprefs(unittest.TestCase):
 
         logliks = [tl.loglik for tl in tls.values()]
         self.assertTrue(
-            all([numpy.allclose(logliks[0], logliki) for logliki in logliks]),
+            all((numpy.allclose(logliks[0], logliki) for logliki in logliks)),
             "All loglik should be equal prior to optimization as pi "
             "starts at initial origpi values.",
         )

--- a/tests/test_treelikelihood_fitprefs.py
+++ b/tests/test_treelikelihood_fitprefs.py
@@ -79,8 +79,9 @@ class test_TreeLikelihood_ExpCM_fitprefs(unittest.TestCase):
                             for r in range(nsites)}
         self.aacounts = {r: {a: 0 for a in range(N_AA)} for r in range(nsites)}
         for (_head, seq) in self.alignment:
-            self.codoncounts[r][seq] += 1
-            self.aacounts[r][CODON_TO_AA[CODON_TO_INDEX[seq]]] += 1
+            for r, i in enumerate(range(0, nsites+1, 3)):
+                self.codoncounts[r][seq[i: i+3]] += 1
+                self.aacounts[r][CODON_TO_AA[CODON_TO_INDEX[seq[i: i+3]]]] += 1
 
         self.tl = phydmslib.treelikelihood.TreeLikelihood(
             self.tree, self.alignment, self.model

--- a/tests/test_underflow.py
+++ b/tests/test_underflow.py
@@ -18,7 +18,6 @@ class test_underflow(unittest.TestCase):
 
     def test_underflow(self):
         """Tests correction for numerical underflow."""
-
         numpy.random.seed(1)
         random.seed(1)
 

--- a/tests/test_underflow.py
+++ b/tests/test_underflow.py
@@ -23,22 +23,17 @@ class test_underflow(unittest.TestCase):
 
         treefile = os.path.abspath(
             os.path.join(os.path.dirname(__file__),
-                         "./NP_data/NP_tree_short.newick")
-        )
+                         "./NP_data/NP_tree_short.newick"))
         alignmentfile = os.path.abspath(
             os.path.join(
                 os.path.dirname(__file__),
-                "./NP_data/NP_alignment_short.fasta"
-            )
-        )
+                "./NP_data/NP_alignment_short.fasta"))
         prefsfile = os.path.abspath(
             os.path.join(os.path.dirname(__file__),
-                         "./NP_data/NP_prefs_short.csv")
-        )
+                         "./NP_data/NP_prefs_short.csv"))
 
         alignment = phydmslib.file_io.ReadCodonAlignment(
-            alignmentfile, checknewickvalid=True
-        )
+            alignmentfile, checknewickvalid=True)
         tree = Bio.Phylo.read(treefile, "newick")
         tree.root_at_midpoint()
         prefs = phydmslib.file_io.readPrefs(prefsfile, minpref=0.005)
@@ -50,30 +45,21 @@ class test_underflow(unittest.TestCase):
 
         for (m, desc) in [(model, "simple"), (distmodel, "distribution")]:
             tl = phydmslib.treelikelihood.TreeLikelihood(
-                tree, alignment, m, underflowfreq=1
-            )
+                tree, alignment, m, underflowfreq=1)
             tl_nocorrection = phydmslib.treelikelihood.TreeLikelihood(
-                tree, alignment, m, underflowfreq=100000
-            )
+                tree, alignment, m, underflowfreq=100000)
 
             self.assertTrue(
                 numpy.allclose(tl.loglik, tl_nocorrection.loglik),
-                (
-                    "Log likelihoods differ with and without correction "
-                    "for {0}: {1} versus {2}".format(
-                        desc, tl.loglik, tl_nocorrection.loglik
-                    )
-                ),
-            )
+                ("Log likelihoods differ with and without correction "
+                 "for {0}: {1} versus {2}".format(desc, tl.loglik,
+                                                  tl_nocorrection.loglik)))
             for (param, dl) in tl_nocorrection.dloglik.items():
                 self.assertTrue(
                     numpy.allclose(dl, tl.dloglik[param]),
-                    (
-                        "dloglik differs with and without correction for {0}: "
-                        "{1}, {2} versus {3}"
-                        .format(param, desc, tl.dloglik[param], dl)
-                    ),
-                )
+                    ("dloglik differs with and without correction for {0}: "
+                     "{1}, {2} versus {3}".format(param, desc,
+                                                  tl.dloglik[param], dl)))
 
             oldloglik = tl.loglik
             tl.dparamscurrent = False
@@ -82,13 +68,9 @@ class test_underflow(unittest.TestCase):
             tl_nocorrection.dtcurrent = True
             self.assertTrue(
                 numpy.allclose(tl.loglik, tl_nocorrection.loglik),
-                (
-                    "Log likelihoods differ with and without correction "
-                    "for {0}: {1} versus {2}".format(
-                        desc, tl.loglik, tl_nocorrection.loglik
-                    )
-                ),
-            )
+                ("Log likelihoods differ with and without correction "
+                 "for {0}: {1} versus {2}".format(desc, tl.loglik,
+                                                  tl_nocorrection.loglik)))
             self.assertTrue(numpy.allclose(tl.loglik, oldloglik))
             self.assertTrue(numpy.allclose(tl.dloglik_dt,
                                            tl_nocorrection.dloglik_dt))

--- a/tests/test_underflow.py
+++ b/tests/test_underflow.py
@@ -4,15 +4,13 @@ Written by Jesse Bloom.
 """
 
 import os
-import sys
-import math
 import unittest
 import random
 import phydmslib.models
 import phydmslib.file_io
 import phydmslib.treelikelihood
-from phydmslib.constants import *
 import Bio.Phylo
+import numpy
 
 
 class test_underflow(unittest.TestCase):
@@ -24,55 +22,79 @@ class test_underflow(unittest.TestCase):
         numpy.random.seed(1)
         random.seed(1)
 
-        treefile = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './NP_data/NP_tree_short.newick'))
-        alignmentfile = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './NP_data/NP_alignment_short.fasta'))
-        prefsfile = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                './NP_data/NP_prefs_short.csv'))
+        treefile = os.path.abspath(
+            os.path.join(os.path.dirname(__file__),
+                         "./NP_data/NP_tree_short.newick")
+        )
+        alignmentfile = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "./NP_data/NP_alignment_short.fasta"
+            )
+        )
+        prefsfile = os.path.abspath(
+            os.path.join(os.path.dirname(__file__),
+                         "./NP_data/NP_prefs_short.csv")
+        )
 
-        alignment = phydmslib.file_io.ReadCodonAlignment(alignmentfile,
-                checknewickvalid=True)
-        tree = Bio.Phylo.read(treefile, 'newick')
+        alignment = phydmslib.file_io.ReadCodonAlignment(
+            alignmentfile, checknewickvalid=True
+        )
+        tree = Bio.Phylo.read(treefile, "newick")
         tree.root_at_midpoint()
         prefs = phydmslib.file_io.readPrefs(prefsfile, minpref=0.005)
         sites = sorted(prefs.keys())
         prefslist = [prefs[r] for r in sites]
 
         model = phydmslib.models.ExpCM(prefslist)
-        distmodel = phydmslib.models.GammaDistributedOmegaModel(
-                model, ncats=4)
+        distmodel = phydmslib.models.GammaDistributedOmegaModel(model, ncats=4)
 
-        for (m, desc) in [(model, 'simple'), (distmodel, 'distribution')]:
-            tl = phydmslib.treelikelihood.TreeLikelihood(tree,
-                    alignment, m, underflowfreq=1)
+        for (m, desc) in [(model, "simple"), (distmodel, "distribution")]:
+            tl = phydmslib.treelikelihood.TreeLikelihood(
+                tree, alignment, m, underflowfreq=1
+            )
             tl_nocorrection = phydmslib.treelikelihood.TreeLikelihood(
-                    tree, alignment, m, underflowfreq=100000)
+                tree, alignment, m, underflowfreq=100000
+            )
 
-            self.assertTrue(numpy.allclose(tl.loglik, tl_nocorrection.loglik),
-                    ("Log likelihoods differ with and without correction "
-                    "for {0}: {1} versus {2}".format(desc, tl.loglik,
-                    tl_nocorrection.loglik)))
+            self.assertTrue(
+                numpy.allclose(tl.loglik, tl_nocorrection.loglik),
+                (
+                    "Log likelihoods differ with and without correction "
+                    "for {0}: {1} versus {2}".format(
+                        desc, tl.loglik, tl_nocorrection.loglik
+                    )
+                ),
+            )
             for (param, dl) in tl_nocorrection.dloglik.items():
-                self.assertTrue(numpy.allclose(dl, tl.dloglik[param]),
-                        ('dloglik differs with and without correction for {0}: '
-                        '{1}, {2} versus {3}'.format(param, desc,
-                        tl.dloglik[param], dl)))
+                self.assertTrue(
+                    numpy.allclose(dl, tl.dloglik[param]),
+                    (
+                        "dloglik differs with and without correction for {0}: "
+                        "{1}, {2} versus {3}"
+                        .format(param, desc, tl.dloglik[param], dl)
+                    ),
+                )
 
             oldloglik = tl.loglik
             tl.dparamscurrent = False
             tl_nocorrection.dparamscurrent = False
             tl.dtcurrent = True
             tl_nocorrection.dtcurrent = True
-            self.assertTrue(numpy.allclose(tl.loglik, tl_nocorrection.loglik),
-                    ("Log likelihoods differ with and without correction "
-                    "for {0}: {1} versus {2}".format(desc, tl.loglik,
-                    tl_nocorrection.loglik)))
+            self.assertTrue(
+                numpy.allclose(tl.loglik, tl_nocorrection.loglik),
+                (
+                    "Log likelihoods differ with and without correction "
+                    "for {0}: {1} versus {2}".format(
+                        desc, tl.loglik, tl_nocorrection.loglik
+                    )
+                ),
+            )
             self.assertTrue(numpy.allclose(tl.loglik, oldloglik))
             self.assertTrue(numpy.allclose(tl.dloglik_dt,
-                    tl_nocorrection.dloglik_dt))
+                                           tl_nocorrection.dloglik_dt))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     runner = unittest.TextTestRunner()
     unittest.main(testRunner=runner)


### PR DESCRIPTION
This PR does two things
1. Lint the code to make it `pep8` compliant
2. Add `flake8` to the `travis` build to check for `pep8` compliance. 

The vast majority of the code changes are purely cosmetic. Of the top of my head I can think only two categories of changes that I wanted to run by you
1. One of the flags that was raised was about "bare" `except:` statements. I believe I replaced all of those with either `except Exception:` or `except ValueError` but let me know if you have a better way of handling that
2. I changed a docstring test so that it all fit on one line. Specifically, testing the `DiscreteGamma` function with three categories instead of four. 

After you look this over, but before were merge, I can update the CHANGELOG and the version and etc.