### PR TITLE
no `usetex` for matplotlib fonts in logo plots

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 ------
 * Stop using matplotlib LaTex fonts in logo plots.
 
+* Pin `biopython` to <1.78 until `Bio.Alphabet` issues fixed in `pyvolve`. See `here <https://github.com/sjspielman/pyvolve/issues/19>`_
+
 2.3.9
 ------
 * Started testing Pep8 compliance with `flake8`

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,10 @@
 Changelog
 ===========
+
+2.4.0
+------
+* Stop using matplotlib LaTex fonts in logo plots.
+
 2.3.9
 ------
 * Started testing Pep8 compliance with `flake8`

--- a/phydmslib/_metadata.py
+++ b/phydmslib/_metadata.py
@@ -1,4 +1,4 @@
-__version__ = '2.3.9'
+__version__ = '2.4.0'
 __author__ = 'the Bloom lab (see https://github.com/jbloomlab/phydms/contributors)'
 __url__ = 'http://jbloomlab.github.io/phydms'
 __author_email__ = 'jbloom@fredhutch.org'

--- a/phydmslib/weblogo.py
+++ b/phydmslib/weblogo.py
@@ -1027,7 +1027,7 @@ def LogoOverlay(sites, overlayfile, overlay, nperline, sitewidth, rmargin,
         cmap = mapper.get_cmap()
     pts_per_inch = 72.0  # to convert between points and inches
     # some general properties of the plot
-    matplotlib.rc('text', usetex=True)
+    #matplotlib.rc('text', usetex=True)
     matplotlib.rc('xtick', labelsize=8)
     matplotlib.rc('xtick', direction='out')
     matplotlib.rc('ytick', direction='out')

--- a/phydmslib/weblogo.py
+++ b/phydmslib/weblogo.py
@@ -1027,7 +1027,7 @@ def LogoOverlay(sites, overlayfile, overlay, nperline, sitewidth, rmargin,
         cmap = mapper.get_cmap()
     pts_per_inch = 72.0  # to convert between points and inches
     # some general properties of the plot
-    #matplotlib.rc('text', usetex=True)
+    matplotlib.rc('text', usetex=False)  # now set to false, version 2.4.0
     matplotlib.rc('xtick', labelsize=8)
     matplotlib.rc('xtick', direction='out')
     matplotlib.rc('ytick', direction='out')

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,9 @@ setup(
         'numpy>=1.11',
         ],
     install_requires = [
-        'biopython>=1.67',
+        # pin bipython until this is fixed in pyvolve:
+        # https://github.com/sjspielman/pyvolve/issues/19
+        'biopython>=1.67,<1.78',
         'cython>=0.28',
         'numpy>=1.11',
         'scipy>=0.18',


### PR DESCRIPTION
Fixes error that otherwise occurs when building logo plots.